### PR TITLE
[GSSoC] fix: Inconsistent Stage Definitions

### DIFF
--- a/backend/services/batchService.js
+++ b/backend/services/batchService.js
@@ -10,7 +10,7 @@ const Counter = require('../models/Counter');
 const blockchainService = require('./blockchainService');
 const notificationService = require('./notificationService');
 const apiResponse = require('../utils/apiResponse');
-const { STAGE_TO_NUMBER } = require('../constants/stages');
+const { getStageNumber, getStagesString, isValidStage, normalizeStage } = require('../constants/stages');
 
 class BatchService {
     /**
@@ -164,7 +164,11 @@ class BatchService {
     async updateBatch(batchId, updateData, user) {
         try {
             // Normalize stage to lowercase
-            const normalizedStage = updateData.stage.toLowerCase();
+            const normalizedStage = normalizeStage(updateData.stage);
+
+            if (!isValidStage(normalizedStage)) {
+                throw new Error(`Invalid stage: ${updateData.stage}. Must be one of: ${getStagesString()}`);
+            }
 
             const blockchainHash = blockchainService.simulateHash(updateData);
 
@@ -333,7 +337,7 @@ class BatchService {
                     batch.description || ''
                 );
             } else if (action === 'update') {
-                const stageNum = STAGE_TO_NUMBER[batch.currentStage] ?? 0;
+                const stageNum = getStageNumber(batch.currentStage);
                 const lastUpdate = batch.updates[batch.updates.length - 1];
 
                 await blockchainService.updateBatchOnChain(


### PR DESCRIPTION
Fixed the batch sync path in batchService.js, batchService.js, and batchService.js. The service now uses the shared stage helpers from stages.js, rejects invalid or legacy stage names before updating the batch, and maps the stored stage back to the contract enum with `getStageNumber` instead of silently falling back to `0`.

I did not change stages.js because it already matches the contract’s farmer/mandi/transport/retailer order in CropChain.sol. Validation passed: a runtime check confirmed `updateBatch` now fails fast for `processor`, and the four valid stages still map to `0` through `3`.

closes #174