### PR TITLE
[SECURITY] MongoDB NoSQL injection

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -3,6 +3,22 @@ const Counter = require('../models/Counter');
 const mongoose = require('mongoose');
 const apiResponse = require('../utils/apiResponse');
 
+const escapeRegex = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const buildSafeSearchFilter = (value) => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+        return null;
+    }
+
+    return { $regex: escapeRegex(trimmedValue), $options: 'i' };
+};
+
 /**
  * Generate a unique batch ID using MongoDB counter
  */
@@ -260,14 +276,17 @@ exports.getBatches = async (req, res) => {
 
         const query = {};
 
-        if (batchId) {
-            query.batchId = { $regex: batchId, $options: 'i' };
+        const batchIdFilter = buildSafeSearchFilter(batchId);
+        if (batchIdFilter) {
+            query.batchId = batchIdFilter;
         }
-        if (farmerName) {
-            query.farmerName = { $regex: farmerName, $options: 'i' };
+        const farmerNameFilter = buildSafeSearchFilter(farmerName);
+        if (farmerNameFilter) {
+            query.farmerName = farmerNameFilter;
         }
-        if (cropType) {
-            query.cropType = { $regex: cropType, $options: 'i' };
+        const cropTypeFilter = buildSafeSearchFilter(cropType);
+        if (cropTypeFilter) {
+            query.cropType = cropTypeFilter;
         }
         
         if (status) {

--- a/backend/tests/batchSearchRegex.test.js
+++ b/backend/tests/batchSearchRegex.test.js
@@ -1,0 +1,97 @@
+process.env.NODE_ENV = 'test';
+
+const mockCounter = {
+  findOneAndUpdate: jest.fn()
+};
+
+const mockBatch = {
+  create: jest.fn(),
+  countDocuments: jest.fn(),
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  find: jest.fn()
+};
+
+jest.mock('mongoose', () => {
+  const Schema = jest.fn();
+  Schema.Types = {
+    ObjectId: 'ObjectId',
+    String: 'String',
+    Number: 'Number',
+    Date: 'Date',
+    Boolean: 'Boolean'
+  };
+
+  return {
+    Schema,
+    model: jest.fn((name) => {
+      if (name === 'Counter') return mockCounter;
+      if (name === 'Batch') return mockBatch;
+      return {
+        findOne: jest.fn(),
+        create: jest.fn(),
+        find: jest.fn(),
+        findOneAndUpdate: jest.fn()
+      };
+    }),
+    connect: jest.fn(),
+    startSession: jest.fn(),
+    connection: {
+      host: 'localhost',
+      readyState: 1
+    }
+  };
+});
+
+jest.mock('../models/Counter', () => mockCounter);
+jest.mock('../models/Batch', () => mockBatch);
+
+const { getBatches } = require('../controllers/batchController');
+
+describe('batch search regex safety', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('escapes regex metacharacters in search query params before querying MongoDB', async () => {
+    const queryChain = {
+      lean: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([])
+    };
+
+    mockBatch.find.mockReturnValue(queryChain);
+    mockBatch.countDocuments.mockResolvedValue(0);
+
+    const req = {
+      query: {
+        batchId: 'BATCH(1).*',
+        farmerName: 'A+B',
+        cropType: '[rice]',
+        status: 'Active'
+      }
+    };
+
+    const res = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis()
+    };
+
+    await getBatches(req, res);
+
+    expect(mockBatch.find).toHaveBeenCalledWith({
+      batchId: { $regex: 'BATCH\\(1\\)\\.\\*', $options: 'i' },
+      farmerName: { $regex: 'A\\+B', $options: 'i' },
+      cropType: { $regex: '\\[rice\\]', $options: 'i' },
+      status: 'Active'
+    });
+
+    expect(mockBatch.countDocuments).toHaveBeenCalledWith({
+      batchId: { $regex: 'BATCH\\(1\\)\\.\\*', $options: 'i' },
+      farmerName: { $regex: 'A\\+B', $options: 'i' },
+      cropType: { $regex: '\\[rice\\]', $options: 'i' },
+      status: 'Active'
+    });
+  });
+});


### PR DESCRIPTION
Escaped the batch search parameters before they reach MongoDB regex filters in batchController.js and batchController.js. The controller now trims input, ignores empty or non-string values, and treats metacharacters as literals, which closes the NoSQL injection and ReDoS path from untrusted regex query params.

Added a regression test in batchSearchRegex.test.js that proves inputs like `BATCH(1).*`, `A+B`, and `[rice]` are escaped before the query is sent to Mongoose.

Validation: npx jest --runInBand tests/batchSearchRegex.test.js --verbose passed.


closes #228