### PR TITLE
Implement CCIP for cross-chain batch data migration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -78,6 +78,23 @@ CONTRACT_ADDRESS=0x...                                      # Smart contract add
 PRIVATE_KEY=0x...                                          # Wallet private key
 ```
 
+### CCIP Cross-Chain Configuration (Optional)
+
+When configured, `PUT /api/batches/:batchId` automatically dispatches a CCIP message
+once the batch stage is updated to `retailer`.
+
+```env
+CCIP_SOURCE_RPC_URL=https://polygon-rpc.example             # Source chain RPC (fallback: INFURA_URL)
+CCIP_SENDER_CONTRACT_ADDRESS=0x...                          # Deployed CropChainCCIPSender address
+CCIP_SENDER_PRIVATE_KEY=0x...                               # Signer with CCIP_SENDER_ROLE
+CCIP_DESTINATION_LABEL=ethereum-mainnet                     # Stored label in batch.crossChain.destinationChain
+CCIP_DEFAULT_FARMER_WALLET=0x...                            # Fallback farmer wallet if batch has none
+```
+
+Notes:
+- Paymaster fees are debited from sender contract credits (`paymasterCredits[farmer]`).
+- If CCIP is not configured, the API continues to work and skips cross-chain dispatch.
+
 ### Database Configuration (Optional - Uses in-memory storage if not provided)
 
 ```env

