### PR TITLE
feat: synchronize smart contract role permissions with backend JWT roles

### DIFF
--- a/backend/config/blockchain.js
+++ b/backend/config/blockchain.js
@@ -12,7 +12,9 @@ const contractABI = [
     "function getTotalBatches() view returns (uint256)",
     "function getBatchIdByIndex(uint256 index) view returns (bytes32)",
     "function createBatch(bytes32 batchId, bytes32 cropTypeHash, string calldata ipfsCID, uint256 quantity, string calldata actorName, string calldata location, string calldata notes) returns (bool)",
-    "function updateBatch(bytes32 batchId, uint8 stage, string calldata actorName, string calldata location, string calldata notes) returns (bool)"
+    "function updateBatch(bytes32 batchId, uint8 stage, string calldata actorName, string calldata location, string calldata notes) returns (bool)",
+    "function setRole(address user, uint8 role)",
+    "function roles(address user) view returns (uint8)"
 ];
 
 let contractInstance = null;

--- a/backend/scripts/reconcile.js
+++ b/backend/scripts/reconcile.js
@@ -90,18 +90,97 @@ async function reconcile() {
             }
         }
 
-        console.log(`\n✅ Reconciliation complete:`);
+        console.log(`\n✅ Batch Reconciliation complete:`);
         console.log(`   - Synced: ${synced}`);
         console.log(`   - Skipped: ${skipped}`);
         console.log(`   - Errors: ${errors}`);
+
+        // Reconcile user roles
+        await reconcileRoles(contract);
+
     } catch (error) {
         console.error('❌ Reconciliation failed:', error.message);
         process.exit(1);
     }
 }
 
