### PR TITLE
Fix #303: Add isSpoiled check and humidity bounds

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -309,6 +309,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     {
         CropBatch storage batch = cropBatches[batchId];
         require(!batch.isRecalled, "Batch is recalled");
+        require(!batch.isSpoiled, "Batch is spoiled");
         require(quantity > 0, "Quantity must be > 0");
         require(unitPriceWei > 0, "Price=0");
 
@@ -359,6 +360,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
 
         CropBatch storage batch = cropBatches[listing.batchId];
         require(batch.exists && !batch.isRecalled, "Batch unavailable");
+        require(!batch.isSpoiled, "Batch is spoiled");
 
         uint256 twapPrice = getTwapPrice(batch.cropTypeHash, twapWindow);
         if (twapPrice > 0) {
@@ -641,6 +643,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         batchExists(batchId)
     {
         require(!cropBatches[batchId].isRecalled, "Batch is recalled");
+        require(humidity >= 0 && humidity <= 10000, "Humidity out of range (0-100.00%)");
         
         // Update batch IoT data
         cropBatches[batchId].currentTemperature = temperature;


### PR DESCRIPTION
## 📌 Overview
Fixes the critical bug where spoiled batches could still be purchased and listed. This is resolved by adding an `isSpoiled` check in `buyFromListing()` and `createListing()`. Additionally, it introduces bounds validation for humidity (0-100.00%) in `fulfillIoTData()` to prevent invalid data from being permanently stored on-chain.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #303

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
The `require` statements added strictly enforce the bounds for physical metrics (humidity) and ensure that business logic correctly rejects actions on batches flagged as unsafe by the IoT Oracles.