### PR TITLE
fix(backend): remove duplicate raw /api/batches route handler

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -465,32 +465,6 @@ app.post(
     }
 );
 
-// GET all batches - requires authentication
-// NOTE: This endpoint uses .lean() and compound indexes for optimal performance.
-// The new { currentStage: 1, createdAt: -1 } compound index handles pagination and sorting efficiently.
-app.get('/api/batches', batchLimiter, protect, async (req, res) => {
-    try {
-        const result = await batchService.getAllBatches();
-
-        console.log(`[SUCCESS] Batches list retrieved by user: ${req.user?.id} from IP: ${req.ip}`);
-
-        const response = apiResponse.successResponse(
-            { stats: result.stats, batches: result.batches },
-            'Batches retrieved successfully'
-        );
-        res.json(response);
-    } catch (error) {
-        notificationService.notifyError('batches fetch', error);
-        console.error('Error fetching batches:', error);
-        const response = apiResponse.errorResponse(
-            'Failed to fetch batches',
-            'BATCHES_FETCH_ERROR',
-            500
-        );
-        res.status(500).json(response);
-    }
-});
-
 // ==================== AI SERVICE ====================
 
 // Create batch service interface for AI service


### PR DESCRIPTION
## 📌 Overview

This PR resolves an Express route precedence oversight by removing a duplicate, dead `GET /api/batches` route handler block declaration from the root server initialization layer.

## 🛠 Type of Change
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)

---

## 🔗 Related Issue
Closes #321

---

## 🧪 Testing & Verification
- [ ] **Integration:** Verified local server initialization loop passes cleanly.

---

## 📸 Screenshots / Demos
_Removed duplicate `app.get('/api/batches')` controller block from backend/server.js (lines 468-492)._

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] My changes generate no new warnings.