### PR TITLE
feat: Add Back to Top button

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import BackToTop from "../components/BackToTop"; 
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -38,6 +39,7 @@ export default function RootLayout({
             <main className="container mx-auto px-4 py-8">
               {children}
             </main>
+            <BackToTop />
             <AIChatbot />
           </div>
         </Providers>

--- a/frontend/src/components/BackToTop.tsx
+++ b/frontend/src/components/BackToTop.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ArrowUp } from "lucide-react";
+
+const BackToTop = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-24 right-8 z-50 p-3 rounded-full bg-green-600 hover:bg-green-700 text-white shadow-lg transition-all duration-300"
+      aria-label="Back to top"
+    >
+      <ArrowUp size={20} />
+    </button>
+  );
+};
+
+export default BackToTop;


### PR DESCRIPTION
Fix #278 

## Summary
Added a "Back to Top" button to improve navigation across long pages.

## Changes
- Added `frontend/src/components/BackToTop.tsx` — reusable component with scroll detection and smooth scroll behaviour
- Updated `frontend/src/app/layout.tsx` to include `BackToTop` globally

## Behaviour
- Button appears when the user scrolls down more than 300px
- Smoothly scrolls back to the top on click
- Fixed at bottom-right, positioned above the AI chatbot button to avoid overlap
- Matches the existing green accent color (`bg-green-600`)

## Screenshots

<img width="1000" height="500" alt="Screenshot (548)" src="https://github.com/user-attachments/assets/11afbfa6-dc4a-4b0e-a32a-2f3f68301f3f" />
