### PR TITLE
Add HttpOnly refresh token auth flow

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -105,8 +105,10 @@ MONGODB_TEST_URI=mongodb://localhost:27017/cropchain_test  # Test database
 ### Authentication Configuration (Optional - For future features)
 
 ```env
-JWT_SECRET=your_super_secret_jwt_key_minimum_32_characters  # JWT signing key
-JWT_EXPIRES_IN=7d                                          # Token expiration
+JWT_SECRET=your_super_secret_jwt_key_minimum_32_characters  # Access-token signing key
+JWT_REFRESH_SECRET=your_refresh_secret_minimum_32_characters # Refresh-token signing key
+JWT_ACCESS_EXPIRES_IN=15m                                  # In-memory access-token lifetime
+JWT_REFRESH_EXPIRES_IN=7d                                  # HttpOnly refresh-cookie lifetime
 BCRYPT_ROUNDS=12                                           # Password hashing rounds
 ```
 
@@ -126,6 +128,8 @@ PUT    /api/batches/:batchId     - Update batch with new stage
 ```
 POST   /api/auth/login           - User login (rate limited: 5/15min)
 POST   /api/auth/register        - User registration (rate limited: 5/15min)
+POST   /api/auth/refresh         - Refresh access token from HttpOnly cookie
+POST   /api/auth/logout          - Clear refresh cookie
 ```
 
 ### System

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,7 +1,9 @@
 const User = require('../models/User');
 const generateToken = require('../utils/generateToken');
+const { generateRefreshToken } = require('../utils/generateToken');
 const bcrypt = require('bcryptjs');
 const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
 const { verifyMessage } = require('ethers');
@@ -73,6 +75,40 @@ const sanitizeUser = (user) => ({
     createdAt: user.createdAt
 });
 