--- a/backend/models/Batch.js
+++ b/backend/models/Batch.js
@@ -83,6 +83,12 @@ const batchSchema = new mongoose.Schema({
     maxlength: 500,
     trim: true
   },
+  farmerWalletAddress: {
+    type: String,
+    default: '',
+    lowercase: true,
+    trim: true
+  },
   cropType: {
     type: String,
     required: true,
@@ -147,6 +153,33 @@ const batchSchema = new mongoose.Schema({
     enum: ['pending', 'synced', 'error'],
     default: 'pending'
   },
+    crossChain: {
+      status: {
+        type: String,
+        enum: ['not_required', 'pending', 'sent', 'failed'],
+        default: 'not_required'
+      },
+      destinationChain: {
+        type: String,
+        default: ''
+      },
+      messageId: {
+        type: String,
+        default: ''
+      },
+      txHash: {
+        type: String,
+        default: ''
+      },
+      error: {
+        type: String,
+        default: ''
+      },
+      lastAttemptAt: {
+        type: Date,
+        default: null
+      }
+    },
   updates: [updateSchema],
   status: {
     type: String,

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ const errorHandlerMiddleware = require('./middleware/errorHandler');
 const { createBatchSchema, updateBatchSchema } = require("./validations/batchSchema");
 const { protect, adminOnly, authorizeBatchOwner, authorizeRoles, authorizeStageTransition, authorizeBlockchainTransaction } = require('./middleware/auth');
 const apiResponse = require('./utils/apiResponse');
+const ccipService = require('./services/ccipService');
 const crypto = require('crypto');
 
 // Import MongoDB Model
@@ -362,6 +363,7 @@ app.post('/api/batches', batchLimiter, protect, authorizeRoles('farmer'), author
             batchId,
             farmerId: req.user.farmerId || req.user.id, // Use authenticated user's ID
             farmerName: validatedData.farmerName || req.user.name,
+            farmerWalletAddress: (req.user.walletAddress || '').toLowerCase(),
             farmerAddress: validatedData.farmerAddress || req.user.address || '',
             cropType: validatedData.cropType,
             quantity: validatedData.quantity,
@@ -374,6 +376,9 @@ app.post('/api/batches', batchLimiter, protect, authorizeRoles('farmer'), author
             qrCode,
             blockchainHash: simulateBlockchainHash(validatedData),
             syncStatus: 'pending',
+            crossChain: {
+                status: 'not_required'
+            },
             updates: [{
                 stage: "farmer",
                 actor: validatedData.farmerName || req.user.name,
@@ -459,16 +464,83 @@ app.put('/api/batches/:batchId', batchLimiter, protect, authorizeBatchOwner, aut
             notes: validatedData.notes
         };
 
+        const shouldDispatchCrossChain = normalizedStage === 'retailer' && ccipService.isEnabled();
+
+        const crossChainState = shouldDispatchCrossChain
+            ? {
+                status: 'pending',
+                destinationChain: process.env.CCIP_DESTINATION_LABEL || 'ethereum',
+                error: '',
+                lastAttemptAt: new Date()
+            }
+            : {
+                status: 'not_required',
+                destinationChain: '',
+                messageId: '',
+                txHash: '',
+                error: '',
+                lastAttemptAt: null
+            };
+
         const batch = await Batch.findOneAndUpdate(
             { batchId },
             {
                 $push: { updates: update },
                 currentStage: normalizedStage,
                 blockchainHash: simulateBlockchainHash(update),
-                syncStatus: 'pending'
+                syncStatus: 'pending',
+                crossChain: crossChainState
             },
             { new: true }
         );
+
+        if (shouldDispatchCrossChain) {
+            try {
+                const syncResult = await ccipService.dispatchRetailerProof(batch, update);
+                await Batch.updateOne(
+                    { batchId },
+                    {
+                        $set: {
+                            'crossChain.status': 'sent',
+                            'crossChain.destinationChain': syncResult.destinationChain,
+                            'crossChain.messageId': syncResult.messageId,
+                            'crossChain.txHash': syncResult.txHash,
+                            'crossChain.error': '',
+                            'crossChain.lastAttemptAt': new Date()
+                        }
+                    }
+                );
+
+                batch.crossChain = {
+                    ...batch.crossChain,
+                    status: 'sent',
+                    destinationChain: syncResult.destinationChain,
+                    messageId: syncResult.messageId,
+                    txHash: syncResult.txHash,
+                    error: '',
+                    lastAttemptAt: new Date()
+                };
+            } catch (ccipError) {
+                console.error(`[CCIP ERROR] Failed to dispatch retailer proof for ${batchId}:`, ccipError.message);
+                await Batch.updateOne(
+                    { batchId },
+                    {
+                        $set: {
+                            'crossChain.status': 'failed',
+                            'crossChain.error': ccipError.message,
+                            'crossChain.lastAttemptAt': new Date()
+                        }
+                    }
+                );
+
+                batch.crossChain = {
+                    ...batch.crossChain,
+                    status: 'failed',
+                    error: ccipError.message,
+                    lastAttemptAt: new Date()
+                };
+            }
+        }
 
         console.log(`[SUCCESS] Batch updated: ${batchId} to stage ${normalizedStage} by ${validatedData.actor} from IP: ${req.ip}`);
 
@@ -763,6 +835,13 @@ if (process.env.NODE_ENV !== 'test') {
             }
         } else {
             console.log('ℹ️  Skipping blockchain listener (no contract instance available)');
+        }
+
+        // Initialize CCIP dispatch service.
+        if (ccipService.initialize()) {
+            console.log('🌉 CCIP service initialized');
+        } else {
+            console.log('ℹ️  CCIP service not configured - cross-chain dispatch disabled');
         }
 
         // Start Oracle service for IoT data verification

--- a/backend/services/ccipService.js
+++ b/backend/services/ccipService.js
@@ -1,0 +1,102 @@
+const { ethers } = require('ethers');
+
+const SENDER_ABI = [
+    "function syncRetailerProof((bytes32 batchId,string actorName,string location,uint64 deliveredAt,string notes,address farmer,uint256 quantity,string ipfsCID) payload) external returns (bytes32)",
+    "function destinationChainSelector() view returns (uint64)",
+    "function paymasterCredits(address farmer) view returns (uint256)"
+];
+
+function toBatchIdBytes32(batchId) {
+    if (!batchId || typeof batchId !== 'string') {
+        throw new Error('Invalid batchId');
+    }
+
+    if (/^0x[a-fA-F0-9]{64}$/.test(batchId)) {
+        return batchId;
+    }
+
+    // Use deterministic hashing to support IDs longer than 31 bytes.
+    return ethers.id(batchId);
+}
+
+class CCIPService {
+    constructor() {
+        this.provider = null;
+        this.wallet = null;
+        this.senderContract = null;
+        this.enabled = false;
+
+        this.destinationLabel = process.env.CCIP_DESTINATION_LABEL || 'ethereum';
+    }
+
+    initialize() {
+        const rpcUrl = process.env.CCIP_SOURCE_RPC_URL || process.env.INFURA_URL;
+        const contractAddress = process.env.CCIP_SENDER_CONTRACT_ADDRESS;
+        const privateKey = process.env.CCIP_SENDER_PRIVATE_KEY || process.env.PRIVATE_KEY;
+
+        if (!rpcUrl || !contractAddress || !privateKey) {
+            this.enabled = false;
+            return false;
+        }
+
+        this.provider = new ethers.JsonRpcProvider(rpcUrl);
+        this.wallet = new ethers.Wallet(privateKey, this.provider);
+        this.senderContract = new ethers.Contract(contractAddress, SENDER_ABI, this.wallet);
+        this.enabled = true;
+
+        return true;
+    }
+
+    isEnabled() {
+        return this.enabled;
+    }
+
+    async dispatchRetailerProof(batch, update) {
+        if (!this.enabled) {
+            throw new Error('CCIP service is not configured');
+        }
+
+        const farmerWallet = (batch.farmerWalletAddress || process.env.CCIP_DEFAULT_FARMER_WALLET || '').trim().toLowerCase();
+        if (!ethers.isAddress(farmerWallet)) {
+            throw new Error('Missing valid farmer wallet for CCIP paymaster debit');
+        }
+
+        const payload = {
+            batchId: toBatchIdBytes32(batch.batchId),
+            actorName: update.actor,
+            location: update.location,
+            deliveredAt: Math.floor(new Date(update.timestamp || Date.now()).getTime() / 1000),
+            notes: update.notes || '',
+            farmer: farmerWallet,
+            quantity: BigInt(batch.quantity || 0),
+            ipfsCID: batch.ipfsCID || ''
+        };
+
+        // Preflight check to provide clear operator errors when credit is missing.
+        const credit = await this.senderContract.paymasterCredits(farmerWallet);
+        if (credit <= 0n) {
+            throw new Error(`No paymaster credit for farmer ${farmerWallet}`);
+        }
+
+        const tx = await this.senderContract.syncRetailerProof(payload);
+        const receipt = await tx.wait();
+
+        const messageEvent = receipt.logs
+            .map((log) => {
+                try {
+                    return this.senderContract.interface.parseLog(log);
+                } catch (_) {
+                    return null;
+                }
+            })
+            .find((parsed) => parsed && parsed.name === 'RetailerProofDispatched');
+
+        return {
+            txHash: tx.hash,
+            messageId: messageEvent ? messageEvent.args.messageId : '',
+            destinationChain: this.destinationLabel
+        };
+    }
+}
+
+module.exports = new CCIPService();

--- a/contracts/CropChainCCIPReceiver.sol
+++ b/contracts/CropChainCCIPReceiver.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./lib/openzeppelin/access/AccessControl.sol";
+import "./lib/openzeppelin/security/Pausable.sol";
+import "./ccip/Client.sol";
+import "./ccip/IAny2EVMMessageReceiver.sol";
+import "./ProofOfDeliveryNFT.sol";
+
+contract CropChainCCIPReceiver is AccessControl, Pausable, IAny2EVMMessageReceiver {
+    struct RetailerProofPayload {
+        bytes32 batchId;
+        string actorName;
+        string location;
+        uint64 deliveredAt;
+        string notes;
+        address farmer;
+        uint256 quantity;
+        string ipfsCID;
+    }
+
+    address public immutable router;
+    ProofOfDeliveryNFT public immutable proofOfDeliveryNFT;
+
+    uint64 public trustedSourceChainSelector;
+    address public trustedSourceSender;
+
+    mapping(bytes32 => bool) public processedMessages;
+
+    event SourceConfigured(uint64 indexed sourceChainSelector, address indexed sourceSender);
+    event RetailerProofReceived(
+        bytes32 indexed messageId,
+        bytes32 indexed batchId,
+        address indexed farmer,
+        uint256 tokenId,
+        uint64 sourceChainSelector
+    );
+
+    constructor(address routerAddress, address nftAddress) {
+        require(routerAddress != address(0), "Invalid router");
+        require(nftAddress != address(0), "Invalid NFT");
+
+        router = routerAddress;
+        proofOfDeliveryNFT = ProofOfDeliveryNFT(nftAddress);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    function setTrustedSource(uint64 sourceChainSelector, address sourceSender)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(sourceChainSelector > 0, "Invalid chain");
+        require(sourceSender != address(0), "Invalid sender");
+
+        trustedSourceChainSelector = sourceChainSelector;
+        trustedSourceSender = sourceSender;
+
+        emit SourceConfigured(sourceChainSelector, sourceSender);
+    }
+
+    function ccipReceive(Client.Any2EVMMessage calldata message) external override whenNotPaused {
+        require(msg.sender == router, "Only router");
+        require(!processedMessages[message.messageId], "Message processed");
+
+        if (trustedSourceChainSelector != 0) {
+            require(message.sourceChainSelector == trustedSourceChainSelector, "Untrusted source chain");
+        }
+
+        if (trustedSourceSender != address(0)) {
+            address decodedSender = abi.decode(message.sender, (address));
+            require(decodedSender == trustedSourceSender, "Untrusted source sender");
+        }
+
+        RetailerProofPayload memory payload = abi.decode(message.data, (RetailerProofPayload));
+        require(payload.batchId != bytes32(0), "Invalid batchId");
+
+        processedMessages[message.messageId] = true;
+
+        string memory metadataURI = payload.ipfsCID;
+        uint256 tokenId = proofOfDeliveryNFT.mintProof(payload.farmer, payload.batchId, metadataURI);
+
+        emit RetailerProofReceived(
+            message.messageId,
+            payload.batchId,
+            payload.farmer,
+            tokenId,
+            message.sourceChainSelector
+        );
+    }
+
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+}

--- a/contracts/CropChainCCIPSender.sol
+++ b/contracts/CropChainCCIPSender.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./lib/openzeppelin/access/AccessControl.sol";
+import "./lib/openzeppelin/security/Pausable.sol";
+import "./ccip/Client.sol";
+import "./ccip/IRouterClient.sol";
+
+contract CropChainCCIPSender is AccessControl, Pausable {
+    bytes32 public constant CCIP_SENDER_ROLE = keccak256("CCIP_SENDER_ROLE");
+
+    struct RetailerProofPayload {
+        bytes32 batchId;
+        string actorName;
+        string location;
+        uint64 deliveredAt;
+        string notes;
+        address farmer;
+        uint256 quantity;
+        string ipfsCID;
+    }
+
+    IRouterClient public immutable router;
+
+    uint64 public destinationChainSelector;
+    address public destinationReceiver;
+
+    mapping(address => uint256) public paymasterCredits;
+
+    event DestinationConfigured(uint64 indexed chainSelector, address indexed receiver);
+    event PaymasterCreditFunded(address indexed farmer, uint256 amount);
+    event PaymasterCreditDebited(address indexed farmer, uint256 amount, uint256 remainingBalance);
+    event RetailerProofDispatched(
+        bytes32 indexed messageId,
+        bytes32 indexed batchId,
+        address indexed farmer,
+        uint256 feePaid,
+        uint64 destinationChainSelector,
+        address destinationReceiver
+    );
+
+    constructor(address routerAddress) {
+        require(routerAddress != address(0), "Invalid router");
+
+        router = IRouterClient(routerAddress);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(CCIP_SENDER_ROLE, msg.sender);
+    }
+
+    function setDestination(uint64 chainSelector, address receiver) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(chainSelector > 0, "Invalid chain");
+        require(receiver != address(0), "Invalid receiver");
+
+        destinationChainSelector = chainSelector;
+        destinationReceiver = receiver;
+
+        emit DestinationConfigured(chainSelector, receiver);
+    }
+
+    function fundPaymasterCredit(address farmer) external payable onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(farmer != address(0), "Invalid farmer");
+        require(msg.value > 0, "No value");
+
+        paymasterCredits[farmer] += msg.value;
+        emit PaymasterCreditFunded(farmer, msg.value);
+    }
+
+    function syncRetailerProof(RetailerProofPayload calldata payload)
+        external
+        onlyRole(CCIP_SENDER_ROLE)
+        whenNotPaused
+        returns (bytes32 messageId)
+    {
+        require(destinationChainSelector > 0, "Destination not set");
+        require(destinationReceiver != address(0), "Receiver not set");
+        require(payload.batchId != bytes32(0), "Invalid batchId");
+        require(payload.farmer != address(0), "Invalid farmer");
+
+        bytes memory data = abi.encode(payload);
+
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationReceiver),
+            data: data,
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            feeToken: address(0),
+            extraArgs: ""
+        });
+
+        uint256 fee = router.getFee(destinationChainSelector, message);
+        uint256 farmerCredit = paymasterCredits[payload.farmer];
+        require(farmerCredit >= fee, "Insufficient paymaster credit");
+
+        unchecked {
+            paymasterCredits[payload.farmer] = farmerCredit - fee;
+        }
+
+        emit PaymasterCreditDebited(payload.farmer, fee, paymasterCredits[payload.farmer]);
+
+        messageId = router.ccipSend{value: fee}(destinationChainSelector, message);
+
+        emit RetailerProofDispatched(
+            messageId,
+            payload.batchId,
+            payload.farmer,
+            fee,
+            destinationChainSelector,
+            destinationReceiver
+        );
+    }
+
+    function quoteFee(RetailerProofPayload calldata payload) external view returns (uint256) {
+        require(destinationChainSelector > 0, "Destination not set");
+        require(destinationReceiver != address(0), "Receiver not set");
+
+        Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+            receiver: abi.encode(destinationReceiver),
+            data: abi.encode(payload),
+            tokenAmounts: new Client.EVMTokenAmount[](0),
+            feeToken: address(0),
+            extraArgs: ""
+        });
+
+        return router.getFee(destinationChainSelector, message);
+    }
+
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
+    }
+
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
+    }
+
+    function withdraw(address payable to, uint256 amount) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(to != address(0), "Invalid recipient");
+        require(amount <= address(this).balance, "Insufficient balance");
+
+        (bool sent, ) = to.call{value: amount}("");
+        require(sent, "Withdraw failed");
+    }
+
+    receive() external payable {}
+}

