### PR TITLE
Add Copy to Clipboard for Batch IDs

### DIFF
--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Shield, TrendingUp, Package, Users, Calendar, BarChart3 } from 'lucide-react';
+import { Shield, TrendingUp, Package, Users, Calendar, BarChart3, Copy, Check } from 'lucide-react';
 import { cropBatchService } from '../services/cropBatchService';
 
 const AdminDashboard: React.FC = () => {
@@ -11,6 +11,17 @@ const AdminDashboard: React.FC = () => {
   });
   const [batches, setBatches] = useState<any[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const copyToClipboard = async (batchId: string) => {
+    try {
+      await navigator.clipboard.writeText(batchId);
+      setCopiedId(batchId);
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
 
   useEffect(() => {
     loadDashboardData();
@@ -148,9 +159,22 @@ const AdminDashboard: React.FC = () => {
               {batches.map((batch, index) => (
                 <tr key={batch.batchId} className={`border-b border-gray-100 dark:border-gray-700 ${index % 2 === 0 ? 'bg-gray-50 dark:bg-gray-700' : 'bg-white dark:bg-gray-800'} hover:bg-green-50 dark:hover:bg-gray-600 transition-colors`}>
                   <td className="py-4 px-6">
-                    <span className="font-mono text-sm bg-gray-100 dark:bg-gray-600 dark:text-white px-2 py-1 rounded">
-                      {batch.batchId}
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-sm bg-gray-100 dark:bg-gray-600 dark:text-white px-2 py-1 rounded">
+                        {batch.batchId}
+                      </span>
+                      <button
+                        onClick={() => copyToClipboard(batch.batchId)}
+                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-500 rounded transition-colors"
+                        title={copiedId === batch.batchId ? 'Copied!' : 'Copy Batch ID'}
+                      >
+                        {copiedId === batch.batchId ? (
+                          <Check className="h-4 w-4 text-green-600" />
+                        ) : (
+                          <Copy className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                        )}
+                      </button>
+                    </div>
                   </td>
                   <td className="py-4 px-6">
                     <div>

--- a/src/pages/TrackBatch.tsx
+++ b/src/pages/TrackBatch.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Search, QrCode, Package, Calendar, MapPin, User, FileText } from 'lucide-react';
+import { Search, QrCode, Package, Calendar, MapPin, User, FileText, Copy, Check } from 'lucide-react';
 import { cropBatchService } from '../services/cropBatchService';
 import Timeline from '../components/Timeline';
 import QRScanner from '../components/QRScanner';
@@ -9,6 +9,17 @@ const TrackBatch: React.FC = () => {
   const [batch, setBatch] = useState<any>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [showScanner, setShowScanner] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
 
   const handleSearch = async () => {
     if (!batchId.trim()) return;
@@ -92,7 +103,20 @@ const TrackBatch: React.FC = () => {
           <div className="bg-gradient-to-r from-green-600 to-blue-600 rounded-2xl shadow-xl p-8 text-white">
             <div className="flex items-center justify-between">
               <div>
-                <h2 className="text-3xl font-bold mb-2">Batch #{batch.batchId}</h2>
+                <div className="flex items-center gap-3 mb-2">
+                  <h2 className="text-3xl font-bold">Batch #{batch.batchId}</h2>
+                  <button
+                    onClick={() => copyToClipboard(batch.batchId)}
+                    className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+                    title={copied ? 'Copied!' : 'Copy Batch ID'}
+                  >
+                    {copied ? (
+                      <Check className="h-5 w-5 text-green-300" />
+                    ) : (
+                      <Copy className="h-5 w-5 text-white/80" />
+                    )}
+                  </button>
+                </div>
                 <p className="text-green-100 text-lg">Complete supply chain transparency</p>
               </div>
               <div className="text-right">


### PR DESCRIPTION
## Summary
- Added "Copy" icon (lucide-react) next to Batch IDs on the Admin Dashboard table
- Added "Copy" icon next to Batch ID on the Track Batch page header
- Implemented "Copied!" visual feedback (checkmark icon) that shows for 2 seconds

## Changes
- `src/pages/AdminDashboard.tsx` - Added copy functionality to batch ID column in the table
- `src/pages/TrackBatch.tsx` - Added copy functionality to batch header

## Test plan
- [x] Click copy icon on Dashboard - batch ID should be copied to clipboard
- [ ] Click copy icon on Track page - batch ID should be copied to clipboard
- [x] Verify checkmark icon appears briefly after copying

Fixes #11