### PR TITLE
fix: add missing /login, /register and /access-denied routes to App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,10 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AIChatbot from './components/AIChatbot';
 import { CurrencyProvider } from "./context/CurrencyContext";
 
+import Login from './pages/Login';
+import Register from './pages/Register';
+import AccessDenied from './pages/AccessDenied';
+
 
 function App() {
   return (
@@ -37,6 +41,10 @@ function App() {
               <Route path="/track-batch" element={<TrackBatch />} />
               <Route path="/admin" element={<AdminDashboard />} />
               <Route path="/crop-recommendation" element={<CropRecommendation />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/register" element={<Register />} />
+              <Route path="/access-denied" element={<AccessDenied />} />
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </main>
 


### PR DESCRIPTION
Fixes #201 

## What this PR does
- Imports `Login`, `Register` and `AccessDenied` pages in `App.tsx`
- Adds missing `/login` route → `Login.tsx`
- Adds missing `/register` route → `Register.tsx`
- Adds missing `/access-denied` route → `AccessDenied.tsx`
- Adds `*` catch-all fallback → `NotFound.tsx`

## Screenshot
<img width="1820" height="820" alt="Screenshot 2026-05-17 155936" src="https://github.com/user-attachments/assets/d83da06a-af3f-434c-ae33-7d0d8fb1cd0d" />


## Note
The app currently fails to compile locally due to a pre-existing 
unresolved merge conflict in `Header.tsx` unrelated to this fix.
My changes in `App.tsx` are isolated and correct.