--- a/contracts/ProofOfDeliveryNFT.sol
+++ b/contracts/ProofOfDeliveryNFT.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./lib/openzeppelin/access/AccessControl.sol";
+
+contract ProofOfDeliveryNFT is AccessControl {
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    string public name;
+    string public symbol;
+
+    uint256 public totalSupply;
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
+    mapping(uint256 => string) private _tokenURIs;
+    mapping(bytes32 => uint256) public batchToTokenId;
+
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event ProofMinted(bytes32 indexed batchId, uint256 indexed tokenId, address indexed recipient, string tokenURI);
+
+    constructor(string memory tokenName, string memory tokenSymbol) {
+        name = tokenName;
+        symbol = tokenSymbol;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(MINTER_ROLE, msg.sender);
+    }
+
+    function mintProof(address recipient, bytes32 batchId, string calldata metadataURI)
+        external
+        onlyRole(MINTER_ROLE)
+        returns (uint256 tokenId)
+    {
+        require(recipient != address(0), "Invalid recipient");
+        require(batchId != bytes32(0), "Invalid batchId");
+        require(batchToTokenId[batchId] == 0, "Proof already minted");
+
+        unchecked {
+            totalSupply += 1;
+        }
+
+        tokenId = totalSupply;
+        _owners[tokenId] = recipient;
+        _balances[recipient] += 1;
+        _tokenURIs[tokenId] = metadataURI;
+        batchToTokenId[batchId] = tokenId;
+
+        emit Transfer(address(0), recipient, tokenId);
+        emit ProofMinted(batchId, tokenId, recipient, metadataURI);
+    }
+
+    function ownerOf(uint256 tokenId) external view returns (address) {
+        address owner = _owners[tokenId];
+        require(owner != address(0), "Token does not exist");
+        return owner;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        require(account != address(0), "Zero address");
+        return _balances[account];
+    }
+
+    function tokenURI(uint256 tokenId) external view returns (string memory) {
+        require(_owners[tokenId] != address(0), "Token does not exist");
+        return _tokenURIs[tokenId];
+    }
+}

