### PR TITLE
refactor: remove batch ID retry loop and use atomic ID generation

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -252,34 +252,6 @@ if (PROVIDER_URL && CONTRACT_ADDRESS && PRIVATE_KEY) {
 }
 
 // Helper functions
-async function generateBatchId() {
-    const session = await mongoose.startSession();
-    session.startTransaction();
-
-    try {
-        const counter = await Counter.findOneAndUpdate(
-            { name: 'batchId' },
-            { $inc: { seq: 1 } },
-            { new: true, upsert: true, session }
-        );
-
-        const currentYear = new Date().getFullYear();
-        const batchId = `CROP-${currentYear}-${String(counter.seq).padStart(3, '0')}`;
-
-        await session.commitTransaction();
-        session.endSession();
-
-        return batchId;
-
-    } catch (error) {
-        await session.abortTransaction();
-        session.endSession();
-        throw error;
-/**
- * Generate batch ID with optional session support for transaction safety
- * @param {mongoose.ClientSession} session - MongoDB session for transaction
- * @returns {string} - Generated batch ID
- */
 async function generateBatchId(session = null) {
     const options = { new: true, upsert: true };
     if (session) {
@@ -291,7 +263,9 @@ async function generateBatchId(session = null) {
         { $inc: { seq: 1 } },
         options
     );
-    return `CROP-2024-${String(counter.seq).padStart(3, '0')}`;
+
+    const batchId = `CROP-${new Date().getFullYear()}-${String(counter.seq).padStart(4, '0')}`;
+    return batchId;
 }
 
 async function generateQRCode(batchId) {


### PR DESCRIPTION
Applied the requested changes to [`backend/server.js`](backend/server.js:255):

**1. Updated Batch ID format** (line 267):
- Changed from 3-digit to 4-digit padding: `padStart(4, '0')`
- Uses dynamic year: `new Date().getFullYear()`
- New format: `CROP-{year}-{4-digit-sequence}` (e.g., `CROP-2026-0001`)

**2. Removed duplicate/broken code**:
- Removed the incomplete first `generateBatchId` function that was missing a closing brace
- Removed the duplicate second function with hardcoded year `2024` and 3-digit padding
- Replaced with a single clean function that:
  - Supports optional session parameter for transaction safety
  - Uses dynamic year
  - Uses 4-digit sequence padding

**No retry loop was found** in the codebase to remove.

The diff shows:
- Before: `CROP-${currentYear}-${String(counter.seq).padStart(3, '0')}` 
- After: `CROP-${new Date().getFullYear()}-${String(counter.seq).padStart(4, '0')}`