+const REFRESH_COOKIE_NAME = 'refreshToken';
+
+const getRefreshCookieOptions = () => ({
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/api/auth',
+    maxAge: 7 * 24 * 60 * 60 * 1000
+});
+
+const parseCookieHeader = (cookieHeader = '') => {
+    return cookieHeader.split(';').reduce((cookies, cookie) => {
+        const [rawName, ...rawValue] = cookie.trim().split('=');
+        if (!rawName || rawValue.length === 0) return cookies;
+
+        cookies[rawName] = decodeURIComponent(rawValue.join('='));
+        return cookies;
+    }, {});
+};
+
+const buildAuthPayload = (user) => ({
+    token: generateToken(user._id, user.role, user.name),
+    user: sanitizeUser(user)
+});
+
+const attachRefreshCookie = (res, user) => {
+    res.cookie(REFRESH_COOKIE_NAME, generateRefreshToken(user._id), getRefreshCookieOptions());
+};
+
+const clearRefreshCookie = (res) => {
+    const { maxAge, ...cookieOptions } = getRefreshCookieOptions();
+    res.clearCookie(REFRESH_COOKIE_NAME, cookieOptions);
+};
+
 const registerUser = async (req, res) => {
     try {
         // Validate request body
@@ -112,11 +148,9 @@ const registerUser = async (req, res) => {
         });
 
         if (user) {
+            attachRefreshCookie(res, user);
             const response = apiResponse.successResponse(
-                {
-                    token: generateToken(user._id, user.role, user.name),
-                    user: sanitizeUser(user)
-                },
+                buildAuthPayload(user),
                 'Registration successful',
                 201
             );
@@ -163,11 +197,9 @@ const loginUser = async (req, res) => {
         const user = await User.findOne({ email }).select('+password');
 
         if (user && (await bcrypt.compare(password, user.password))) {
+            attachRefreshCookie(res, user);
             const response = apiResponse.successResponse(
-                {
-                    token: generateToken(user._id, user.role, user.name),
-                    user: sanitizeUser(user)
-                },
+                buildAuthPayload(user),
                 'Login successful'
             );
             return res.json(response);
@@ -396,11 +428,9 @@ const walletLogin = async (req, res) => {
         nonceStore.delete(normalizedAddress);
 
         // Generate JWT with user's role from database
+        attachRefreshCookie(res, user);
         const response = apiResponse.successResponse(
-            {
-                token: generateToken(user._id, user.role, user.name),
-                user: sanitizeUser(user)
-            },
+            buildAuthPayload(user),
             'Wallet authentication successful'
         );
         
@@ -511,11 +541,9 @@ const walletRegister = async (req, res) => {
         // Delete used nonce
         nonceStore.delete(normalizedAddress);
 
+        attachRefreshCookie(res, user);
         const response = apiResponse.successResponse(
-            {
-                token: generateToken(user._id, user.role, user.name),
-                user: sanitizeUser(user)
-            },
+            buildAuthPayload(user),
             'Wallet registration successful',
             201
         );
@@ -535,11 +563,61 @@ const walletRegister = async (req, res) => {
     }
 };
 
+const refreshSession = async (req, res) => {
+    try {
+        const cookies = parseCookieHeader(req.headers.cookie);
+        const refreshToken = cookies[REFRESH_COOKIE_NAME];
+
+        if (!refreshToken) {
+            return res.status(401).json(
+                apiResponse.unauthorizedResponse('Refresh token is required')
+            );
+        }
+
+        const refreshSecret = process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET;
+        const decoded = jwt.verify(refreshToken, refreshSecret);
+
+        if (decoded.type !== 'refresh') {
+            return res.status(401).json(
+                apiResponse.unauthorizedResponse('Invalid refresh token')
+            );
+        }
+
+        const user = await User.findById(decoded.id).select('-password');
+
+        if (!user) {
+            clearRefreshCookie(res);
+            return res.status(401).json(
+                apiResponse.unauthorizedResponse('User not found')
+            );
+        }
+
+        attachRefreshCookie(res, user);
+        return res.json(
+            apiResponse.successResponse(buildAuthPayload(user), 'Session refreshed')
+        );
+    } catch (error) {
+        clearRefreshCookie(res);
+        return res.status(401).json(
+            apiResponse.unauthorizedResponse('Invalid or expired refresh token')
+        );
+    }
+};
+
+const logoutUser = (req, res) => {
+    clearRefreshCookie(res);
+    return res.json(
+        apiResponse.successResponse(null, 'Logout successful')
+    );
+};
+
 module.exports = {
     registerUser,
     loginUser,
     walletLogin,
     walletRegister,
     getNonce,
-    updateProfile
+    updateProfile,
+    refreshSession,
+    logoutUser
 };

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,11 +1,22 @@
 const express = require('express');
 const router = express.Router();
-const { registerUser, loginUser, walletLogin, walletRegister, getNonce, updateProfile } = require('../controllers/authController');
+const {
+    registerUser,
+    loginUser,
+    walletLogin,
+    walletRegister,
+    getNonce,
+    updateProfile,
+    refreshSession,
+    logoutUser
+} = require('../controllers/authController');
 const { protect } = require('../middleware/auth');
 const validateRegistration = require('../middleware/validateRegistration');
 
 router.post('/register', validateRegistration, registerUser);
 router.post('/login', loginUser);
+router.post('/refresh', refreshSession);
+router.post('/logout', logoutUser);
 
 // Wallet authentication routes
 router.get('/nonce', getNonce);

--- a/backend/utils/generateToken.js
+++ b/backend/utils/generateToken.js
@@ -3,8 +3,17 @@ require('dotenv').config();
 
 const generateToken = (id, role, name) => {
     return jwt.sign({ id, role, name }, process.env.JWT_SECRET, {
-        expiresIn: '24h',
+        expiresIn: process.env.JWT_ACCESS_EXPIRES_IN || '15m',
+    });
+};
+
+const generateRefreshToken = (id) => {
+    const refreshSecret = process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET;
+
+    return jwt.sign({ id, type: 'refresh' }, refreshSecret, {
+        expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
     });
 };
 
 module.exports = generateToken;
+module.exports.generateRefreshToken = generateRefreshToken;

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,7 +8,7 @@ interface AuthContextType {
   register: (credentials: RegisterCredentials) => Promise<void>;
   connectWallet: () => Promise<void>;
   walletLogin: () => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   isLoading: boolean;
   isWalletConnected: boolean;
 }
@@ -23,16 +23,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   useEffect(() => {
     const initAuth = async () => {
       try {
-        const currentUser = authService.getCurrentUser();
-        if (currentUser && currentUser.role) {
-          // User has a valid role from backend authentication
-          setUser(currentUser);
-        } else {
-          // Only check wallet if no user is logged in
-          await checkWalletConnected();
-        }
+        const response = await authService.refreshSession();
+        setUser(response.user);
+        localStorage.setItem('user', JSON.stringify(response.user));
       } catch (error) {
-        console.error("Auth initialization error:", error);
+        localStorage.removeItem('user');
+        await checkWalletConnected();
       } finally {
         setIsLoading(false);
       }
@@ -66,7 +62,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       const response = await authService.login(credentials);
       setUser(response.user);
       localStorage.setItem('user', JSON.stringify(response.user));
-      localStorage.setItem('token', response.token);
       toast.success('Login successful!');
     } catch (error: any) {
       const message = error.response?.data?.message || 'Login failed';
@@ -83,7 +78,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       const response = await authService.register(credentials);
       setUser(response.user);
       localStorage.setItem('user', JSON.stringify(response.user));
-      localStorage.setItem('token', response.token);
       toast.success('Registration successful!');
     } catch (error: any) {
       const message = error.response?.data?.message || 'Registration failed';
@@ -174,7 +168,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       // Step 4: Store JWT and user data
       setUser(response.user);
       localStorage.setItem('user', JSON.stringify(response.user));
-      localStorage.setItem('token', response.token);
       
       toast.success('Wallet authentication successful!');
     } catch (error: any) {
@@ -191,8 +184,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     }
   };
 
-  const logout = () => {
-    authService.logout();
+  const logout = async () => {
+    await authService.logout();
     setUser(null);
     setIsWalletConnected(false);
     toast.success("Logged out");

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,62 @@
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import { tokenService } from './token.service';
+
+export const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+
+interface RetriableRequestConfig extends InternalAxiosRequestConfig {
+    _retry?: boolean;
+}
+
+export const apiClient = axios.create({
+    baseURL: API_URL,
+    withCredentials: true
+});
+
+apiClient.interceptors.request.use((config) => {
+    const token = tokenService.getAccessToken();
+
+    if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    return config;
+});
+
+apiClient.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+        const originalRequest = error.config as RetriableRequestConfig | undefined;
+        const requestUrl = originalRequest?.url || '';
+        const isAuthRefresh = requestUrl.includes('/auth/refresh');
+        const isAuthLogout = requestUrl.includes('/auth/logout');
+
+        if (
+            error.response?.status !== 401 ||
+            !originalRequest ||
+            originalRequest._retry ||
+            isAuthRefresh ||
+            isAuthLogout
+        ) {
+            return Promise.reject(error);
+        }
+
+        originalRequest._retry = true;
+
+        try {
+            const response = await apiClient.post('/auth/refresh');
+            const nextToken = response.data?.data?.token;
+
+            if (!nextToken) {
+                tokenService.clearAccessToken();
+                return Promise.reject(error);
+            }
+
+            tokenService.setAccessToken(nextToken);
+            originalRequest.headers.Authorization = `Bearer ${nextToken}`;
+            return apiClient(originalRequest);
+        } catch (refreshError) {
+            tokenService.clearAccessToken();
+            return Promise.reject(refreshError);
+        }
+    }
+);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,6 +1,5 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+import { apiClient } from './apiClient';
+import { tokenService } from './token.service';
 
 export interface User {
     id: string;
@@ -59,12 +58,14 @@ interface NonceResponse {
 
 export const authService = {
     async login(credentials: LoginCredentials): Promise<AuthResponse> {
-        const response = await axios.post<{ data: AuthResponse }>(`${API_URL}/auth/login`, credentials);
+        const response = await apiClient.post<{ data: AuthResponse }>('/auth/login', credentials);
+        tokenService.setAccessToken(response.data.data.token);
         return response.data.data;
     },
 
     async register(credentials: RegisterCredentials): Promise<AuthResponse> {
-        const response = await axios.post<{ data: AuthResponse }>(`${API_URL}/auth/register`, credentials);
+        const response = await apiClient.post<{ data: AuthResponse }>('/auth/register', credentials);
+        tokenService.setAccessToken(response.data.data.token);
         return response.data.data;
     },
 
@@ -73,7 +74,7 @@ export const authService = {
      * This should be called before signing the message
      */
     async getNonce(address: string): Promise<string> {
-        const response = await axios.get<NonceResponse>(`${API_URL}/auth/nonce`, {
+        const response = await apiClient.get<NonceResponse>('/auth/nonce', {
             params: { address }
         });
         return response.data.data.nonce;
@@ -88,7 +89,8 @@ export const authService = {
      * 4. Backend verifies signature and returns JWT with user role
      */
     async walletLogin(credentials: WalletLoginCredentials): Promise<AuthResponse> {
-        const response = await axios.post<{ data: AuthResponse }>(`${API_URL}/auth/wallet-login`, credentials);
+        const response = await apiClient.post<{ data: AuthResponse }>('/auth/wallet-login', credentials);
+        tokenService.setAccessToken(response.data.data.token);
         return response.data.data;
     },
 
@@ -97,13 +99,24 @@ export const authService = {
      * Similar to wallet login but creates a new user
      */
     async walletRegister(credentials: WalletRegisterCredentials): Promise<AuthResponse> {
-        const response = await axios.post<{ data: AuthResponse }>(`${API_URL}/auth/wallet-register`, credentials);
+        const response = await apiClient.post<{ data: AuthResponse }>('/auth/wallet-register', credentials);
+        tokenService.setAccessToken(response.data.data.token);
         return response.data.data;
     },
 
-    logout() {
+    async refreshSession(): Promise<AuthResponse> {
+        const response = await apiClient.post<{ data: AuthResponse }>('/auth/refresh');
+        tokenService.setAccessToken(response.data.data.token);
+        return response.data.data;
+    },
+
+    async logout() {
+        try {
+            await apiClient.post('/auth/logout');
+        } finally {
+            tokenService.clearAccessToken();
+        }
         localStorage.removeItem('user');
-        localStorage.removeItem('token');
     },
 
     getCurrentUser(): User | null {
@@ -119,6 +132,6 @@ export const authService = {
     },
 
     getToken(): string | null {
-        return localStorage.getItem('token');
+        return tokenService.getAccessToken();
     }
 };

--- a/src/services/token.service.ts
+++ b/src/services/token.service.ts
@@ -1,0 +1,15 @@
+let accessToken: string | null = null;
+
+export const tokenService = {
+    getAccessToken(): string | null {
+        return accessToken;
+    },
+
+    setAccessToken(token: string | null) {
+        accessToken = token;
+    },
+
+    clearAccessToken() {
+        accessToken = null;
+    }
+};

--- a/src/services/verificationService.ts
+++ b/src/services/verificationService.ts
@@ -1,6 +1,4 @@
-import axios from 'axios';
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
+import { apiClient } from './apiClient';
 
 export interface VerificationStatus {
     isVerified: boolean;
@@ -60,16 +58,7 @@ export const verificationService = {
             params: [message, walletAddress],
         }) as string;
 
-        const token = localStorage.getItem('token');
-        const response = await axios.post(
-            `${API_URL}/verification/link-wallet`,
-            { walletAddress, signature },
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            }
-        );
+        const response = await apiClient.post('/verification/link-wallet', { walletAddress, signature });
 
         return response.data;
     },
@@ -91,8 +80,6 @@ export const verificationService = {
 
         const adminAddress = accounts[0];
 
-        const token = localStorage.getItem('token');
-
         // Sign verification message with deterministic, non-PII content
         const message = `Issue credential for user ${userId} with wallet ${walletAddress}`;
         const signature = await window.ethereum.request({
@@ -100,15 +87,7 @@ export const verificationService = {
             params: [message, adminAddress],
         }) as string;
 
-        const response = await axios.post(
-            `${API_URL}/verification/issue`,
-            { userId, signature, walletAddress },
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            }
-        );
+        const response = await apiClient.post('/verification/issue', { userId, signature, walletAddress });
 
         return response.data;
     },
@@ -120,16 +99,7 @@ export const verificationService = {
         userId: string,
         reason: string
     ): Promise<{ success: boolean }> {
-        const token = localStorage.getItem('token');
-        const response = await axios.post(
-            `${API_URL}/verification/revoke`,
-            { userId, reason },
-            {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            }
-        );
+        const response = await apiClient.post('/verification/revoke', { userId, reason });
 
         return response.data;
     },
@@ -138,7 +108,7 @@ export const verificationService = {
      * Check verification status
      */
     async checkVerification(userId: string): Promise<VerificationStatus> {
-        const response = await axios.get(`${API_URL}/verification/check/${userId}`);
+        const response = await apiClient.get(`/verification/check/${userId}`);
         return response.data;
     },
 
@@ -146,12 +116,7 @@ export const verificationService = {
      * Get unverified users (Admin only)
      */
     async getUnverifiedUsers(): Promise<UnverifiedUser[]> {
-        const token = localStorage.getItem('token');
-        const response = await axios.get(`${API_URL}/verification/unverified`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        });
+        const response = await apiClient.get('/verification/unverified');
 
         return response.data.users;
     },
@@ -160,12 +125,7 @@ export const verificationService = {
      * Get verified users (Admin only)
      */
     async getVerifiedUsers(): Promise<VerifiedUser[]> {
-        const token = localStorage.getItem('token');
-        const response = await axios.get(`${API_URL}/verification/verified`, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-            },
-        });
+        const response = await apiClient.get('/verification/verified');
 
         return response.data.users;
     },


### PR DESCRIPTION
## Summary
- add short-lived access tokens with a refresh-token cookie for login, register, and wallet auth flows
- add /api/auth/refresh and /api/auth/logout endpoints for silent session renewal and cookie cleanup
- move frontend bearer-token handling into an in-memory token service with an axios retry interceptor
- remove frontend JWT reads/writes from localStorage in auth and verification services

## Verification
- node --check backend/controllers/authController.js
- node --check backend/routes/authRoutes.js
- node --check backend/utils/generateToken.js
- git diff --check

Note: I could not run the full npm build in this local runtime because npm is not installed here.

Closes #215