--- a/contracts/ccip/Client.sol
+++ b/contracts/ccip/Client.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+library Client {
+    struct EVMTokenAmount {
+        address token;
+        uint256 amount;
+    }
+
+    struct Any2EVMMessage {
+        bytes32 messageId;
+        uint64 sourceChainSelector;
+        bytes sender;
+        bytes data;
+        EVMTokenAmount[] destTokenAmounts;
+    }
+
+    struct EVM2AnyMessage {
+        bytes receiver;
+        bytes data;
+        EVMTokenAmount[] tokenAmounts;
+        address feeToken;
+        bytes extraArgs;
+    }
+}

--- a/contracts/ccip/IAny2EVMMessageReceiver.sol
+++ b/contracts/ccip/IAny2EVMMessageReceiver.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./Client.sol";
+
+interface IAny2EVMMessageReceiver {
+    function ccipReceive(Client.Any2EVMMessage calldata message) external;
+}

--- a/contracts/ccip/IRouterClient.sol
+++ b/contracts/ccip/IRouterClient.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./Client.sol";
+
+interface IRouterClient {
+    function ccipSend(uint64 destinationChainSelector, Client.EVM2AnyMessage calldata message)
+        external
+        payable
+        returns (bytes32);
+
+    function getFee(uint64 destinationChainSelector, Client.EVM2AnyMessage calldata message)
+        external
+        view
+        returns (uint256);
+}

