### PR TITLE
[GSSoC] Oracle hardening: TWAP + deviation tolerance + circuit breaker

### DIFF
--- a/contracts/CropChain.sol
+++ b/contracts/CropChain.sol
@@ -181,15 +181,15 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         emit OwnershipTransferred(previousOwner, newOwner);
     }
 
-    function pause() external onlyOwner nonReentrant {
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         _pause();
     }
 
-    function unpause() external onlyOwner nonReentrant {
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         _unpause();
     }
 
-    function setPaused(bool shouldPause) external onlyOwner nonReentrant {
+    function setPaused(bool shouldPause) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         if (shouldPause) {
             _pause();
         } else {
@@ -197,7 +197,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         }
     }
 
-    function setTwapConfig(uint256 twapWindowSeconds, uint256 maxDeviationBps) external onlyOwner nonReentrant {
+    function setTwapConfig(uint256 twapWindowSeconds, uint256 maxDeviationBps) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         require(twapWindowSeconds > 0, "Window=0");
         require(maxDeviationBps <= 5000, "Deviation too high");
 

--- a/test/security.refactor.test.js
+++ b/test/security.refactor.test.js
@@ -125,4 +125,32 @@ describe("CropChain Security Refactor", function () {
       cropChain.buyFromListing(1, 1, { value: ethers.parseEther("5") })
     ).to.be.revertedWith("TWAP deviation too high");
   });
+
+  it("restricts circuit breaker and TWAP tuning to the admin role", async function () {
+    const { cropChain, buyer } = await deployFixture();
+
+    await expect(cropChain.connect(buyer).pause()).to.be.revertedWith(
+      "AccessControl: account " +
+        buyer.address.toLowerCase() +
+        " is missing role " +
+        DEFAULT_ADMIN_ROLE
+    );
+
+    await expect(
+      cropChain.connect(buyer).setTwapConfig(3600, 1000)
+    ).to.be.revertedWith(
+      "AccessControl: account " +
+        buyer.address.toLowerCase() +
+        " is missing role " +
+        DEFAULT_ADMIN_ROLE
+    );
+
+    await expect(cropChain.pause()).to.not.be.reverted;
+    expect(await cropChain.paused()).to.be.true;
+
+    await expect(cropChain.setTwapConfig(7200, 1000))
+      .to.not.be.reverted;
+    expect(await cropChain.twapWindow()).to.equal(7200n);
+    expect(await cropChain.maxPriceDeviationBps()).to.equal(1000n);
+  });
 });


### PR DESCRIPTION
I hardened the oracle-side controls in CropChain.sol by moving pause, unpause, setPaused, and setTwapConfig behind DEFAULT_ADMIN_ROLE instead of onlyOwner. That keeps the privileged controls compatible with a multisig-admin setup, while the existing TWAP observation, rolling-window pricing, and purchase-time deviation check remain in place.

I also added a regression in security.refactor.test.js that proves a non-admin cannot pause or retune TWAP, and that the admin can still do both. Syntax checks on the touched Solidity and test files passed, but the focused Hardhat test could not be completed because the workspace currently lacks a working local Hardhat installation and npm dependency resolution is failing on the existing peer-version conflict.

closes #208