### PR TITLE
fix: wrap app with AuthProvider to resolve useAuth context error

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ import AccessDenied from './pages/AccessDenied';
 
 function App() {
   return (
-
+    <AuthProvider>
     <CurrencyProvider>
       <Toaster position="top-right" reverseOrder={false} />
       <Router>
@@ -57,7 +57,7 @@ function App() {
         </div>
       </Router>
     </CurrencyProvider>
-
+    </AuthProvider>
   );
 }
 


### PR DESCRIPTION
Fix #271 

## What does this PR do?
Wraps the entire app in `<AuthProvider>` in `App.tsx` so that 
all components have access to the auth context.

## Problem
The app crashed on load with a white screen because `Header` 
calls `useAuth()` but was rendering outside the `<AuthProvider>` 
tree.

**Error:**
Uncaught Error: useAuth must be used within an AuthProvider
  at AuthContext.tsx:213:11
  at Header (Header.tsx:11:28)

## Root Cause
In `frontend/src/App.tsx`, `<AuthProvider>` was imported but not 
wrapping the component tree. `<Router>` and `<Header>` were 
rendering outside it.

## Fix
Wrapped the `<Router>` and all child components inside 
`<AuthProvider>` in `App.tsx`.

## Steps to Reproduce
1. Clone the repo and run `npm run dev`
2. Open `http://localhost:5173`
3. Open browser DevTools → Console tab → see the error

## Expected Behavior
App loads normally with authentication context available to all components.