### PR TITLE
[SECURITY] NoSQL Injection Sanitization

### DIFF
--- a/backend/middleware/nosqlSanitizer.js
+++ b/backend/middleware/nosqlSanitizer.js
@@ -1,0 +1,21 @@
+const mongoSanitize = require('express-mongo-sanitize');
+const logger = require('../utils/logger');
+const notificationService = require('../services/notificationService');
+
+module.exports = function createNoSqlSanitizer() {
+    return mongoSanitize({
+        replaceWith: '_',
+        onSanitize: ({ req, key }) => {
+            const details = {
+                requestPart: key,
+                method: req.method,
+                url: req.originalUrl,
+                ip: req.ip || req.connection.remoteAddress,
+                userAgent: req.get('User-Agent') || 'Unknown'
+            };
+
+            logger.warn('NoSQL injection payload sanitized', details);
+            notificationService.notifySecurityEvent('nosql_injection_sanitized', details);
+        }
+    });
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,6 @@ const path = require('path');
 const cors = require('cors');
 const helmet = require('helmet');
 const rateLimit = require('express-rate-limit');
-const mongoSanitize = require('express-mongo-sanitize');
 const jwt = require('jsonwebtoken');
 const { ethers } = require('ethers');
 const swaggerUi = require('swagger-ui-express');
@@ -13,6 +12,7 @@ require('dotenv').config();
 const mainRoutes = require("./routes/index");
 const oracleRoutes = require("./routes/oracle");
 const validateRequest = require('./middleware/validator');
+const createNoSqlSanitizer = require('./middleware/nosqlSanitizer');
 const { chatSchema } = require("./validations/chatSchema");
 const aiService = require('./services/aiService');
 const errorHandlerMiddleware = require('./middleware/errorHandler');
@@ -233,7 +233,7 @@ app.use(express.json({
 app.use(express.urlencoded({ extended: true, limit: maxFileSize }));
 
 // NoSQL injection protection
-app.use(mongoSanitize());
+app.use(createNoSqlSanitizer());
 app.use(securityLogger);
 
 // ==================== BLOCKCHAIN SERVICE INITIALIZATION ====================

--- a/backend/tests/nosqlSanitizer.test.js
+++ b/backend/tests/nosqlSanitizer.test.js
@@ -1,0 +1,70 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../utils/logger', () => ({
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn()
+}));
+
+jest.mock('../services/notificationService', () => ({
+    notifySecurityEvent: jest.fn()
+}));
+
+const logger = require('../utils/logger');
+const notificationService = require('../services/notificationService');
+const createNoSqlSanitizer = require('../middleware/nosqlSanitizer');
+
+describe('NoSQL Sanitizer Middleware', () => {
+    let app;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        app = express();
+        app.use(express.json());
+        app.use(express.urlencoded({ extended: true }));
+        app.use(createNoSqlSanitizer());
+
+        app.post('/inspect', (req, res) => {
+            res.json({
+                body: req.body,
+                query: req.query
+            });
+        });
+    });
+
+    test('replaces MongoDB operators and logs sanitization events', async () => {
+        const response = await request(app)
+            .post('/inspect?%24where=return%20true')
+            .send({
+                crop: {
+                    '$regex': '.*',
+                    'owner.name': 'Test Farmer'
+                }
+            })
+            .expect(200);
+
+        expect(response.body.body).toEqual({
+            crop: {
+                _regex: '.*',
+                owner_name: 'Test Farmer'
+            }
+        });
+
+        expect(response.body.query).toEqual({
+            _where: 'return true'
+        });
+
+        expect(logger.warn).toHaveBeenCalled();
+        expect(notificationService.notifySecurityEvent).toHaveBeenCalledWith(
+            'nosql_injection_sanitized',
+            expect.objectContaining({
+                requestPart: expect.any(String),
+                method: 'POST',
+                url: '/inspect?%24where=return%20true'
+            })
+        );
+    });
+});


### PR DESCRIPTION
Implemented NoSQL sanitization as a dedicated middleware in nosqlSanitizer.js that wraps express-mongo-sanitize with underscore replacement and emits structured security events whenever a request segment is sanitized. server.js now mounts that middleware globally before routes, so request body, query, and params are sanitized on ingress.

Added nosqlSanitizer.test.js to verify operator keys are rewritten and sanitization events are logged. I validated it with a focused Jest run, and it passed.


closes #280