### PR TITLE
API idempotency + stronger request replay protection for wallet linking & credential issuing

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -21,19 +21,39 @@ const revokeCredentialSchema = z.object({
     reason: z.string().min(1, 'Revocation reason is required'),
 });
 
+const handleZodValidation = (res, schema, reqBody) => {
+    const validationResult = schema.safeParse(reqBody);
+
+    if (!validationResult.success) {
+        res.status(400).json(
+            apiResponse.validationErrorResponse(
+                validationResult.error.errors.map(err => err.message)
+            )
+        );
+
+        return { ok: false };
+    }
+
+    return { ok: true, data: validationResult.data };
+};
+
+const handleServerError = (res, error, { code, message }) => {
+    console.error(message, error);
+
+    return res.status(500).json(
+        apiResponse.errorResponse(message, code, 500)
+    );
+};
+
 /**
  * Link wallet address to user account
  */
 const linkWallet = async (req, res) => {
     try {
-        const validationResult = linkWalletSchema.safeParse(req.body);
+        const validationResult = handleZodValidation(res, linkWalletSchema, req.body);
 
-        if (!validationResult.success) {
-            return res.status(400).json(
-                apiResponse.validationErrorResponse(
-                    validationResult.error.errors.map(err => err.message)
-                )
-            );
+        if (!validationResult.ok) {
+            return;
         }
 
         const { walletAddress, signature } = validationResult.data;
@@ -43,11 +63,10 @@ const linkWallet = async (req, res) => {
 
         res.json(result);
     } catch (error) {
-        console.error('Wallet linking failed:', error);
-
-        return res.status(500).json(
-            apiResponse.errorResponse('Wallet linking failed', 'WALLET_LINKING_ERROR', 500)
-        );
+        return handleServerError(res, error, {
+            code: 'WALLET_LINKING_ERROR',
+            message: 'Wallet linking failed',
+        });
     }
 };
 
@@ -56,14 +75,10 @@ const linkWallet = async (req, res) => {
  */
 const issueCredential = async (req, res) => {
     try {
-        const validationResult = issueCredentialSchema.safeParse(req.body);
+        const validationResult = handleZodValidation(res, issueCredentialSchema, req.body);
 
-        if (!validationResult.success) {
-            return res.status(400).json(
-                apiResponse.validationErrorResponse(
-                    validationResult.error.errors.map(err => err.message)
-                )
-            );
+        if (!validationResult.ok) {
+            return;
         }
 
         const { userId, signature, walletAddress } = validationResult.data;
@@ -73,15 +88,10 @@ const issueCredential = async (req, res) => {
 
         res.json(result);
     } catch (error) {
-        console.error('Credential issuing failed:', error);
-
-        return res.status(500).json(
-            apiResponse.errorResponse(
-                'Credential issuing failed',
-                'CREDENTIAL_ISSUE_ERROR',
-                500
-            )
-        );
+        return handleServerError(res, error, {
+            code: 'CREDENTIAL_ISSUE_ERROR',
+            message: 'Credential issuing failed',
+        });
     }
 };
 
@@ -90,14 +100,10 @@ const issueCredential = async (req, res) => {
  */
 const revokeCredential = async (req, res) => {
     try {
-        const validationResult = revokeCredentialSchema.safeParse(req.body);
+        const validationResult = handleZodValidation(res, revokeCredentialSchema, req.body);
 
-        if (!validationResult.success) {
-            return res.status(400).json(
-                apiResponse.validationErrorResponse(
-                    validationResult.error.errors.map(err => err.message)
-                )
-            );
+        if (!validationResult.ok) {
+            return;
         }
 
         const { userId, reason } = validationResult.data;
@@ -107,15 +113,10 @@ const revokeCredential = async (req, res) => {
 
         res.json(result);
     } catch (error) {
-        console.error('Credential revocation failed:', error);
-
-        return res.status(500).json(
-            apiResponse.errorResponse(
-                'Credential revocation failed',
-                'CREDENTIAL_REVOKE_ERROR',
-                500
-            )
-        );
+        return handleServerError(res, error, {
+            code: 'CREDENTIAL_REVOKE_ERROR',
+            message: 'Credential revocation failed',
+        });
     }
 };
 

--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -3,16 +3,39 @@ const User = require('../models/User');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
 const { ROLES } = require('../constants/permissions');
+const {
+    CHALLENGE_ACTIONS,
+    createChallenge,
+    consumeChallenge,
+    createFingerprint,
+    deleteIdempotencyRecord,
+    getIdempotencyRecord,
+    reserveIdempotencyKey,
+    storeCompletedIdempotencyRecord,
+} = require('../services/verificationSecurityService');
 
 // Validation schemas
 const linkWalletSchema = z.object({
     walletAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address'),
     signature: z.string().min(1, 'Signature is required'),
+    nonce: z.string().min(1, 'Nonce is required'),
+    expiresAt: z.coerce.number().int().positive('Expiry timestamp is required'),
 });
 
 const issueCredentialSchema = z.object({
     userId: z.string().min(1, 'User ID is required'),
     signature: z.string().min(1, 'Signature is required'),
+    walletAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address'),
+    nonce: z.string().min(1, 'Nonce is required'),
+    expiresAt: z.coerce.number().int().positive('Expiry timestamp is required'),
+});
+
+const linkWalletChallengeSchema = z.object({
+    walletAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address'),
+});
+
+const issueCredentialChallengeSchema = z.object({
+    userId: z.string().min(1, 'User ID is required'),
     walletAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid Ethereum address'),
 });
 
@@ -45,6 +68,180 @@ const handleServerError = (res, error, { code, message }) => {
     );
 };
 
+const requireIdempotencyKey = (req, res) => {
+    const idempotencyKey = req.get('Idempotency-Key');
+
+    if (!idempotencyKey || !idempotencyKey.trim()) {
+        res.status(400).json(
+            apiResponse.validationErrorResponse(['Idempotency-Key header is required'])
+        );
+
+        return null;
+    }
+
+    return idempotencyKey.trim();
+};
+
+const handleIdempotencyReplay = (res, record) => {
+    return res.status(record.statusCode || 200).json(record.response);
+};
+
+const handleDuplicateIdempotencyKey = (res, message) => {
+    return res.status(409).json(apiResponse.conflictResponse(message));
+};
+
+const handleChallengeValidation = (res, challengeRecord, requestPayload) => {
+    if (!challengeRecord) {
+        return handleDuplicateIdempotencyKey(res, 'Nonce is missing, expired, or already used');
+    }
+
+    if (
+        challengeRecord.expiresAt !== requestPayload.expiresAt ||
+        challengeRecord.nonce !== requestPayload.nonce
+    ) {
+        return handleDuplicateIdempotencyKey(res, 'Nonce does not match the active challenge');
+    }
+
+    return null;
+};
+
+const handleVerificationWithIdempotency = async ({
+    res,
+    action,
+    actorId,
+    userId,
+    walletAddress,
+    signature,
+    nonce,
+    expiresAt,
+    idempotencyKey,
+    execute,
+}) => {
+    const fingerprint = createFingerprint({ action, actorId, userId, walletAddress });
+    const existingRecord = await getIdempotencyRecord({ action, actorId, key: idempotencyKey });
+
+    if (existingRecord) {
+        if (existingRecord.fingerprint !== fingerprint) {
+            return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
+        }
+
+        if (existingRecord.state === 'completed') {
+            return handleIdempotencyReplay(res, existingRecord);
+        }
+
+        return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
+    }
+
+    const challengeRecord = await consumeChallenge({
+        action,
+        actorId,
+        nonce,
+        userId,
+        walletAddress,
+        expiresAt,
+    });
+
+    const challengeError = handleChallengeValidation(res, challengeRecord, { nonce, expiresAt });
+
+    if (challengeError) {
+        return challengeError;
+    }
+
+    const reservation = await reserveIdempotencyKey({
+        action,
+        actorId,
+        key: idempotencyKey,
+        fingerprint,
+    });
+
+    if (!reservation.reserved) {
+        if (!reservation.record) {
+            return handleDuplicateIdempotencyKey(res, 'Unable to reserve the idempotency key');
+        }
+
+        if (reservation.record.fingerprint !== fingerprint) {
+            return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
+        }
+
+        if (reservation.record.state === 'completed') {
+            return handleIdempotencyReplay(res, reservation.record);
+        }
+
+        return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
+    }
+
+    try {
+        const result = await execute(challengeRecord);
+        await storeCompletedIdempotencyRecord({
+            action,
+            actorId,
+            key: idempotencyKey,
+            fingerprint,
+            response: result,
+            statusCode: 200,
+        });
+
+        return res.json(result);
+    } catch (error) {
+        await deleteIdempotencyRecord({ action, actorId, key: idempotencyKey });
+        throw error;
+    }
+};
+
+const generateLinkWalletChallenge = async (req, res) => {
+    try {
+        const validationResult = handleZodValidation(res, linkWalletChallengeSchema, req.body);
+
+        if (!validationResult.ok) {
+            return;
+        }
+
+        const userId = req.user.id;
+        const { walletAddress } = validationResult.data;
+
+        const challenge = await createChallenge({
+            action: CHALLENGE_ACTIONS.LINK_WALLET,
+            actorId: userId,
+            userId,
+            walletAddress,
+        });
+
+        res.json(apiResponse.successResponse({ challenge }, 'Wallet linking challenge generated'));
+    } catch (error) {
+        return handleServerError(res, error, {
+            code: 'WALLET_LINK_CHALLENGE_ERROR',
+            message: 'Failed to generate wallet linking challenge',
+        });
+    }
+};
+
+const generateIssueCredentialChallenge = async (req, res) => {
+    try {
+        const validationResult = handleZodValidation(res, issueCredentialChallengeSchema, req.body);
+
+        if (!validationResult.ok) {
+            return;
+        }
+
+        const actorId = req.user.id;
+        const { userId, walletAddress } = validationResult.data;
+
+        const challenge = await createChallenge({
+            action: CHALLENGE_ACTIONS.ISSUE_CREDENTIAL,
+            actorId,
+            userId,
+            walletAddress,
+        });
+
+        res.json(apiResponse.successResponse({ challenge }, 'Credential issuance challenge generated'));
+    } catch (error) {
+        return handleServerError(res, error, {
+            code: 'CREDENTIAL_ISSUE_CHALLENGE_ERROR',
+            message: 'Failed to generate credential issuance challenge',
+        });
+    }
+};
+
 /**
  * Link wallet address to user account
  */
@@ -56,12 +253,27 @@ const linkWallet = async (req, res) => {
             return;
         }
 
-        const { walletAddress, signature } = validationResult.data;
+        const idempotencyKey = requireIdempotencyKey(req, res);
+
+        if (!idempotencyKey) {
+            return;
+        }
+
+        const { walletAddress, signature, nonce, expiresAt } = validationResult.data;
         const userId = req.user.id;
 
-        const result = await didService.linkWallet(userId, walletAddress, signature);
-
-        res.json(result);
+        return handleVerificationWithIdempotency({
+            res,
+            action: CHALLENGE_ACTIONS.LINK_WALLET,
+            actorId: userId,
+            userId,
+            walletAddress,
+            signature,
+            nonce,
+            expiresAt,
+            idempotencyKey,
+            execute: (challenge) => didService.linkWallet(userId, walletAddress, signature, challenge),
+        });
     } catch (error) {
         return handleServerError(res, error, {
             code: 'WALLET_LINKING_ERROR',
@@ -81,12 +293,27 @@ const issueCredential = async (req, res) => {
             return;
         }
 
-        const { userId, signature, walletAddress } = validationResult.data;
+        const idempotencyKey = requireIdempotencyKey(req, res);
+
+        if (!idempotencyKey) {
+            return;
+        }
+
+        const { userId, signature, walletAddress, nonce, expiresAt } = validationResult.data;
         const verifierId = req.user.id;
 
-        const result = await didService.issueCredential(userId, verifierId, signature, walletAddress);
-
-        res.json(result);
+        return handleVerificationWithIdempotency({
+            res,
+            action: CHALLENGE_ACTIONS.ISSUE_CREDENTIAL,
+            actorId: verifierId,
+            userId,
+            walletAddress,
+            signature,
+            nonce,
+            expiresAt,
+            idempotencyKey,
+            execute: (challenge) => didService.issueCredential(userId, verifierId, signature, walletAddress, challenge),
+        });
     } catch (error) {
         return handleServerError(res, error, {
             code: 'CREDENTIAL_ISSUE_ERROR',
@@ -225,6 +452,8 @@ const getVerifiedUsers = async (req, res) => {
 };
 
 module.exports = {
+    generateLinkWalletChallenge,
+    generateIssueCredentialChallenge,
     linkWallet,
     issueCredential,
     revokeCredential,

--- a/backend/routes/verification.js
+++ b/backend/routes/verification.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const {
+    generateLinkWalletChallenge,
+    generateIssueCredentialChallenge,
     linkWallet,
     issueCredential,
     revokeCredential,
@@ -14,6 +16,8 @@ const { protect, adminOnly } = require('../middleware/auth');
 router.get('/check/:userId', checkVerification);
 
 // Protected routes
+router.post('/challenge/link-wallet', protect, generateLinkWalletChallenge);
+router.post('/challenge/issue', protect, adminOnly, generateIssueCredentialChallenge);
 router.post('/link-wallet', protect, linkWallet);
 
 // Admin only routes

--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -1,6 +1,7 @@
 const { ethers } = require('ethers');
 const User = require('../models/User');
 const { isAdminRole } = require('../constants/permissions');
+const { buildVerificationMessage, CHALLENGE_ACTIONS } = require('./verificationSecurityService');
 
 /**
  * DID Service for Verifiable Credentials
@@ -44,7 +45,7 @@ class DIDService {
      * @param {string} walletAddress - User's wallet address
      * @returns {Object} - Verification result
      */
-    async issueCredential(userId, verifierId, signature, walletAddress) {
+    async issueCredential(userId, verifierId, signature, walletAddress, challenge) {
         try {
             const user = await User.findById(userId);
             const verifier = await User.findById(verifierId);
@@ -55,6 +56,10 @@ class DIDService {
 
             if (!verifier || !isAdminRole(verifier.role)) {
                 throw new Error('Only Mandi officers (admins) can verify users');
+            }
+
+            if (!challenge || challenge.action !== CHALLENGE_ACTIONS.ISSUE_CREDENTIAL) {
+                throw new Error('A valid issuance challenge is required');
             }
 
             if (user.verification?.isVerified) {
@@ -83,7 +88,14 @@ class DIDService {
             });
 
             // Verify signature
-            const message = `Verify user ${user.name} (${user.email}) with wallet ${linkedWalletAddress}`;
+            const message = buildVerificationMessage({
+                action: CHALLENGE_ACTIONS.ISSUE_CREDENTIAL,
+                actorId: verifierId,
+                userId: user._id.toString(),
+                walletAddress: linkedWalletAddress,
+                nonce: challenge.nonce,
+                expiresAt: challenge.expiresAt,
+            });
 
             if (!verifier.walletAddress) {
                 throw new Error('Verifier wallet address not found');
@@ -193,7 +205,7 @@ class DIDService {
      * @param {string} signature - Signature proving ownership
      * @returns {Object} - Link result
      */
-    async linkWallet(userId, walletAddress, signature) {
+    async linkWallet(userId, walletAddress, signature, challenge) {
         try {
             const user = await User.findById(userId);
 
@@ -201,8 +213,19 @@ class DIDService {
                 throw new Error('User not found');
             }
 
+            if (!challenge || challenge.action !== CHALLENGE_ACTIONS.LINK_WALLET) {
+                throw new Error('A valid wallet linking challenge is required');
+            }
+
             // Verify wallet ownership
-            const message = `Link wallet ${walletAddress} to CropChain account`;
+            const message = buildVerificationMessage({
+                action: CHALLENGE_ACTIONS.LINK_WALLET,
+                actorId: userId,
+                userId,
+                walletAddress,
+                nonce: challenge.nonce,
+                expiresAt: challenge.expiresAt,
+            });
             const isValidSignature = this.verifySignature(message, signature, walletAddress);
 
             if (!isValidSignature) {

--- a/backend/services/verificationSecurityService.js
+++ b/backend/services/verificationSecurityService.js
@@ -1,0 +1,176 @@
+const crypto = require('crypto');
+const { getRedisConnection } = require('../config/redis');
+
+const CHALLENGE_TTL_SECONDS = parseInt(process.env.VERIFICATION_CHALLENGE_TTL_SECONDS, 10) || 180;
+const IDEMPOTENCY_TTL_SECONDS = parseInt(process.env.VERIFICATION_IDEMPOTENCY_TTL_SECONDS, 10) || 24 * 60 * 60;
+
+const CHALLENGE_ACTIONS = {
+    LINK_WALLET: 'LINK_WALLET',
+    ISSUE_CREDENTIAL: 'ISSUE_CREDENTIAL',
+};
+
+const buildChallengeKey = ({ action, actorId, nonce }) => `verification:challenge:${action}:${actorId}:${nonce}`;
+const buildIdempotencyKey = ({ action, actorId, key }) => `verification:idempotency:${action}:${actorId}:${key}`;
+
+const normalizeWalletAddress = (walletAddress) => (walletAddress ? walletAddress.toLowerCase() : walletAddress);
+
+const createFingerprint = ({ action, actorId, userId, walletAddress }) => {
+    const payload = {
+        action,
+        actorId,
+        userId,
+        walletAddress: normalizeWalletAddress(walletAddress),
+    };
+
+    return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+};
+
+const buildVerificationMessage = ({ action, actorId, userId, walletAddress, nonce, expiresAt }) => {
+    const lines = [
+        'CropChain verification request',
+        `Action: ${action}`,
+        `Actor ID: ${actorId}`,
+        `User ID: ${userId}`,
+    ];
+
+    if (walletAddress) {
+        lines.push(`Wallet Address: ${normalizeWalletAddress(walletAddress)}`);
+    }
+
+    lines.push(`Nonce: ${nonce}`);
+    lines.push(`Expires At: ${expiresAt}`);
+
+    return lines.join('\n');
+};
+
+const parseJsonRecord = (value) => {
+    if (!value) {
+        return null;
+    }
+
+    if (typeof value === 'object') {
+        return value;
+    }
+
+    return JSON.parse(value);
+};
+
+const createChallenge = async ({ action, actorId, userId, walletAddress }) => {
+    const redis = getRedisConnection();
+    const nonce = crypto.randomBytes(32).toString('hex');
+    const expiresAt = Date.now() + (CHALLENGE_TTL_SECONDS * 1000);
+    const record = {
+        action,
+        actorId,
+        userId,
+        walletAddress: normalizeWalletAddress(walletAddress),
+        nonce,
+        expiresAt,
+        status: 'unused',
+        createdAt: Date.now(),
+    };
+
+    await redis.set(buildChallengeKey({ action, actorId, nonce }), JSON.stringify(record), 'EX', CHALLENGE_TTL_SECONDS);
+
+    return {
+        nonce,
+        expiresAt,
+        action,
+        actorId,
+        userId,
+        walletAddress: record.walletAddress,
+    };
+};
+
+const consumeChallenge = async ({ action, actorId, nonce, userId, walletAddress, expiresAt }) => {
+    const redis = getRedisConnection();
+    const key = buildChallengeKey({ action, actorId, nonce });
+    const rawRecord = await redis.eval(
+        "local value = redis.call('GET', KEYS[1]); if not value then return nil end; redis.call('DEL', KEYS[1]); return value",
+        1,
+        key
+    );
+
+    const storedRecord = parseJsonRecord(rawRecord);
+
+    if (!storedRecord) {
+        return null;
+    }
+
+    const normalizedWalletAddress = normalizeWalletAddress(walletAddress);
+
+    if (
+        storedRecord.action !== action ||
+        storedRecord.actorId !== actorId ||
+        storedRecord.userId !== userId ||
+        storedRecord.expiresAt !== expiresAt ||
+        normalizeWalletAddress(storedRecord.walletAddress) !== normalizedWalletAddress
+    ) {
+        return null;
+    }
+
+    if (storedRecord.expiresAt <= Date.now()) {
+        return null;
+    }
+
+    return storedRecord;
+};
+
+const getIdempotencyRecord = async ({ action, actorId, key }) => {
+    const redis = getRedisConnection();
+    const rawRecord = await redis.get(buildIdempotencyKey({ action, actorId, key }));
+    return parseJsonRecord(rawRecord);
+};
+
+const reserveIdempotencyKey = async ({ action, actorId, key, fingerprint }) => {
+    const redis = getRedisConnection();
+    const storageKey = buildIdempotencyKey({ action, actorId, key });
+    const record = {
+        state: 'pending',
+        fingerprint,
+        createdAt: Date.now(),
+    };
+
+    const result = await redis.set(storageKey, JSON.stringify(record), 'EX', IDEMPOTENCY_TTL_SECONDS, 'NX');
+
+    if (result === 'OK') {
+        return { reserved: true, key: storageKey, record };
+    }
+
+    const existingRecord = await getIdempotencyRecord({ action, actorId, key });
+
+    return { reserved: false, key: storageKey, record: existingRecord };
+};
+
+const storeCompletedIdempotencyRecord = async ({ action, actorId, key, fingerprint, response, statusCode = 200 }) => {
+    const redis = getRedisConnection();
+    const storageKey = buildIdempotencyKey({ action, actorId, key });
+    const record = {
+        state: 'completed',
+        fingerprint,
+        statusCode,
+        response,
+        completedAt: Date.now(),
+    };
+
+    await redis.set(storageKey, JSON.stringify(record), 'EX', IDEMPOTENCY_TTL_SECONDS);
+
+    return record;
+};
+
+const deleteIdempotencyRecord = async ({ action, actorId, key }) => {
+    const redis = getRedisConnection();
+    await redis.del(buildIdempotencyKey({ action, actorId, key }));
+};
+
+module.exports = {
+    CHALLENGE_ACTIONS,
+    buildVerificationMessage,
+    createChallenge,
+    consumeChallenge,
+    createFingerprint,
+    deleteIdempotencyRecord,
+    getIdempotencyRecord,
+    reserveIdempotencyKey,
+    storeCompletedIdempotencyRecord,
+};

--- a/backend/tests/verificationController.replay.test.js
+++ b/backend/tests/verificationController.replay.test.js
@@ -1,0 +1,140 @@
+jest.mock('../services/didService', () => ({
+    linkWallet: jest.fn(),
+    issueCredential: jest.fn(),
+    revokeCredential: jest.fn(),
+    checkVerificationStatus: jest.fn(),
+}));
+
+jest.mock('../services/verificationSecurityService', () => ({
+    CHALLENGE_ACTIONS: {
+        LINK_WALLET: 'LINK_WALLET',
+        ISSUE_CREDENTIAL: 'ISSUE_CREDENTIAL',
+    },
+    createChallenge: jest.fn(),
+    consumeChallenge: jest.fn(),
+    createFingerprint: jest.fn(() => 'fingerprint'),
+    deleteIdempotencyRecord: jest.fn(),
+    getIdempotencyRecord: jest.fn(),
+    reserveIdempotencyKey: jest.fn(),
+    storeCompletedIdempotencyRecord: jest.fn(),
+}));
+
+const didService = require('../services/didService');
+const securityService = require('../services/verificationSecurityService');
+const { linkWallet, issueCredential, generateLinkWalletChallenge } = require('../controllers/verificationController');
+
+const createResponse = () => {
+    const response = {
+        statusCode: 200,
+        body: null,
+        status: jest.fn(function status(code) {
+            this.statusCode = code;
+            return this;
+        }),
+        json: jest.fn(function json(payload) {
+            this.body = payload;
+            return this;
+        }),
+    };
+
+    return response;
+};
+
+describe('verification controller replay protection', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('returns the stored idempotent link-wallet response without reprocessing', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            state: 'completed',
+            fingerprint: 'fingerprint',
+            statusCode: 200,
+            response: {
+                success: true,
+                message: 'Wallet linked successfully',
+                walletAddress: '0xabc0000000000000000000000000000000000000',
+            },
+        });
+
+        const req = {
+            body: {
+                walletAddress: '0xabc0000000000000000000000000000000000000',
+                signature: '0xdeadbeef',
+                nonce: 'nonce-1',
+                expiresAt: Date.now() + 60000,
+            },
+            user: { id: 'user-1' },
+            get: jest.fn(() => 'idem-1'),
+        };
+        const res = createResponse();
+
+        await linkWallet(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            message: 'Wallet linked successfully',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+        });
+        expect(didService.linkWallet).not.toHaveBeenCalled();
+        expect(securityService.consumeChallenge).not.toHaveBeenCalled();
+    });
+
+    test('returns conflict for an in-progress idempotent issue request', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            state: 'pending',
+            fingerprint: 'fingerprint',
+        });
+
+        const req = {
+            body: {
+                userId: 'target-user',
+                walletAddress: '0xabc0000000000000000000000000000000000000',
+                signature: '0xdeadbeef',
+                nonce: 'nonce-2',
+                expiresAt: Date.now() + 60000,
+            },
+            user: { id: 'verifier-1' },
+            get: jest.fn(() => 'idem-2'),
+        };
+        const res = createResponse();
+
+        await issueCredential(req, res);
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body.code).toBe('CONFLICT');
+        expect(didService.issueCredential).not.toHaveBeenCalled();
+        expect(securityService.consumeChallenge).not.toHaveBeenCalled();
+    });
+
+    test('generates a wallet linking challenge for the authenticated user', async () => {
+        securityService.createChallenge.mockResolvedValue({
+            nonce: 'nonce-3',
+            expiresAt: 123456789,
+            action: 'LINK_WALLET',
+            actorId: 'user-2',
+            userId: 'user-2',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+        });
+
+        const req = {
+            body: {
+                walletAddress: '0xABC0000000000000000000000000000000000000',
+            },
+            user: { id: 'user-2' },
+        };
+        const res = createResponse();
+
+        await generateLinkWalletChallenge(req, res);
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(securityService.createChallenge).toHaveBeenCalledWith({
+            action: 'LINK_WALLET',
+            actorId: 'user-2',
+            userId: 'user-2',
+            walletAddress: '0xABC0000000000000000000000000000000000000',
+        });
+    });
+});


### PR DESCRIPTION
Added Redis-backed replay protection for the verification flow. Wallet linking and credential issuance now require a short-lived nonce plus expiry in the signed message, and both endpoints enforce an Idempotency-Key so a duplicate request can return the prior response or a 409 instead of re-running the mutation. The new challenge endpoints and request gating are in verification.js, with the security helpers in verificationSecurityService.js, and the controller/service changes in verificationController.js and didService.js.

Validation passed with the focused regression test: npx jest tests/verificationController.replay.test.js --runInBand.

closes #261