### PR TITLE
[REFACTOR] Standardize request validation and parameter checks

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -2,6 +2,7 @@ const didService = require('../services/didService');
 const User = require('../models/User');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
+const { validateParams } = require('../utils/validation');
 const { ROLES } = require('../constants/permissions');
 const {
     CHALLENGE_ACTIONS,
@@ -42,6 +43,10 @@ const issueCredentialChallengeSchema = z.object({
 const revokeCredentialSchema = z.object({
     userId: z.string().min(1, 'User ID is required'),
     reason: z.string().min(1, 'Revocation reason is required'),
+});
+
+const checkVerificationParamsSchema = z.object({
+    userId: z.string().regex(/^[a-fA-F0-9]{24}$/),
 });
 
 const handleZodValidation = (res, schema, reqBody) => {
@@ -352,52 +357,32 @@ const revokeCredential = async (req, res) => {
  */
 const checkVerification = async (req, res) => {
     try {
-        const { userId } = req.params;
+        const validatedParams = validateParams(res, checkVerificationParamsSchema, req.params);
 
-        // Basic validation of userId (e.g., MongoDB ObjectId-style 24 hex chars)
-        if (!userId || typeof userId !== 'string' || userId.trim().length === 0) {
-            return res.status(400).json(
-                apiResponse.errorResponse(
-                    'User ID is required',
-                    'MISSING_USERID',
-                    400
-                )
-            );
+        if (!validatedParams) {
+            return;
         }
 
-        if (!/^[a-fA-F0-9]{24}$/.test(userId)) {
-            return res.status(400).json(
-                apiResponse.errorResponse(
-                    'User ID must be a valid identifier',
-                    'INVALID_USERID',
-                    400
-                )
-            );
-        }
+        const { userId } = validatedParams;
 
         const result = await didService.checkVerificationStatus(userId);
 
         res.json(result);
     } catch (error) {
+        const message = error && error.message ? error.message : 'An unexpected error occurred';
+
         let statusCode = 500;
         let errorCode = 'VERIFICATION_CHECK_ERROR';
 
-        const message = error && error.message ? error.message : 'An unexpected error occurred';
-        const name = error && error.name ? error.name : '';
-
-        // Map validation/format errors to 400
-        if (
-            name === 'CastError' ||
-            name === 'ValidationError' ||
-            /invalid/i.test(message)
-        ) {
+        if (error?.name === 'CastError' || error?.name === 'ValidationError') {
             statusCode = 400;
             errorCode = 'INVALID_DATA';
-        }
-        // Map "not found" semantics to 404
-        else if (/not found/i.test(message)) {
+        } else if (error?.name === 'NotFoundError' || error?.code === 'NOT_FOUND' || error?.statusCode === 404) {
             statusCode = 404;
-            errorCode = 'NOT_FOUND';
+            errorCode = error?.code || 'NOT_FOUND';
+        } else if (error?.statusCode && error.statusCode < 500) {
+            statusCode = error.statusCode;
+            errorCode = error?.code || errorCode;
         }
 
         res.status(statusCode).json(

--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -2,6 +2,7 @@ const { ethers } = require('ethers');
 const User = require('../models/User');
 const { isAdminRole } = require('../constants/permissions');
 const { buildVerificationMessage, CHALLENGE_ACTIONS } = require('./verificationSecurityService');
+const { NotFoundError } = require('../utils/errorHandler');
 
 /**
  * DID Service for Verifiable Credentials
@@ -183,7 +184,7 @@ class DIDService {
             const user = await User.findById(userId).select('verification role');
 
             if (!user) {
-                throw new Error('User not found');
+                throw new NotFoundError('User', userId);
             }
 
             // Zero-knowledge proof: Only return verification status

--- a/backend/tests/verificationController.replay.test.js
+++ b/backend/tests/verificationController.replay.test.js
@@ -21,7 +21,7 @@ jest.mock('../services/verificationSecurityService', () => ({
 
 const didService = require('../services/didService');
 const securityService = require('../services/verificationSecurityService');
-const { linkWallet, issueCredential, generateLinkWalletChallenge } = require('../controllers/verificationController');
+const { linkWallet, issueCredential, generateLinkWalletChallenge, checkVerification } = require('../controllers/verificationController');
 
 const createResponse = () => {
     const response = {
@@ -136,5 +136,52 @@ describe('verification controller replay protection', () => {
             userId: 'user-2',
             walletAddress: '0xABC0000000000000000000000000000000000000',
         });
+    });
+
+    test('returns validation errors for an invalid verification userId param', async () => {
+        const req = {
+            params: {
+                userId: 'not-a-valid-object-id',
+            },
+        };
+        const res = createResponse();
+
+        await checkVerification(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            success: false,
+            data: null,
+            error: 'Validation failed',
+            code: 'VALIDATION_ERROR',
+            message: 'Validation failed',
+            statusCode: 400,
+            details: {
+                errors: [expect.any(String)],
+            },
+        });
+        expect(didService.checkVerificationStatus).not.toHaveBeenCalled();
+    });
+
+    test('maps a not-found verification lookup to a 404 response', async () => {
+        didService.checkVerificationStatus.mockRejectedValue({
+            name: 'NotFoundError',
+            code: 'NOT_FOUND',
+            statusCode: 404,
+            message: 'User with 507f1f77bcf86cd799439011 not found',
+        });
+
+        const req = {
+            params: {
+                userId: '507f1f77bcf86cd799439011',
+            },
+        };
+        const res = createResponse();
+
+        await checkVerification(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body.code).toBe('NOT_FOUND');
+        expect(res.body.message).toBe('User with 507f1f77bcf86cd799439011 not found');
     });
 });

--- a/backend/utils/validation.js
+++ b/backend/utils/validation.js
@@ -1,0 +1,26 @@
+const apiResponse = require('./apiResponse');
+
+const validateParams = (res, schema, params) => {
+    const validationResult = schema.safeParse(params);
+
+    if (!validationResult.success) {
+        res.status(400).json(
+            apiResponse.errorResponse(
+                'Validation failed',
+                'VALIDATION_ERROR',
+                400,
+                {
+                    errors: validationResult.error.issues.map((issue) => issue.message),
+                }
+            )
+        );
+
+        return null;
+    }
+
+    return validationResult.data;
+};
+
+module.exports = {
+    validateParams,
+};


### PR DESCRIPTION
Standardized the verification lookup path so `checkVerification` now uses a shared Zod param validator and no longer does manual string/regex checks. I added validation.js, wired it into verificationController.js, and changed didService.js to throw a typed not-found error instead of a plain message.

I also added coverage in verificationController.replay.test.js for invalid params and 404 mapping. Verification passed with `npx jest --runInBand tests/verificationController.replay.test.js`, and the touched files are clean under `get_errors`.



closes #307