--- a/contracts/mocks/MockCCIPRouter.sol
+++ b/contracts/mocks/MockCCIPRouter.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../ccip/Client.sol";
+import "../ccip/IRouterClient.sol";
+import "../ccip/IAny2EVMMessageReceiver.sol";
+
+contract MockCCIPRouter is IRouterClient {
+    uint256 public fee;
+    uint256 public nonce;
+
+    struct QueuedMessage {
+        bytes32 messageId;
+        uint64 sourceChainSelector;
+        bytes sender;
+        bytes data;
+    }
+
+    mapping(bytes32 => QueuedMessage) public queuedMessages;
+
+    event MessageQueued(bytes32 indexed messageId, uint64 indexed destinationChainSelector, bytes receiver, bytes sender, bytes data);
+
+    function setFee(uint256 newFee) external {
+        fee = newFee;
+    }
+
+    function getFee(uint64, Client.EVM2AnyMessage calldata) external view override returns (uint256) {
+        return fee;
+    }
+
+    function ccipSend(uint64 destinationChainSelector, Client.EVM2AnyMessage calldata message)
+        external
+        payable
+        override
+        returns (bytes32)
+    {
+        require(msg.value >= fee, "insufficient fee");
+
+        unchecked {
+            nonce += 1;
+        }
+
+        bytes32 messageId = keccak256(abi.encodePacked(block.chainid, msg.sender, nonce, message.data));
+
+        queuedMessages[messageId] = QueuedMessage({
+            messageId: messageId,
+            sourceChainSelector: destinationChainSelector,
+            sender: abi.encode(msg.sender),
+            data: message.data
+        });
+
+        emit MessageQueued(messageId, destinationChainSelector, message.receiver, abi.encode(msg.sender), message.data);
+
+        return messageId;
+    }
+
+    function deliverToReceiver(bytes32 messageId, address receiver, uint64 sourceChainSelector, address sourceSender) external {
+        QueuedMessage memory queued = queuedMessages[messageId];
+        require(queued.messageId != bytes32(0), "message missing");
+
+        Client.Any2EVMMessage memory inbound = Client.Any2EVMMessage({
+            messageId: queued.messageId,
+            sourceChainSelector: sourceChainSelector,
+            sender: abi.encode(sourceSender),
+            data: queued.data,
+            destTokenAmounts: new Client.EVMTokenAmount[](0)
+        });
+
+        IAny2EVMMessageReceiver(receiver).ccipReceive(inbound);
+    }
+}

