### PR TITLE
Fix critical double-spend vulnerability in buyFromListing

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -372,6 +372,8 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // FIX: Release sold units from the batch's listed-quantity tracker so those
         // physical units are correctly accounted for as having been fulfilled/sold.
         batchListedQuantity[listing.batchId] -= quantity;
+        // FIX: Decrease the physical batch quantity to reflect the sold units.
+        batch.quantity -= quantity;
         if (listing.quantityAvailable == 0) {
             listing.active = false;
         }


### PR DESCRIPTION
## Description
This PR addresses a critical double-spend/infinite selling vulnerability in the marketplace logic of `CropChain.sol`.

Previously, when a listing was purchased via `buyFromListing`, the `batchListedQuantity` was decremented, but the physical `batch.quantity` remained unchanged. Because `createListing` validates the quantity against `batch.quantity - batchListedQuantity`, a seller could recreate listings infinitely for the same physical crop batch.

## Changes
- Updated `buyFromListing` to correctly decrement `batch.quantity` by the purchased amount, ensuring that physical inventory is properly depleted upon sale and preventing further invalid listings.

## Security Impact
Resolves a High-severity vulnerability that allowed financial exploits and market manipulation.

 - Closes #319 