+async function reconcileRoles(contract) {
+    console.log('\n🔄 Starting role reconciliation...');
+    const User = require('../models/User');
+
+    try {
+        const users = await User.find({ walletAddress: { $exists: true, $ne: null } });
+        console.log(`📊 Found ${users.length} users with linked wallets in database`);
+
+        let roleSynced = 0;
+        let roleMismatches = 0;
+        let roleErrors = 0;
+
+        for (const user of users) {
+            try {
+                const walletAddress = user.walletAddress;
+                if (!ethers.isAddress(walletAddress)) {
+                    console.log(`  - Invalid wallet address for user ${user.email}: ${walletAddress}`);
+                    roleErrors++;
+                    continue;
+                }
+
+                // Check verification and user account status
+                const isVerified = user.verification?.isVerified === true;
+                const isActive = user.status === 'active';
+                const shouldHaveRole = isVerified && isActive;
+                const expectedRoleName = shouldHaveRole ? user.role : 'none';
+
+                // Map to on-chain ActorRole
+                const mapping = {
+                    'farmer': 1,
+                    'mandi': 2,
+                    'transporter': 3,
+                    'retailer': 4,
+                    'oracle': 5,
+                    'admin': 6,
+                    'super_admin': 6
+                };
+                const expectedOnChainRole = mapping[expectedRoleName] || 0;
+
+                // Query on-chain role
+                const currentOnChainRole = Number(await contract.roles(walletAddress));
+
+                if (currentOnChainRole !== expectedOnChainRole) {
+                    roleMismatches++;
+                    console.log(`  ⚠ Role mismatch for ${user.email} (${walletAddress}): expected ${expectedRoleName} (${expectedOnChainRole}), got on-chain ${currentOnChainRole}. Syncing...`);
+                    
+                    const tx = await contract.setRole(walletAddress, expectedOnChainRole);
+                    await tx.wait();
+                    
+                    console.log(`  ✓ Synced role for ${user.email} on-chain`);
+                    roleSynced++;
+                } else {
+                    console.log(`  ✓ User ${user.email} (${walletAddress}) in sync: ${expectedRoleName} (${expectedOnChainRole})`);
+                }
+            } catch (userError) {
+                roleErrors++;
+                console.error(`  ✗ Error processing user ${user.email}:`, userError.message);
+            }
+        }
+
+        console.log(`\n✅ Role Reconciliation complete:`);
+        console.log(`   - Synced/Updated: ${roleSynced}`);
+        console.log(`   - Mismatches corrected: ${roleMismatches}`);
+        console.log(`   - Errors/Skipped: ${roleErrors}`);
+    } catch (error) {
+        console.error('❌ Role reconciliation failed:', error.message);
+    }
+}
+
 if (require.main === module) {
-    reconcile()
+    const connectDB = require('../config/db');
+    connectDB()
+        .then(() => reconcile())
+        .then(() => {
+            const mongoose = require('mongoose');
+            return mongoose.connection.close();
+        })
         .then(() => process.exit(0))
         .catch((error) => {
             console.error('Fatal error:', error);

--- a/backend/services/blockchainService.js
+++ b/backend/services/blockchainService.js
@@ -223,6 +223,84 @@ class BlockchainService {
     }
 
     /**
+     * Synchronize a user's role to the blockchain
+     * @param {string} walletAddress - The user's wallet address
+     * @param {string} roleName - The user's backend role
+     * @returns {Promise<Object>} - Transaction result
+     */
+    async syncUserRole(walletAddress, roleName) {
+        if (!this.isInitialized || !this.contract) {
+            return {
+                success: false,
+                demo: true,
+                message: 'Blockchain not configured, role sync skipped',
+                simulated: true
+            };
+        }
+
+        if (!walletAddress || !ethers.isAddress(walletAddress)) {
+            console.error('[BlockchainService] Invalid wallet address for role sync:', walletAddress);
+            return {
+                success: false,
+                error: 'Invalid wallet address',
+                message: 'Invalid wallet address'
+            };
+        }
+
+        try {
+            const onChainRole = this.mapRoleToOnChain(roleName);
+            
+            console.log(`[BlockchainService] Syncing role for ${walletAddress}: ${roleName} (mapped to on-chain: ${onChainRole})`);
+            
+            // Check current on-chain role first to avoid redundant transactions
+            const currentOnChainRole = Number(await this.contract.roles(walletAddress));
+            if (currentOnChainRole === onChainRole) {
+                console.log(`[BlockchainService] Role for ${walletAddress} is already synced on-chain (${currentOnChainRole})`);
+                return {
+                    success: true,
+                    alreadySynced: true,
+                    message: 'Role already in sync'
+                };
+            }
+
+            const tx = await this.contract.setRole(walletAddress, onChainRole);
+            const receipt = await tx.wait();
+
+            console.log(`[BlockchainService] Role synced on-chain for ${walletAddress}. Tx: ${receipt.hash}`);
+
+            return {
+                success: true,
+                transactionHash: receipt.hash,
+                blockNumber: receipt.blockNumber,
+                message: 'Role synced on blockchain'
+            };
+        } catch (error) {
+            console.error('[BlockchainService] Error syncing user role on-chain:', error.message);
+            return {
+                success: false,
+                error: error.message,
+                message: 'Failed to sync user role on blockchain'
+            };
+        }
+    }
+
+    /**
+     * Helper to map backend role string to on-chain ActorRole enum
+     */
+    mapRoleToOnChain(roleName) {
+        const mapping = {
+            'farmer': 1,
+            'mandi': 2,
+            'transporter': 3,
+            'retailer': 4,
+            'oracle': 5,
+            'admin': 6,
+            'super_admin': 6
+        };
+        return mapping[roleName] || 0; // ActorRole.None
+    }
+
+    /**
      * Get contract instance for external use (e.g., event listeners)
      * @returns {ethers.Contract|null}
      */

--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -123,6 +123,16 @@ class DIDService {
 
             await user.save();
 
+            // Sync user role to blockchain
+            const blockchainService = require('./blockchainService');
+            if (user.walletAddress) {
+                try {
+                    await blockchainService.syncUserRole(user.walletAddress, user.role);
+                } catch (bcError) {
+                    console.error(`Failed to sync user role on blockchain for ${user.email} during credential issue:`, bcError.message);
+                }
+            }
+
             return {
                 success: true,
                 message: 'Credential issued successfully',
@@ -163,6 +173,16 @@ class DIDService {
             user.verification.revocationReason = reason;
 
             await user.save();
+
+            // Revoke user role on blockchain (sync to ActorRole.None)
+            const blockchainService = require('./blockchainService');
+            if (user.walletAddress) {
+                try {
+                    await blockchainService.syncUserRole(user.walletAddress, 'none');
+                } catch (bcError) {
+                    console.error(`Failed to revoke user role on blockchain for ${user.email}:`, bcError.message);
+                }
+            }
 
             return {
                 success: true,


### PR DESCRIPTION


# PR Description: Sync Smart Contract Role Permissions with Backend JWT Roles

**Severity Level:** 🔴 Critical

## Description
This PR resolves a critical vulnerability where backend role/verification changes do not sync to the blockchain, allowing revoked users with direct smart contract access to bypass Web2 backend authorization checks. 

This is solved by introducing automatic role synchronization during credential issuance & revocation, and a reconciliation job to audit and fix role mismatches.

## 🔗 Related Issue
Closes #345 

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes)

---

## 📸 Screenshots / Demos
*Console logs showing automated database & smart contract role synchronization:*
```text
🔄 Starting role reconciliation...
📊 Found 1 users with linked wallets in database
  ⚠ Role mismatch for user@test.com (0x90F79bf6EB2c4f870365E785982E1f101E93b906): expected transporter (3), got on-chain 0. Syncing...
  ✓ Synced role for user@test.com on-chain
```

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
This update is critical for securing Web3 writes, ensuring the blockchain's `onlyRole` and `onlyAuthorized` modifiers remain fully aligned with the active Web2 credential status.