--- a/test/ccip.integration.test.js
+++ b/test/ccip.integration.test.js
@@ -1,0 +1,121 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("CCIP Cross-Chain Settlement", function () {
+  let router;
+  let sender;
+  let receiver;
+  let nft;
+
+  let admin;
+  let serviceWallet;
+  let farmer;
+
+  const SOURCE_SELECTOR = 12532609583862916517n; // Polygon-like selector for tests
+  const DEST_SELECTOR = 16015286601757825753n; // Ethereum-like selector for tests
+
+  async function deployAndWait(factory, args = []) {
+    const contract = await factory.deploy(...args);
+    if (typeof contract.waitForDeployment === "function") {
+      await contract.waitForDeployment();
+    } else if (typeof contract.deployed === "function") {
+      await contract.deployed();
+    }
+    return contract;
+  }
+
+  async function addressOf(contract) {
+    if (typeof contract.getAddress === "function") {
+      return await contract.getAddress();
+    }
+    return contract.address;
+  }
+
+  beforeEach(async function () {
+    [admin, serviceWallet, farmer] = await ethers.getSigners();
+
+    const Router = await ethers.getContractFactory("MockCCIPRouter");
+    router = await deployAndWait(Router);
+
+    const Sender = await ethers.getContractFactory("CropChainCCIPSender");
+    sender = await deployAndWait(Sender, [await addressOf(router)]);
+
+    const NFT = await ethers.getContractFactory("ProofOfDeliveryNFT");
+    nft = await deployAndWait(NFT, ["CropChain Proof of Delivery", "CPOD"]);
+
+    const Receiver = await ethers.getContractFactory("CropChainCCIPReceiver");
+    receiver = await deployAndWait(Receiver, [await addressOf(router), await addressOf(nft)]);
+
+    await sender.setDestination(DEST_SELECTOR, await addressOf(receiver));
+    await receiver.setTrustedSource(SOURCE_SELECTOR, await addressOf(sender));
+
+    const minterRole = await nft.MINTER_ROLE();
+    await nft.grantRole(minterRole, await addressOf(receiver));
+
+    const senderRole = await sender.CCIP_SENDER_ROLE();
+    await sender.grantRole(senderRole, serviceWallet.address);
+
+    await router.setFee(ethers.parseEther("0.01"));
+  });
+
+  it("dispatches retailer proof using paymaster credit and debits the farmer", async function () {
+    await sender.fundPaymasterCredit(farmer.address, { value: ethers.parseEther("0.05") });
+
+    const payload = {
+      batchId: ethers.id("CROP-2026-0001"),
+      actorName: "Retailer A",
+      location: "Mumbai",
+      deliveredAt: BigInt(Math.floor(Date.now() / 1000)),
+      notes: "Delivered and accepted",
+      farmer: farmer.address,
+      quantity: 500n,
+      ipfsCID: "ipfs://bafy-test"
+    };
+
+    await expect(sender.connect(serviceWallet).syncRetailerProof(payload))
+      .to.emit(sender, "RetailerProofDispatched");
+
+    expect(await sender.paymasterCredits(farmer.address)).to.equal(ethers.parseEther("0.04"));
+  });
+
+  it("mints proof NFT on destination chain when the receiver consumes a CCIP message", async function () {
+    await sender.fundPaymasterCredit(farmer.address, { value: ethers.parseEther("0.05") });
+
+    const payload = {
+      batchId: ethers.id("CROP-2026-0002"),
+      actorName: "Retailer B",
+      location: "Pune",
+      deliveredAt: BigInt(Math.floor(Date.now() / 1000)),
+      notes: "Shelf ready",
+      farmer: farmer.address,
+      quantity: 1200n,
+      ipfsCID: "ipfs://bafy-proof-0002"
+    };
+
+    const tx = await sender.connect(serviceWallet).syncRetailerProof(payload);
+    const receipt = await tx.wait();
+
+    const parsedLog = receipt.logs
+      .map((log) => {
+        try {
+          return sender.interface.parseLog(log);
+        } catch {
+          return null;
+        }
+      })
+      .find((item) => item && item.name === "RetailerProofDispatched");
+
+    const messageId = parsedLog.args.messageId;
+
+    await router.deliverToReceiver(
+      messageId,
+      await addressOf(receiver),
+      SOURCE_SELECTOR,
+      await addressOf(sender)
+    );
+
+    const tokenId = await nft.batchToTokenId(payload.batchId);
+    expect(tokenId).to.equal(1n);
+    expect(await nft.ownerOf(tokenId)).to.equal(farmer.address);
+  });
+});


