### PR TITLE
fix: add missing nav.smartPlanting i18n key for en and hi locales

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -11,7 +11,8 @@
     "admin": "Admin",
     "login": "Login",
     "register": "Register",
-    "logout": "Logout"
+    "logout": "Logout",
+    "smartPlanting": "Smart Planting"
   },
   "common": {
     "submit": "Submit",

--- a/frontend/src/i18n/locales/hi.json
+++ b/frontend/src/i18n/locales/hi.json
@@ -11,7 +11,8 @@
     "admin": "एडमिन",
     "login": "लॉगिन",
     "register": "रजिस्टर",
-    "logout": "लॉगआउट"
+    "logout": "लॉगआउट",
+    "smartPlanting": "स्मार्ट प्लांटिंग"
   },
   "common": {
     "submit": "जमा करें",


### PR DESCRIPTION
Fix #243 

## Problem
The navbar was displaying the raw translation key `nav.smartPlanting` 
instead of a human-readable label because the key was missing from 
the i18n locale files.

## Changes Made
- Added `"smartPlanting": "Smart Planting"` to `frontend/src/i18n/locales/en.json`
- Added `"smartPlanting": "स्मार्ट प्लांटिंग"` to `frontend/src/i18n/locales/hi.json`

## Testing
- Verified navbar shows "Smart Planting" instead of raw key `nav.smartPlanting`
- Checked both English and Hindi locales

## Screenshot
<img width="800" height="350" alt="Screenshot (345)" src="https://github.com/user-attachments/assets/2bd86b36-c3be-433a-9cb4-384d26598bfe" />

