### PR TITLE
[SECURITY] Authorization bypass / mis-enforcement 

### DIFF
--- a/backend/constants/permissions.js
+++ b/backend/constants/permissions.js
@@ -250,6 +250,13 @@ function isInspector(role) {
 }
 
 /**
+ * Check if role has admin-level access
+ */
+function isAdminRole(role) {
+    return role === ROLES.ADMIN || role === ROLES.SUPER_ADMIN;
+}
+
+/**
  * Check if user can approve multisig actions
  */
 function canApproveMultisig(role, action) {
@@ -298,6 +305,7 @@ module.exports = {
     hasAnyPermission,
     hasAllPermissions,
     isInspector,
+    isAdminRole,
     canApproveMultisig,
     getRoleLevel,
     isRoleHigher

--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -2,6 +2,7 @@ const Batch = require('../models/Batch');
 const Counter = require('../models/Counter');
 const mongoose = require('mongoose');
 const apiResponse = require('../utils/apiResponse');
+const { isAdminRole } = require('../constants/permissions');
 
 const escapeRegex = (value) => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
@@ -233,6 +234,16 @@ exports.recallBatch = async (req, res) => {
             );
         }
 
+        if (!req.user || !isAdminRole(req.user.role)) {
+            return res.status(403).json(
+                apiResponse.errorResponse(
+                    'Access denied. Admin privileges required.',
+                    'FORBIDDEN',
+                    403
+                )
+            );
+        }
+
         batch.isRecalled = true;
         await batch.save();
 
@@ -332,7 +343,7 @@ exports.getBatches = async (req, res) => {
 exports.updateBatchStatus = async (req, res) => {
     try {
         // CRITICAL: Check if user has admin role
-        if (!req.user || req.user.role !== 'admin') {
+        if (!req.user || !isAdminRole(req.user.role)) {
             return res.status(403).json(
                 apiResponse.errorResponse(
                     'Access denied. Admin privileges required.',

--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -2,6 +2,7 @@ const didService = require('../services/didService');
 const User = require('../models/User');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
+const { ROLES } = require('../constants/permissions');
 
 // Validation schemas
 const linkWalletSchema = z.object({
@@ -184,7 +185,7 @@ const getUnverifiedUsers = async (req, res) => {
     try {
         const users = await User.find({
             'verification.isVerified': { $ne: true },
-            role: { $ne: 'admin' },
+            role: { $nin: [ROLES.ADMIN, ROLES.SUPER_ADMIN] },
         }).select('name email role walletAddress createdAt');
 
         const response = apiResponse.successResponse(

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const Batch = require('../models/Batch');
-const { PERMISSIONS, ROLES } = require('../constants/permissions');
+const { PERMISSIONS, ROLES, isAdminRole } = require('../constants/permissions');
 const RBACService = require('../services/rbacService');
 
 const protect = async (req, res, next) => {
@@ -34,7 +34,7 @@ const protect = async (req, res, next) => {
 };
 
 const adminOnly = (req, res, next) => {
-    if (req.user && (req.user.role === ROLES.ADMIN || req.user.role === ROLES.SUPER_ADMIN)) {
+    if (req.user && isAdminRole(req.user.role)) {
         return next();
     }
     return res.status(403).json({ error: 'Access denied', message: 'Admin access required' });
@@ -56,7 +56,7 @@ const authorizeBatchOwner = async (req, res, next) => {
         const userId = req.user.id || req.user._id;
         const userFarmerId = req.user.farmerId || userId;
         
-        if (req.user.role === ROLES.ADMIN || req.user.role === ROLES.SUPER_ADMIN) {
+        if (isAdminRole(req.user.role)) {
             req.batch = batch;
             return next();
         }
@@ -189,7 +189,7 @@ const checkBatchSafetyStatus = async (req, res, next) => {
         if (!batch) return res.status(404).json({ error: 'Not found', message: 'Batch not found' });
 
         if (batch.safetyStatus && batch.safetyStatus !== 'safe') {
-            if (req.user.role !== ROLES.ADMIN && req.user.role !== ROLES.SUPER_ADMIN) {
+            if (!isAdminRole(req.user.role)) {
                 return res.status(403).json({ error: 'Access denied', message: `Batch is currently ${batch.safetyStatus} and cannot be modified` });
             }
         }

--- a/backend/routes/approvalRoutes.js
+++ b/backend/routes/approvalRoutes.js
@@ -5,7 +5,7 @@
 const express = require('express');
 const router = express.Router();
 const { protect, adminOnly, inspectorOnly, requirePermissions } = require('../middleware/auth');
-const { PERMISSIONS } = require('../constants/permissions');
+const { PERMISSIONS, ROLES, isAdminRole } = require('../constants/permissions');
 const MultisigService = require('../services/multisigService');
 const Joi = require('joi');
 
@@ -71,8 +71,8 @@ router.get('/:requestId', protect, async (req, res) => {
     try {
         const approval = await MultisigService.getRequestDetails(req.params.requestId);
         const isInitiator = approval.initiatedBy._id.toString() === req.user._id.toString();
-        const isAdmin = req.user.role === 'admin' || req.user.role === 'super_admin';
-        const isInspector = req.user.role === 'quality_inspector';
+        const isAdmin = isAdminRole(req.user.role);
+        const isInspector = req.user.role === ROLES.QUALITY_INSPECTOR;
         if (!isInitiator && !isAdmin && !isInspector) {
             return res.status(403).json({ error: 'Access denied', message: 'Not authorized to view this approval request' });
         }

--- a/backend/routes/oracle.js
+++ b/backend/routes/oracle.js
@@ -92,7 +92,7 @@ router.get('/batch/:batchId/iot-data', protect, async (req, res) => {
  * GET /api/oracle/stats
  * Admin only
  */
-router.get('/stats', protect, authorizeRoles('admin'), async (req, res) => {
+router.get('/stats', protect, authorizeRoles('admin', 'super_admin'), async (req, res) => {
     try {
         const status = oracleService.getStatus();
         

--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -1,5 +1,6 @@
 const { ethers } = require('ethers');
 const User = require('../models/User');
+const { isAdminRole } = require('../constants/permissions');
 
 /**
  * DID Service for Verifiable Credentials
@@ -52,7 +53,7 @@ class DIDService {
                 throw new Error('User not found');
             }
 
-            if (!verifier || verifier.role !== 'admin') {
+            if (!verifier || !isAdminRole(verifier.role)) {
                 throw new Error('Only Mandi officers (admins) can verify users');
             }
 
@@ -136,7 +137,7 @@ class DIDService {
                 throw new Error('User not found');
             }
 
-            if (!admin || admin.role !== 'admin') {
+            if (!admin || !isAdminRole(admin.role)) {
                 throw new Error('Only admins can revoke credentials');
             }
 


### PR DESCRIPTION
Patch is complete and validated: admin-role enforcement is now consistent across middleware, routes, controllers, and services, and backend tests are passing (6/6 suites). I’ll summarize exactly what changed and where.

Implemented a security hardening pass for inconsistent admin authorization checks that could cause bypass/mis-enforcement.

**What I changed**

1. Added a single canonical admin-role helper.
- Added `isAdminRole(role)` in permissions.js.
- Exported it for reuse everywhere.

2. Switched middleware admin checks to the canonical helper.
- Updated auth.js:
  - `adminOnly` now uses `isAdminRole`.
  - `authorizeBatchOwner` admin short-circuit now uses `isAdminRole`.
  - `checkBatchSafetyStatus` admin exception now uses `isAdminRole`.

3. Fixed hard-coded admin checks in batch controller.
- Updated batchController.js:
  - `updateBatchStatus` now checks `isAdminRole(req.user.role)` instead of literal `'admin'`.
  - Restored and hardened recall authorization with `isAdminRole` in `recallBatch`.
  - Kept create response logic valid after a transient patch issue and corrected it.

4. Fixed service-level enforcement drift.
- Updated didService.js:
  - `issueCredential` verifier role check now uses `isAdminRole`.
  - `revokeCredential` revoker role check now uses `isAdminRole`.

5. Fixed route-level admin role inconsistency.
- Updated oracle.js:
  - `/stats` now allows both admin and super_admin through `authorizeRoles('admin', 'super_admin')`.

6. Fixed approval route role string literals.
- Updated approvalRoutes.js:
  - Replaced string comparisons with `isAdminRole` and `ROLES.QUALITY_INSPECTOR`.

7. Tightened verification admin-account filtering consistency.
- Updated verificationController.js:
  - Unverified-user query now excludes both admin and super_admin roles via `$nin`.

**Validation**

- Static diagnostics on all edited files: no errors.
- Backend tests run once (non-watch mode): **6 passed, 6 total**; **32 tests passed**.

closes #229