### PR TITLE
fix: add host header validation middleware to prevent host header injection

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,12 @@ NODE_ENV=development
 # Format: Full URL with protocol (e.g., http://localhost:5173)
 # Source: Use your frontend dev server URL
 FRONTEND_URL=http://localhost:5173
+# TRUSTED_HOSTS: Comma-separated list of allowed Host header values for
+#                host header injection protection.
+# Requirement: Optional — auto-populated from FRONTEND_URL and ALLOWED_ORIGINS
+# Format: Comma-separated hostnames (e.g., localhost,api.cropchain.io)
+# Source: Add any deployment domain or reverse-proxy hostname
+TRUSTED_HOSTS=localhost
 
 ### CORS & Rate Limiting
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -246,6 +246,45 @@ if (process.env.NODE_ENV !== 'test') {
     }
 }
 
+// ==================== HOST HEADER VALIDATION ====================
+
+const trustedHosts = (() => {
+    const hosts = new Set(['localhost', '127.0.0.1']);
+    if (process.env.FRONTEND_URL) {
+        try {
+            const hostname = new URL(process.env.FRONTEND_URL).hostname;
+            if (hostname) hosts.add(hostname);
+        } catch { }
+    }
+    if (process.env.ALLOWED_ORIGINS) {
+        process.env.ALLOWED_ORIGINS.split(',').forEach(origin => {
+            try {
+                const hostname = new URL(origin.trim()).hostname;
+                if (hostname) hosts.add(hostname);
+            } catch { }
+        });
+    }
+    if (process.env.TRUSTED_HOSTS) {
+        process.env.TRUSTED_HOSTS.split(',').forEach(h => {
+            const trimmed = h.trim().toLowerCase();
+            if (trimmed) hosts.add(trimmed);
+        });
+    }
+    return hosts;
+})();
+
+app.use((req, res, next) => {
+    const host = req.hostname?.toLowerCase();
+    if (host && !trustedHosts.has(host)) {
+        console.warn(`[HOST BLOCKED] Unexpected Host header: ${host}`);
+        return res.status(400).json({
+            error: 'Invalid request',
+            code: 'INVALID_HOST'
+        });
+    }
+    next();
+});
+
 // ==================== ROUTES ====================
 
 // Mount health check main router


### PR DESCRIPTION
Fixes #294

## Description
Added host header validation middleware to prevent host header injection attacks. The middleware validates the Host header against a whitelist of trusted hostnames derived from `FRONTEND_URL` and `ALLOWED_ORIGINS` environment variables, with an additional `TRUSTED_HOSTS` env var for manual overrides.

## Changes
- Added `trustedHosts` set that auto-populates from `FRONTEND_URL`, `ALLOWED_ORIGINS`, and a new `TRUSTED_HOSTS` env var
- Added middleware that validates `req.hostname` against the trusted hosts whitelist and returns 400 if the host is unexpected
- Added `TRUSTED_HOSTS` documentation to `.env.example`

## Why
Without host header validation, an attacker can manipulate the Host header to:
- Poison cache systems that use the Host header as a cache key
- Bypass security controls that rely on the Host header
- Inject malicious URLs if the host is ever reflected in responses or redirects