### PR DESCRIPTION
# CCIP Cross-Chain Batch Migration

## Overview

This implementation enables cross-chain settlement for CropChain batch records:

- Source chain: Polygon (or any configured chain where batch updates are performed).
- Destination chain: Ethereum (or any configured chain for final settlement).
- Trigger: When a batch reaches the `retailer` stage.
- Result: A `ProofOfDeliveryNFT` token is minted on the destination chain.

## Contracts Added

- `contracts/CropChainCCIPSender.sol`
  - Uses `IRouterClient` to send CCIP messages.
  - Holds paymaster credits per farmer (`paymasterCredits`).
  - Debits CCIP fees from farmer-specific paymaster credit.

- `contracts/CropChainCCIPReceiver.sol`
  - Receives CCIP messages via `ccipReceive`.
  - Verifies trusted source chain and trusted sender.
  - Mints proof NFT through `ProofOfDeliveryNFT`.

- `contracts/ProofOfDeliveryNFT.sol`
  - Minimal proof NFT contract with one-token-per-batch constraint.
  - Supports role-based minting via `MINTER_ROLE`.

- `contracts/ccip/Client.sol`, `contracts/ccip/IRouterClient.sol`, `contracts/ccip/IAny2EVMMessageReceiver.sol`
  - Minimal CCIP type/interface definitions used by sender/receiver.

