### PR TITLE
[REFACTOR] Make idempotency flow more readable by splitting handleVerificationWithIdempotency

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -2,6 +2,7 @@ const didService = require('../services/didService');
 const User = require('../models/User');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
+const { validateParams } = require('../utils/validation');
 const { ROLES } = require('../constants/permissions');
 const {
     CHALLENGE_ACTIONS,
@@ -42,6 +43,10 @@ const issueCredentialChallengeSchema = z.object({
 const revokeCredentialSchema = z.object({
     userId: z.string().min(1, 'User ID is required'),
     reason: z.string().min(1, 'Revocation reason is required'),
+});
+
+const checkVerificationParamsSchema = z.object({
+    userId: z.string().regex(/^[a-fA-F0-9]{24}$/),
 });
 
 const handleZodValidation = (res, schema, reqBody) => {
@@ -352,52 +357,32 @@ const revokeCredential = async (req, res) => {
  */
 const checkVerification = async (req, res) => {
     try {
-        const { userId } = req.params;
+        const validatedParams = validateParams(res, checkVerificationParamsSchema, req.params);
 
-        // Basic validation of userId (e.g., MongoDB ObjectId-style 24 hex chars)
-        if (!userId || typeof userId !== 'string' || userId.trim().length === 0) {
-            return res.status(400).json(
-                apiResponse.errorResponse(
-                    'User ID is required',
-                    'MISSING_USERID',
-                    400
-                )
-            );
+        if (!validatedParams) {
+            return;
         }
 
-        if (!/^[a-fA-F0-9]{24}$/.test(userId)) {
-            return res.status(400).json(
-                apiResponse.errorResponse(
-                    'User ID must be a valid identifier',
-                    'INVALID_USERID',
-                    400
-                )
-            );
-        }
+        const { userId } = validatedParams;
 
         const result = await didService.checkVerificationStatus(userId);
 
         res.json(result);
     } catch (error) {
+        const message = error && error.message ? error.message : 'An unexpected error occurred';
+
         let statusCode = 500;
         let errorCode = 'VERIFICATION_CHECK_ERROR';
 
-        const message = error && error.message ? error.message : 'An unexpected error occurred';
-        const name = error && error.name ? error.name : '';
-
-        // Map validation/format errors to 400
-        if (
-            name === 'CastError' ||
-            name === 'ValidationError' ||
-            /invalid/i.test(message)
-        ) {
+        if (error?.name === 'CastError' || error?.name === 'ValidationError') {
             statusCode = 400;
             errorCode = 'INVALID_DATA';
-        }
-        // Map "not found" semantics to 404
-        else if (/not found/i.test(message)) {
+        } else if (error?.name === 'NotFoundError' || error?.code === 'NOT_FOUND' || error?.statusCode === 404) {
             statusCode = 404;
-            errorCode = 'NOT_FOUND';
+            errorCode = error?.code || 'NOT_FOUND';
+        } else if (error?.statusCode && error.statusCode < 500) {
+            statusCode = error.statusCode;
+            errorCode = error?.code || errorCode;
         }
 
         res.status(statusCode).json(

--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -3,16 +3,11 @@ const User = require('../models/User');
 const { z } = require('zod');
 const apiResponse = require('../utils/apiResponse');
 const { validateParams } = require('../utils/validation');
+const { handleVerificationWithIdempotency } = require('../utils/verificationIdempotency');
 const { ROLES } = require('../constants/permissions');
 const {
     CHALLENGE_ACTIONS,
     createChallenge,
-    consumeChallenge,
-    createFingerprint,
-    deleteIdempotencyRecord,
-    getIdempotencyRecord,
-    reserveIdempotencyKey,
-    storeCompletedIdempotencyRecord,
 } = require('../services/verificationSecurityService');
 
 // Validation schemas
@@ -85,112 +80,6 @@ const requireIdempotencyKey = (req, res) => {
     }
 
     return idempotencyKey.trim();
-};
-
-const handleIdempotencyReplay = (res, record) => {
-    return res.status(record.statusCode || 200).json(record.response);
-};
-
-const handleDuplicateIdempotencyKey = (res, message) => {
-    return res.status(409).json(apiResponse.conflictResponse(message));
-};
-
-const handleChallengeValidation = (res, challengeRecord, requestPayload) => {
-    if (!challengeRecord) {
-        return handleDuplicateIdempotencyKey(res, 'Nonce is missing, expired, or already used');
-    }
-
-    if (
-        challengeRecord.expiresAt !== requestPayload.expiresAt ||
-        challengeRecord.nonce !== requestPayload.nonce
-    ) {
-        return handleDuplicateIdempotencyKey(res, 'Nonce does not match the active challenge');
-    }
-
-    return null;
-};
-
-const handleVerificationWithIdempotency = async ({
-    res,
-    action,
-    actorId,
-    userId,
-    walletAddress,
-    signature,
-    nonce,
-    expiresAt,
-    idempotencyKey,
-    execute,
-}) => {
-    const fingerprint = createFingerprint({ action, actorId, userId, walletAddress });
-    const existingRecord = await getIdempotencyRecord({ action, actorId, key: idempotencyKey });
-
-    if (existingRecord) {
-        if (existingRecord.fingerprint !== fingerprint) {
-            return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
-        }
-
-        if (existingRecord.state === 'completed') {
-            return handleIdempotencyReplay(res, existingRecord);
-        }
-
-        return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
-    }
-
-    const challengeRecord = await consumeChallenge({
-        action,
-        actorId,
-        nonce,
-        userId,
-        walletAddress,
-        expiresAt,
-    });
-
-    const challengeError = handleChallengeValidation(res, challengeRecord, { nonce, expiresAt });
-
-    if (challengeError) {
-        return challengeError;
-    }
-
-    const reservation = await reserveIdempotencyKey({
-        action,
-        actorId,
-        key: idempotencyKey,
-        fingerprint,
-    });
-
-    if (!reservation.reserved) {
-        if (!reservation.record) {
-            return handleDuplicateIdempotencyKey(res, 'Unable to reserve the idempotency key');
-        }
-
-        if (reservation.record.fingerprint !== fingerprint) {
-            return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
-        }
-
-        if (reservation.record.state === 'completed') {
-            return handleIdempotencyReplay(res, reservation.record);
-        }
-
-        return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
-    }
-
-    try {
-        const result = await execute(challengeRecord);
-        await storeCompletedIdempotencyRecord({
-            action,
-            actorId,
-            key: idempotencyKey,
-            fingerprint,
-            response: result,
-            statusCode: 200,
-        });
-
-        return res.json(result);
-    } catch (error) {
-        await deleteIdempotencyRecord({ action, actorId, key: idempotencyKey });
-        throw error;
-    }
 };
 
 const generateLinkWalletChallenge = async (req, res) => {

--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -2,6 +2,7 @@ const { ethers } = require('ethers');
 const User = require('../models/User');
 const { isAdminRole } = require('../constants/permissions');
 const { buildVerificationMessage, CHALLENGE_ACTIONS } = require('./verificationSecurityService');
+const { NotFoundError } = require('../utils/errorHandler');
 
 /**
  * DID Service for Verifiable Credentials
@@ -183,7 +184,7 @@ class DIDService {
             const user = await User.findById(userId).select('verification role');
 
             if (!user) {
-                throw new Error('User not found');
+                throw new NotFoundError('User', userId);
             }
 
             // Zero-knowledge proof: Only return verification status

--- a/backend/tests/verificationController.replay.test.js
+++ b/backend/tests/verificationController.replay.test.js
@@ -21,7 +21,7 @@ jest.mock('../services/verificationSecurityService', () => ({
 
 const didService = require('../services/didService');
 const securityService = require('../services/verificationSecurityService');
-const { linkWallet, issueCredential, generateLinkWalletChallenge } = require('../controllers/verificationController');
+const { linkWallet, issueCredential, generateLinkWalletChallenge, checkVerification } = require('../controllers/verificationController');
 
 const createResponse = () => {
     const response = {
@@ -136,5 +136,52 @@ describe('verification controller replay protection', () => {
             userId: 'user-2',
             walletAddress: '0xABC0000000000000000000000000000000000000',
         });
+    });
+
+    test('returns validation errors for an invalid verification userId param', async () => {
+        const req = {
+            params: {
+                userId: 'not-a-valid-object-id',
+            },
+        };
+        const res = createResponse();
+
+        await checkVerification(req, res);
+
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toEqual({
+            success: false,
+            data: null,
+            error: 'Validation failed',
+            code: 'VALIDATION_ERROR',
+            message: 'Validation failed',
+            statusCode: 400,
+            details: {
+                errors: [expect.any(String)],
+            },
+        });
+        expect(didService.checkVerificationStatus).not.toHaveBeenCalled();
+    });
+
+    test('maps a not-found verification lookup to a 404 response', async () => {
+        didService.checkVerificationStatus.mockRejectedValue({
+            name: 'NotFoundError',
+            code: 'NOT_FOUND',
+            statusCode: 404,
+            message: 'User with 507f1f77bcf86cd799439011 not found',
+        });
+
+        const req = {
+            params: {
+                userId: '507f1f77bcf86cd799439011',
+            },
+        };
+        const res = createResponse();
+
+        await checkVerification(req, res);
+
+        expect(res.statusCode).toBe(404);
+        expect(res.body.code).toBe('NOT_FOUND');
+        expect(res.body.message).toBe('User with 507f1f77bcf86cd799439011 not found');
     });
 });

--- a/backend/tests/verificationIdempotency.test.js
+++ b/backend/tests/verificationIdempotency.test.js
@@ -1,0 +1,170 @@
+jest.mock('../services/verificationSecurityService', () => ({
+    createFingerprint: jest.fn(() => 'fingerprint'),
+    getIdempotencyRecord: jest.fn(),
+    consumeChallenge: jest.fn(),
+    reserveIdempotencyKey: jest.fn(),
+    storeCompletedIdempotencyRecord: jest.fn(),
+    deleteIdempotencyRecord: jest.fn(),
+}));
+
+const securityService = require('../services/verificationSecurityService');
+const {
+    handleVerificationWithIdempotency,
+} = require('../utils/verificationIdempotency');
+
+const createResponse = () => {
+    const response = {
+        statusCode: 200,
+        body: null,
+        status: jest.fn(function status(code) {
+            this.statusCode = code;
+            return this;
+        }),
+        json: jest.fn(function json(payload) {
+            this.body = payload;
+            return this;
+        }),
+    };
+
+    return response;
+};
+
+describe('verification idempotency helper', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('replays a completed idempotency record without reprocessing', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            fingerprint: 'fingerprint',
+            state: 'completed',
+            statusCode: 200,
+            response: {
+                success: true,
+                message: 'Wallet linked successfully',
+            },
+        });
+
+        const res = createResponse();
+
+        await handleVerificationWithIdempotency({
+            res,
+            action: 'LINK_WALLET',
+            actorId: 'user-1',
+            userId: 'user-1',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+            signature: '0xdeadbeef',
+            nonce: 'nonce-1',
+            expiresAt: Date.now() + 60000,
+            idempotencyKey: 'idem-1',
+            execute: jest.fn(),
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            message: 'Wallet linked successfully',
+        });
+        expect(securityService.consumeChallenge).not.toHaveBeenCalled();
+        expect(securityService.reserveIdempotencyKey).not.toHaveBeenCalled();
+    });
+
+    test('executes and stores the completed idempotency result', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue(null);
+        securityService.consumeChallenge.mockResolvedValue({
+            nonce: 'nonce-2',
+            expiresAt: 123456789,
+            action: 'ISSUE_CREDENTIAL',
+            actorId: 'verifier-1',
+            userId: 'target-1',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+        });
+        securityService.reserveIdempotencyKey.mockResolvedValue({
+            reserved: true,
+            record: {
+                state: 'pending',
+                fingerprint: 'fingerprint',
+            },
+        });
+
+        const execute = jest.fn().mockResolvedValue({
+            success: true,
+            message: 'Credential issued successfully',
+        });
+        const res = createResponse();
+
+        await handleVerificationWithIdempotency({
+            res,
+            action: 'ISSUE_CREDENTIAL',
+            actorId: 'verifier-1',
+            userId: 'target-1',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+            signature: '0xdeadbeef',
+            nonce: 'nonce-2',
+            expiresAt: 123456789,
+            idempotencyKey: 'idem-2',
+            execute,
+        });
+
+        expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+            nonce: 'nonce-2',
+            expiresAt: 123456789,
+        }));
+        expect(securityService.storeCompletedIdempotencyRecord).toHaveBeenCalledWith({
+            action: 'ISSUE_CREDENTIAL',
+            actorId: 'verifier-1',
+            key: 'idem-2',
+            fingerprint: 'fingerprint',
+            response: {
+                success: true,
+                message: 'Credential issued successfully',
+            },
+            statusCode: 200,
+        });
+        expect(res.body).toEqual({
+            success: true,
+            message: 'Credential issued successfully',
+        });
+    });
+
+    test('deletes the idempotency record when execution fails', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue(null);
+        securityService.consumeChallenge.mockResolvedValue({
+            nonce: 'nonce-3',
+            expiresAt: 123456789,
+            action: 'LINK_WALLET',
+            actorId: 'user-3',
+            userId: 'user-3',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+        });
+        securityService.reserveIdempotencyKey.mockResolvedValue({
+            reserved: true,
+            record: {
+                state: 'pending',
+                fingerprint: 'fingerprint',
+            },
+        });
+
+        const execute = jest.fn().mockRejectedValue(new Error('boom'));
+        const res = createResponse();
+
+        await expect(handleVerificationWithIdempotency({
+            res,
+            action: 'LINK_WALLET',
+            actorId: 'user-3',
+            userId: 'user-3',
+            walletAddress: '0xabc0000000000000000000000000000000000000',
+            signature: '0xdeadbeef',
+            nonce: 'nonce-3',
+            expiresAt: 123456789,
+            idempotencyKey: 'idem-3',
+            execute,
+        })).rejects.toThrow('boom');
+
+        expect(securityService.deleteIdempotencyRecord).toHaveBeenCalledWith({
+            action: 'LINK_WALLET',
+            actorId: 'user-3',
+            key: 'idem-3',
+        });
+    });
+});

--- a/backend/utils/validation.js
+++ b/backend/utils/validation.js
@@ -1,0 +1,26 @@
+const apiResponse = require('./apiResponse');
+
+const validateParams = (res, schema, params) => {
+    const validationResult = schema.safeParse(params);
+
+    if (!validationResult.success) {
+        res.status(400).json(
+            apiResponse.errorResponse(
+                'Validation failed',
+                'VALIDATION_ERROR',
+                400,
+                {
+                    errors: validationResult.error.issues.map((issue) => issue.message),
+                }
+            )
+        );
+
+        return null;
+    }
+
+    return validationResult.data;
+};
+
+module.exports = {
+    validateParams,
+};

--- a/backend/utils/verificationIdempotency.js
+++ b/backend/utils/verificationIdempotency.js
@@ -1,0 +1,194 @@
+const apiResponse = require('./apiResponse');
+const {
+    createFingerprint,
+    getIdempotencyRecord,
+    consumeChallenge,
+    reserveIdempotencyKey,
+    storeCompletedIdempotencyRecord,
+    deleteIdempotencyRecord,
+} = require('../services/verificationSecurityService');
+
+const handleIdempotencyReplay = (res, record) => {
+    return res.status(record.statusCode || 200).json(record.response);
+};
+
+const handleDuplicateIdempotencyKey = (res, message) => {
+    return res.status(409).json(apiResponse.conflictResponse(message));
+};
+
+const getFingerprintAndExistingRecord = async ({ action, actorId, userId, walletAddress, idempotencyKey }) => {
+    const fingerprint = createFingerprint({ action, actorId, userId, walletAddress });
+    const existingRecord = await getIdempotencyRecord({ action, actorId, key: idempotencyKey });
+
+    return { fingerprint, existingRecord };
+};
+
+const handleExistingIdempotencyRecord = (res, existingRecord, fingerprint) => {
+    if (!existingRecord) {
+        return null;
+    }
+
+    if (existingRecord.fingerprint !== fingerprint) {
+        return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
+    }
+
+    if (existingRecord.state === 'completed') {
+        return handleIdempotencyReplay(res, existingRecord);
+    }
+
+    return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
+};
+
+const consumeAndValidateChallenge = async ({ res, action, actorId, nonce, userId, walletAddress, expiresAt }) => {
+    const challengeRecord = await consumeChallenge({
+        action,
+        actorId,
+        nonce,
+        userId,
+        walletAddress,
+        expiresAt,
+    });
+
+    if (!challengeRecord) {
+        return {
+            response: handleDuplicateIdempotencyKey(res, 'Nonce is missing, expired, or already used'),
+        };
+    }
+
+    if (
+        challengeRecord.expiresAt !== expiresAt ||
+        challengeRecord.nonce !== nonce
+    ) {
+        return {
+            response: handleDuplicateIdempotencyKey(res, 'Nonce does not match the active challenge'),
+        };
+    }
+
+    return { challengeRecord };
+};
+
+const reserveOrHandleReservationOutcome = async ({ res, action, actorId, idempotencyKey, fingerprint }) => {
+    const reservation = await reserveIdempotencyKey({
+        action,
+        actorId,
+        key: idempotencyKey,
+        fingerprint,
+    });
+
+    if (reservation.reserved) {
+        return { reservation };
+    }
+
+    if (!reservation.record) {
+        return {
+            response: handleDuplicateIdempotencyKey(res, 'Unable to reserve the idempotency key'),
+        };
+    }
+
+    if (reservation.record.fingerprint !== fingerprint) {
+        return {
+            response: handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request'),
+        };
+    }
+
+    if (reservation.record.state === 'completed') {
+        return {
+            response: handleIdempotencyReplay(res, reservation.record),
+        };
+    }
+
+    return {
+        response: handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress'),
+    };
+};
+
+const executeAndFinalizeIdempotency = async ({
+    res,
+    action,
+    actorId,
+    idempotencyKey,
+    fingerprint,
+    challengeRecord,
+    execute,
+}) => {
+    try {
+        const result = await execute(challengeRecord);
+
+        await storeCompletedIdempotencyRecord({
+            action,
+            actorId,
+            key: idempotencyKey,
+            fingerprint,
+            response: result,
+            statusCode: 200,
+        });
+
+        return res.json(result);
+    } catch (error) {
+        await deleteIdempotencyRecord({ action, actorId, key: idempotencyKey });
+        throw error;
+    }
+};
+
+const handleVerificationWithIdempotency = async (context) => {
+    const { res, action, actorId, userId, walletAddress, nonce, expiresAt, idempotencyKey, execute } = context;
+
+    const { fingerprint, existingRecord } = await getFingerprintAndExistingRecord({
+        action,
+        actorId,
+        userId,
+        walletAddress,
+        idempotencyKey,
+    });
+
+    const existingRecordOutcome = handleExistingIdempotencyRecord(res, existingRecord, fingerprint);
+
+    if (existingRecordOutcome) {
+        return existingRecordOutcome;
+    }
+
+    const challengeOutcome = await consumeAndValidateChallenge({
+        res,
+        action,
+        actorId,
+        nonce,
+        userId,
+        walletAddress,
+        expiresAt,
+    });
+
+    if (challengeOutcome.response) {
+        return challengeOutcome.response;
+    }
+
+    const reservationOutcome = await reserveOrHandleReservationOutcome({
+        res,
+        action,
+        actorId,
+        idempotencyKey,
+        fingerprint,
+    });
+
+    if (reservationOutcome.response) {
+        return reservationOutcome.response;
+    }
+
+    return executeAndFinalizeIdempotency({
+        res,
+        action,
+        actorId,
+        idempotencyKey,
+        fingerprint,
+        challengeRecord: challengeOutcome.challengeRecord,
+        execute,
+    });
+};
+
+module.exports = {
+    handleVerificationWithIdempotency,
+    getFingerprintAndExistingRecord,
+    handleExistingIdempotencyRecord,
+    consumeAndValidateChallenge,
+    reserveOrHandleReservationOutcome,
+    executeAndFinalizeIdempotency,
+};


### PR DESCRIPTION
The idempotency flow is now split into a dedicated helper module, with the controller reduced to a thin caller. The pipeline is separated into smaller phases for fingerprint/lookup, existing-record handling, challenge consumption, reservation handling, and execute/finalize cleanup in verificationIdempotency.js. The controller now imports that orchestration instead of owning the branching itself in verificationController.js.

I also added focused unit coverage for the extracted helper in verificationIdempotency.test.js and kept the existing controller replay tests passing in verificationController.replay.test.js. Validation passed with npx jest --runInBand tests/verificationIdempotency.test.js tests/verificationController.replay.test.js.


closes #306