### PR TITLE
refactor: remove redundant verify callback from json body parser

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -226,14 +226,7 @@ app.use(cors(corsOptions));
 const maxFileSize = parseInt(process.env.MAX_FILE_SIZE) || 10 * 1024 * 1024;
 
 app.use(express.json({
-    limit: maxFileSize,
-    verify: (req, res, buf) => {
-        try {
-            JSON.parse(buf);
-        } catch (e) {
-            res.status(400).json({ error: 'Invalid JSON' });
-        }
-    }
+    limit: maxFileSize
 }));
 
 app.use(express.urlencoded({ extended: true, limit: maxFileSize }));


### PR DESCRIPTION
## Summary
Removed the custom `verify` callback from the `express.json` body parser configuration in `backend/server.js`. The callback was manually parsing JSON via `JSON.parse(buf)` inside the verify function, which duplicated what `express.json` already handles internally.

closes #266 , @Nitya-003 , approve this pr please.

## Changes
- `backend/server.js` — Removed the `verify` callback parameter from `express.json()` middleware
## Why
- Eliminates redundant JSON validation step
- Uses `express.json` default error handling (returns 400 with `{ error: 'Body parse error' }`) which is more consistent with other middleware patterns
- Removes unnecessary callback closure — simplifies the middleware stack
## Testing
- Existing tests pass
- Invalid JSON requests now use Express's built-in error path
- No behavioral change for valid JSON requests