### PR TITLE
fix(i18n): add missing auth keys to Hindi locale

### DIFF
--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -105,7 +105,10 @@
     "registerButton": "रजिस्टर करें",
     "noAccount": "खाता नहीं है?",
     "haveAccount": "पहले से खाता है?",
-    "forgotPassword": "पासवर्ड भूल गए?"
+    "forgotPassword": "पासवर्ड भूल गए?",
+    "welcomeBack": "वापस स्वागत है!",
+    "loginSubtitle": "अपने डैशबोर्ड तक पहुंचने के लिए लॉगिन करें",
+    "connectWallet": "वॉलेट कनेक्ट करें"
   },
   "batch": {
     "addTitle": "नया बैच जोड़ें",


### PR DESCRIPTION
Fix #242 

## Summary
Adds 3 missing translation keys to `hi.json` that were present in `en.json` but absent from the Hindi locale, causing untranslated text on the login screen for Hindi users.

## Changes
- **File:** `frontend/src/i18n/locales/hi.json`
- **Section:** `auth`
- Added `welcomeBack`, `loginSubtitle`, and `connectWallet`

## Diff
```json
// hi.json — auth section
"forgotPassword": "पासवर्ड भूल गए?",
+ "welcomeBack": "वापस स्वागत है!",
+ "loginSubtitle": "अपने डैशबोर्ड तक पहुंचने के लिए लॉगिन करें",
+ "connectWallet": "वॉलेट कनेक्ट करें"
```

## Checklist
- Keys match the exact key names in `en.json`
- Translations reviewed for accuracy
- No other locale files affected
- No functional code changes