### PR TITLE
[SECURITY] Rate Limiting (DoS + brute-force protection)

### DIFF
--- a/backend/middleware/rateLimiters.js
+++ b/backend/middleware/rateLimiters.js
@@ -1,0 +1,36 @@
+const rateLimit = require('express-rate-limit');
+
+const isTestEnv = process.env.NODE_ENV === 'test';
+const rateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000;
+
+const createLimiter = (maxRequests, message) => rateLimit({
+    windowMs: rateLimitWindowMs,
+    max: isTestEnv ? 10000 : maxRequests,
+    message: {
+        error: message,
+        retryAfter: `${Math.ceil(rateLimitWindowMs / 60000)} minutes`
+    },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+
+const generalLimiter = createLimiter(
+    parseInt(process.env.RATE_LIMIT_MAX_REQUESTS, 10) || 100,
+    'Too many requests from this IP, please try again later.'
+);
+
+const authLimiter = createLimiter(
+    parseInt(process.env.AUTH_RATE_LIMIT_MAX, 10) || 5,
+    'Too many authentication attempts from this IP, please try again later.'
+);
+
+const batchLimiter = createLimiter(
+    parseInt(process.env.BATCH_RATE_LIMIT_MAX, 10) || 20,
+    'Too many batch operations from this IP, please try again later.'
+);
+
+module.exports = {
+    generalLimiter,
+    authLimiter,
+    batchLimiter,
+};

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const mongoose = require("mongoose");
 const { updateBatchStatus, getBatches } = require("../controllers/batchController");
 const { protect, adminOnly } = require("../middleware/auth");
+const { batchLimiter } = require("../middleware/rateLimiters");
 
 router.get('/status', (req, res) => {
     const state = mongoose.connection.readyState;
@@ -22,9 +23,9 @@ router.get('/status', (req, res) => {
     })
 });
 
-router.get('/batches', protect, getBatches);
+router.get('/batches', batchLimiter, protect, getBatches);
 
 // Update batch status (admin only)
-router.patch('/batch/:batchId/status', protect, adminOnly, updateBatchStatus);
+router.patch('/batch/:batchId/status', batchLimiter, protect, adminOnly, updateBatchStatus);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,6 @@ const express = require('express');
 const path = require('path');
 const cors = require('cors');
 const helmet = require('helmet');
-const rateLimit = require('express-rate-limit');
 const jwt = require('jsonwebtoken');
 const swaggerUi = require('swagger-ui-express');
 const swaggerSpec = require('./swagger');
@@ -17,6 +16,7 @@ const aiService = require('./services/aiService');
 const errorHandlerMiddleware = require('./middleware/errorHandler');
 const { createBatchSchema, updateBatchSchema } = require("./validations/batchSchema");
 const { protect, adminOnly, authorizeBatchOwner, authorizeRoles, authorizeStageTransition, authorizeBlockchainTransaction } = require('./middleware/auth');
+const { generalLimiter, authLimiter, batchLimiter } = require('./middleware/rateLimiters');
 const mongoose = require('mongoose');
 const apiResponse = require('./utils/apiResponse');
 const oracleService = require('./services/oracleService');
@@ -146,44 +146,6 @@ app.use((_req, res, next) => {
         'camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()'
     );
     next();
-});
-
-// Rate limiting configurations
-const isTestEnv = process.env.NODE_ENV === 'test';
-const rateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 15 * 60 * 1000;
-const rateLimitMaxRequests = isTestEnv ? 10000 : (parseInt(process.env.RATE_LIMIT_MAX_REQUESTS) || 100);
-
-const generalLimiter = rateLimit({
-    windowMs: rateLimitWindowMs,
-    max: rateLimitMaxRequests,
-    message: {
-        error: 'Too many requests from this IP, please try again later.',
-        retryAfter: `${Math.ceil(rateLimitWindowMs / 60000)} minutes`
-    },
-    standardHeaders: true,
-    legacyHeaders: false,
-});
-
-const authLimiter = rateLimit({
-    windowMs: rateLimitWindowMs,
-    max: isTestEnv ? 10000 : (parseInt(process.env.AUTH_RATE_LIMIT_MAX) || 60),
-    message: {
-        error: 'Too many authentication attempts from this IP, please try again later.',
-        retryAfter: `${Math.ceil(rateLimitWindowMs / 60000)} minutes`
-    },
-    standardHeaders: true,
-    legacyHeaders: false,
-});
-
-const batchLimiter = rateLimit({
-    windowMs: rateLimitWindowMs,
-    max: isTestEnv ? 10000 : (parseInt(process.env.BATCH_RATE_LIMIT_MAX) || 20),
-    message: {
-        error: 'Too many batch operations from this IP, please try again later.',
-        retryAfter: `${Math.ceil(rateLimitWindowMs / 60000)} minutes`
-    },
-    standardHeaders: true,
-    legacyHeaders: false,
 });
 
 app.use(generalLimiter);


### PR DESCRIPTION
Implemented the rate-limiting tiers in rateLimiters.js, then wired them into server.js and index.js. The auth default is now 5 requests per 15 minutes, the general limiter stays at 100 per 15 minutes, and the batch limiter is applied to the batch-owned routes so the `/api/batches` paths are actually covered.

Validated with node --check on server.js, index.js, and rateLimiters.js.


closes #279