- `contracts/mocks/MockCCIPRouter.sol`
  - Test router for local integration tests.

## Backend Trigger Integration

- `backend/services/ccipService.js`
  - Initializes source-chain wallet + sender contract.
  - Dispatches `syncRetailerProof` payload.
  - Parses `RetailerProofDispatched` event to capture CCIP `messageId`.

- `backend/server.js`
  - On `PUT /api/batches/:batchId` with stage `retailer`, dispatches CCIP message.
  - Stores result in `batch.crossChain` metadata.

- `backend/models/Batch.js`
  - Added `crossChain` status fields and `farmerWalletAddress`.

## Paymaster Flow

1. Admin funds sender paymaster credit using `fundPaymasterCredit(farmer)`.
2. Retailer-stage update triggers CCIP send.
3. Sender contract computes fee with `router.getFee(...)`.
4. Fee is debited from `paymasterCredits[farmer]`.
5. Message is sent with `router.ccipSend{value: fee}(...)`.

This abstracts destination-chain gas from farmers and keeps payment in a single source-chain currency.

## Deployment Notes

1. Deploy `ProofOfDeliveryNFT` on destination chain.
2. Deploy `CropChainCCIPReceiver` on destination chain with router + NFT address.
3. Grant `MINTER_ROLE` in NFT to receiver contract.
4. Deploy `CropChainCCIPSender` on source chain with source router address.
5. Configure sender destination:
   - `setDestination(destinationChainSelector, receiverAddress)`
6. Configure receiver trust:
   - `setTrustedSource(sourceChainSelector, senderAddress)`
7. Grant `CCIP_SENDER_ROLE` to backend signer wallet.
8. Pre-fund paymaster credit for farmer wallets.

## Testing

Added test file:

- `test/ccip.integration.test.js`
  - Verifies paymaster fee debit on dispatch.
  - Verifies receiver mints proof NFT when mock router delivers message.

## Runtime Caveat

If CCIP env vars are not configured, backend batch update still succeeds and cross-chain dispatch is skipped.


closes #28