### PR TITLE
feat: add role-specific dashboard pages for Farmer, Mandi, Transporter, and Retailer

### DIFF
--- a/frontend/src/app/farmer/page.tsx
+++ b/frontend/src/app/farmer/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import { Leaf, Package, Plus, RefreshCw, TrendingUp, Clock, MapPin, Eye } from 'lucide-react';
+import Link from 'next/link';
+import { realCropBatchService } from '../../services/realCropBatchService';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../../components/ui/table';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+
+const FarmerDashboardComponent: React.FC = () => {
+  const { user } = useAuth();
+  const [batches, setBatches] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [stats, setStats] = useState({
+    totalBatches: 0,
+    totalQuantity: 0,
+    activeBatches: 0,
+  });
+
+  useEffect(() => {
+    loadBatches();
+  }, []);
+
+  const loadBatches = async () => {
+    setIsLoading(true);
+    try {
+      const data = await realCropBatchService.getAllBatches();
+      const allBatches: any[] = data?.batches || [];
+
+      // Filter to only show this farmer's batches
+      const myBatches = allBatches.filter(
+        (b: any) => b.farmerName === user?.name || b.farmerId === user?.id
+      );
+
+      setBatches(myBatches);
+      setStats({
+        totalBatches: myBatches.length,
+        totalQuantity: myBatches.reduce((sum: number, b: any) => sum + (b.quantity || 0), 0),
+        activeBatches: myBatches.filter((b: any) => b.currentStage !== 'retailer').length,
+      });
+    } catch (error) {
+      console.error('Failed to load batches:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getStageColor = (stage: string) => {
+    switch (stage?.toLowerCase()) {
+      case 'farmer':
+        return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300 border-indigo-300/30';
+      case 'mandi':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-300/30';
+      case 'transport':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 border-blue-300/30';
+      case 'retailer':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300 border-purple-300/30';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300 border-gray-700/30';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-8 animate-pulse py-6">
+        <div className="text-center space-y-3">
+          <div className="h-10 bg-muted rounded-lg w-64 mx-auto"></div>
+          <div className="h-5 bg-muted rounded-lg w-96 mx-auto"></div>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="border-border bg-card">
+              <CardHeader className="h-24"></CardHeader>
+              <CardContent className="h-12"></CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-8 py-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 border-b border-border/40 pb-6">
+        <div className="flex items-center gap-3">
+          <div className="bg-indigo-500/10 p-3 rounded-2xl">
+            <Leaf className="h-8 w-8 text-indigo-600 dark:text-indigo-400" />
+          </div>
+          <div className="text-left">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">Farmer Dashboard</h1>
+            <p className="text-sm text-muted-foreground">
+              Welcome back, <span className="font-semibold text-foreground">{user?.name || 'Farmer'}</span> — manage your crop batches
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={loadBatches} className="gap-1.5 bg-background/50">
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <Link href="/add-batch">
+            <Button size="sm" className="gap-1.5">
+              <Plus className="h-3.5 w-3.5" />
+              New Batch
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">My Batches</span>
+            <div className="bg-indigo-500/10 p-2 rounded-xl">
+              <Package className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.totalBatches}</div>
+            <p className="text-xs text-muted-foreground">Total batches created</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Total Quantity</span>
+            <div className="bg-emerald-500/10 p-2 rounded-xl">
+              <TrendingUp className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.totalQuantity.toLocaleString()} <span className="text-lg font-medium text-muted-foreground">kg</span></div>
+            <p className="text-xs text-muted-foreground">Cumulative crop quantity</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">In Transit</span>
+            <div className="bg-amber-500/10 p-2 rounded-xl">
+              <Clock className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.activeBatches}</div>
+            <p className="text-xs text-muted-foreground">Batches still in supply chain</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="grid sm:grid-cols-2 gap-4">
+        <Link href="/add-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-indigo-300 dark:hover:border-indigo-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-indigo-500/10 p-3 rounded-xl group-hover:bg-indigo-500/20 transition-colors">
+                <Plus className="h-6 w-6 text-indigo-600 dark:text-indigo-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Create New Batch</p>
+                <p className="text-sm text-muted-foreground">Register a new crop harvest on the blockchain</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/track-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-emerald-500/10 p-3 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
+                <MapPin className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Track Batch</p>
+                <p className="text-sm text-muted-foreground">Monitor batch journey through the supply chain</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      {/* My Batches Table */}
+      <Card className="border border-border bg-card">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <div className="flex items-center gap-2">
+            <Package className="h-5 w-5 text-primary" />
+            <CardTitle className="text-lg font-semibold text-foreground">My Batches</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {batches.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+              <div className="bg-muted p-4 rounded-full">
+                <Package className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">No batches yet</p>
+                <p className="text-sm text-muted-foreground mt-1">Create your first batch to get started</p>
+              </div>
+              <Link href="/add-batch">
+                <Button size="sm" className="gap-1.5 mt-2">
+                  <Plus className="h-3.5 w-3.5" />
+                  Create Batch
+                </Button>
+              </Link>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/40 hover:bg-muted/40 border-b border-border/40">
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Batch ID</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Crop Type</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Quantity</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Origin</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Current Stage</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {batches.map((batch) => (
+                    <TableRow key={batch.batchId} className="border-b border-border/40 hover:bg-muted/30 transition-colors text-left">
+                      <TableCell className="py-4 px-6">
+                        <span className="font-mono text-xs bg-muted text-muted-foreground px-2 py-1 rounded border border-border">
+                          {batch.batchId?.slice(0, 8)}...{batch.batchId?.slice(-4)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="capitalize font-medium text-foreground text-sm">{batch.cropType}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="font-medium text-foreground text-sm">{batch.quantity?.toLocaleString()} kg</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="text-sm text-muted-foreground">{batch.origin}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Badge variant="outline" className={`capitalize font-semibold border ${getStageColor(batch.currentStage)}`}>
+                          {batch.currentStage}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Link href={`/track-batch?id=${batch.batchId}`}>
+                          <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
+                            <Eye className="h-3.5 w-3.5" />
+                            View
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default function FarmerDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['farmer']}>
+      <FarmerDashboardComponent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/mandi/page.tsx
+++ b/frontend/src/app/mandi/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import { Store, Package, RefreshCw, CheckCircle, Clock, TrendingUp, Search, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { realCropBatchService } from '../../services/realCropBatchService';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../../components/ui/table';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+
+const MandiDashboardComponent: React.FC = () => {
+  const { user } = useAuth();
+  const [batches, setBatches] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [stats, setStats] = useState({
+    pendingAcceptance: 0,
+    acceptedTotal: 0,
+    totalQuantity: 0,
+  });
+
+  useEffect(() => {
+    loadBatches();
+  }, []);
+
+  const loadBatches = async () => {
+    setIsLoading(true);
+    try {
+      const data = await realCropBatchService.getAllBatches();
+      const allBatches: any[] = data?.batches || [];
+
+      // Mandi sees batches that are at farmer stage (pending arrival) or mandi stage (accepted)
+      const relevantBatches = allBatches.filter(
+        (b: any) => b.currentStage === 'farmer' || b.currentStage === 'mandi'
+      );
+
+      setBatches(relevantBatches);
+      setStats({
+        pendingAcceptance: relevantBatches.filter((b: any) => b.currentStage === 'farmer').length,
+        acceptedTotal: relevantBatches.filter((b: any) => b.currentStage === 'mandi').length,
+        totalQuantity: relevantBatches.reduce((sum: number, b: any) => sum + (b.quantity || 0), 0),
+      });
+    } catch (error) {
+      console.error('Failed to load batches:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getStageColor = (stage: string) => {
+    switch (stage?.toLowerCase()) {
+      case 'farmer':
+        return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300 border-indigo-300/30';
+      case 'mandi':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-300/30';
+      case 'transport':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 border-blue-300/30';
+      case 'retailer':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300 border-purple-300/30';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300 border-gray-700/30';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-8 animate-pulse py-6">
+        <div className="text-center space-y-3">
+          <div className="h-10 bg-muted rounded-lg w-64 mx-auto"></div>
+          <div className="h-5 bg-muted rounded-lg w-96 mx-auto"></div>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="border-border bg-card">
+              <CardHeader className="h-24"></CardHeader>
+              <CardContent className="h-12"></CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-8 py-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 border-b border-border/40 pb-6">
+        <div className="flex items-center gap-3">
+          <div className="bg-amber-500/10 p-3 rounded-2xl">
+            <Store className="h-8 w-8 text-amber-600 dark:text-amber-400" />
+          </div>
+          <div className="text-left">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">Mandi Dashboard</h1>
+            <p className="text-sm text-muted-foreground">
+              Welcome back, <span className="font-semibold text-foreground">{user?.name || 'Mandi Operator'}</span> — manage incoming crop batches
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={loadBatches} className="gap-1.5 bg-background/50">
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <Link href="/update-batch">
+            <Button size="sm" className="gap-1.5 bg-amber-600 hover:bg-amber-700 text-white">
+              <ArrowRight className="h-3.5 w-3.5" />
+              Update Batch Stage
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Pending Arrival</span>
+            <div className="bg-indigo-500/10 p-2 rounded-xl">
+              <Clock className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.pendingAcceptance}</div>
+            <p className="text-xs text-muted-foreground">Batches awaiting acceptance at mandi</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Accepted at Mandi</span>
+            <div className="bg-amber-500/10 p-2 rounded-xl">
+              <CheckCircle className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.acceptedTotal}</div>
+            <p className="text-xs text-muted-foreground">Batches currently at market stage</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Total Volume</span>
+            <div className="bg-emerald-500/10 p-2 rounded-xl">
+              <TrendingUp className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">
+              {stats.totalQuantity.toLocaleString()} <span className="text-lg font-medium text-muted-foreground">kg</span>
+            </div>
+            <p className="text-xs text-muted-foreground">Combined quantity across all batches</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="grid sm:grid-cols-2 gap-4">
+        <Link href="/update-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-amber-300 dark:hover:border-amber-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-amber-500/10 p-3 rounded-xl group-hover:bg-amber-500/20 transition-colors">
+                <ArrowRight className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Accept Batch</p>
+                <p className="text-sm text-muted-foreground">Accept incoming batches and update to market stage</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/track-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-emerald-500/10 p-3 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
+                <Search className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Track a Batch</p>
+                <p className="text-sm text-muted-foreground">Look up any batch in the supply chain</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      {/* Batches Table */}
+      <Card className="border border-border bg-card">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <div className="flex items-center gap-2">
+            <Package className="h-5 w-5 text-primary" />
+            <CardTitle className="text-lg font-semibold text-foreground">Incoming &amp; Current Batches</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {batches.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+              <div className="bg-muted p-4 rounded-full">
+                <Package className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">No batches available</p>
+                <p className="text-sm text-muted-foreground mt-1">Batches from farmers will appear here</p>
+              </div>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/40 hover:bg-muted/40 border-b border-border/40">
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Batch ID</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Farmer</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Crop Type</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Quantity</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Stage</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {batches.map((batch) => (
+                    <TableRow key={batch.batchId} className="border-b border-border/40 hover:bg-muted/30 transition-colors text-left">
+                      <TableCell className="py-4 px-6">
+                        <span className="font-mono text-xs bg-muted text-muted-foreground px-2 py-1 rounded border border-border">
+                          {batch.batchId?.slice(0, 8)}...{batch.batchId?.slice(-4)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <div>
+                          <p className="font-medium text-foreground text-sm">{batch.farmerName}</p>
+                          <p className="text-xs text-muted-foreground">{batch.origin}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="capitalize font-medium text-foreground text-sm">{batch.cropType}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="font-medium text-foreground text-sm">{batch.quantity?.toLocaleString()} kg</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Badge variant="outline" className={`capitalize font-semibold border ${getStageColor(batch.currentStage)}`}>
+                          {batch.currentStage === 'farmer' ? 'Pending Arrival' : 'At Market'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Link href={`/update-batch?id=${batch.batchId}`}>
+                          <Button
+                            variant={batch.currentStage === 'farmer' ? 'default' : 'ghost'}
+                            size="sm"
+                            className="gap-1.5"
+                          >
+                            <ArrowRight className="h-3.5 w-3.5" />
+                            {batch.currentStage === 'farmer' ? 'Accept' : 'Update'}
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default function MandiDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['mandi']}>
+      <MandiDashboardComponent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/retailer/page.tsx
+++ b/frontend/src/app/retailer/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import { ShoppingBag, Package, RefreshCw, CheckCircle, Clock, TrendingUp, Search, ArrowRight, Tag } from 'lucide-react';
+import Link from 'next/link';
+import { realCropBatchService } from '../../services/realCropBatchService';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../../components/ui/table';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+
+const RetailerDashboardComponent: React.FC = () => {
+  const { user } = useAuth();
+  const [batches, setBatches] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [stats, setStats] = useState({
+    incomingShipments: 0,
+    receivedBatches: 0,
+    totalQuantity: 0,
+  });
+
+  useEffect(() => {
+    loadBatches();
+  }, []);
+
+  const loadBatches = async () => {
+    setIsLoading(true);
+    try {
+      const data = await realCropBatchService.getAllBatches();
+      const allBatches: any[] = data?.batches || [];
+
+      // Retailer sees batches in transport (incoming) or at retailer stage (received)
+      const relevantBatches = allBatches.filter(
+        (b: any) => b.currentStage === 'transport' || b.currentStage === 'retailer'
+      );
+
+      setBatches(relevantBatches);
+      setStats({
+        incomingShipments: relevantBatches.filter((b: any) => b.currentStage === 'transport').length,
+        receivedBatches: relevantBatches.filter((b: any) => b.currentStage === 'retailer').length,
+        totalQuantity: relevantBatches.reduce((sum: number, b: any) => sum + (b.quantity || 0), 0),
+      });
+    } catch (error) {
+      console.error('Failed to load batches:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getStageColor = (stage: string) => {
+    switch (stage?.toLowerCase()) {
+      case 'farmer':
+        return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300 border-indigo-300/30';
+      case 'mandi':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-300/30';
+      case 'transport':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 border-blue-300/30';
+      case 'retailer':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300 border-purple-300/30';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300 border-gray-700/30';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-8 animate-pulse py-6">
+        <div className="text-center space-y-3">
+          <div className="h-10 bg-muted rounded-lg w-64 mx-auto"></div>
+          <div className="h-5 bg-muted rounded-lg w-96 mx-auto"></div>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="border-border bg-card">
+              <CardHeader className="h-24"></CardHeader>
+              <CardContent className="h-12"></CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-8 py-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 border-b border-border/40 pb-6">
+        <div className="flex items-center gap-3">
+          <div className="bg-purple-500/10 p-3 rounded-2xl">
+            <ShoppingBag className="h-8 w-8 text-purple-600 dark:text-purple-400" />
+          </div>
+          <div className="text-left">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">Retailer Dashboard</h1>
+            <p className="text-sm text-muted-foreground">
+              Welcome back, <span className="font-semibold text-foreground">{user?.name || 'Retailer'}</span> — manage incoming inventory
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={loadBatches} className="gap-1.5 bg-background/50">
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <Link href="/update-batch">
+            <Button size="sm" className="gap-1.5 bg-purple-600 hover:bg-purple-700 text-white">
+              <Tag className="h-3.5 w-3.5" />
+              Mark as Received
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Incoming Shipments</span>
+            <div className="bg-blue-500/10 p-2 rounded-xl">
+              <Clock className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.incomingShipments}</div>
+            <p className="text-xs text-muted-foreground">Batches currently in transit to your store</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Received</span>
+            <div className="bg-purple-500/10 p-2 rounded-xl">
+              <CheckCircle className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.receivedBatches}</div>
+            <p className="text-xs text-muted-foreground">Batches received and on sale</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Total Inventory</span>
+            <div className="bg-emerald-500/10 p-2 rounded-xl">
+              <TrendingUp className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">
+              {stats.totalQuantity.toLocaleString()} <span className="text-lg font-medium text-muted-foreground">kg</span>
+            </div>
+            <p className="text-xs text-muted-foreground">Combined stock across incoming and received</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="grid sm:grid-cols-2 gap-4">
+        <Link href="/update-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-purple-300 dark:hover:border-purple-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-purple-500/10 p-3 rounded-xl group-hover:bg-purple-500/20 transition-colors">
+                <Tag className="h-6 w-6 text-purple-600 dark:text-purple-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Mark as Received / Sold</p>
+                <p className="text-sm text-muted-foreground">Update batch stage when delivery arrives</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/track-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-emerald-500/10 p-3 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
+                <Search className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Verify a Batch</p>
+                <p className="text-sm text-muted-foreground">Check provenance and full journey of any batch</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      {/* Batches Table */}
+      <Card className="border border-border bg-card">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <div className="flex items-center gap-2">
+            <ShoppingBag className="h-5 w-5 text-primary" />
+            <CardTitle className="text-lg font-semibold text-foreground">Inventory &amp; Incoming Batches</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {batches.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+              <div className="bg-muted p-4 rounded-full">
+                <ShoppingBag className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">No batches yet</p>
+                <p className="text-sm text-muted-foreground mt-1">Incoming shipments from transporters will appear here</p>
+              </div>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/40 hover:bg-muted/40 border-b border-border/40">
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Batch ID</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Farmer</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Crop</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Quantity</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Harvest Date</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Status</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {batches.map((batch) => (
+                    <TableRow key={batch.batchId} className="border-b border-border/40 hover:bg-muted/30 transition-colors text-left">
+                      <TableCell className="py-4 px-6">
+                        <span className="font-mono text-xs bg-muted text-muted-foreground px-2 py-1 rounded border border-border">
+                          {batch.batchId?.slice(0, 8)}...{batch.batchId?.slice(-4)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <div>
+                          <p className="font-medium text-foreground text-sm">{batch.farmerName}</p>
+                          <p className="text-xs text-muted-foreground">{batch.origin}</p>
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="capitalize font-medium text-foreground text-sm">{batch.cropType}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="font-medium text-foreground text-sm">{batch.quantity?.toLocaleString()} kg</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="text-sm text-muted-foreground">
+                          {batch.harvestDate ? new Date(batch.harvestDate).toLocaleDateString() : '—'}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Badge variant="outline" className={`capitalize font-semibold border ${getStageColor(batch.currentStage)}`}>
+                          {batch.currentStage === 'transport' ? 'In Transit' : 'Received'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        {batch.currentStage === 'transport' ? (
+                          <Link href={`/update-batch?id=${batch.batchId}`}>
+                            <Button variant="default" size="sm" className="gap-1.5 bg-purple-600 hover:bg-purple-700 text-white">
+                              <Tag className="h-3.5 w-3.5" />
+                              Receive
+                            </Button>
+                          </Link>
+                        ) : (
+                          <Link href={`/track-batch?id=${batch.batchId}`}>
+                            <Button variant="ghost" size="sm" className="gap-1.5 text-muted-foreground hover:text-foreground">
+                              <ArrowRight className="h-3.5 w-3.5" />
+                              View
+                            </Button>
+                          </Link>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default function RetailerDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['retailer']}>
+      <RetailerDashboardComponent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/app/transporter/page.tsx
+++ b/frontend/src/app/transporter/page.tsx
@@ -1,0 +1,289 @@
+"use client";
+import React, { useState, useEffect } from 'react';
+import { Truck, Package, RefreshCw, MapPin, Clock, CheckCircle, Navigation, Search, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { realCropBatchService } from '../../services/realCropBatchService';
+import { Card, CardHeader, CardTitle, CardContent } from '../../components/ui/card';
+import { Badge } from '../../components/ui/badge';
+import { Button } from '../../components/ui/button';
+import { Table, TableHeader, TableBody, TableHead, TableRow, TableCell } from '../../components/ui/table';
+import ProtectedRoute from '../../components/ProtectedRoute';
+import { useAuth } from '../../context/AuthContext';
+
+const TransporterDashboardComponent: React.FC = () => {
+  const { user } = useAuth();
+  const [batches, setBatches] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [stats, setStats] = useState({
+    awaitingPickup: 0,
+    inTransit: 0,
+    totalQuantity: 0,
+  });
+
+  useEffect(() => {
+    loadBatches();
+  }, []);
+
+  const loadBatches = async () => {
+    setIsLoading(true);
+    try {
+      const data = await realCropBatchService.getAllBatches();
+      const allBatches: any[] = data?.batches || [];
+
+      // Transporter sees batches at mandi stage (ready for pickup) or transport stage (in transit)
+      const relevantBatches = allBatches.filter(
+        (b: any) => b.currentStage === 'mandi' || b.currentStage === 'transport'
+      );
+
+      setBatches(relevantBatches);
+      setStats({
+        awaitingPickup: relevantBatches.filter((b: any) => b.currentStage === 'mandi').length,
+        inTransit: relevantBatches.filter((b: any) => b.currentStage === 'transport').length,
+        totalQuantity: relevantBatches.reduce((sum: number, b: any) => sum + (b.quantity || 0), 0),
+      });
+    } catch (error) {
+      console.error('Failed to load batches:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const getStageColor = (stage: string) => {
+    switch (stage?.toLowerCase()) {
+      case 'farmer':
+        return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/30 dark:text-indigo-300 border-indigo-300/30';
+      case 'mandi':
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 border-amber-300/30';
+      case 'transport':
+        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 border-blue-300/30';
+      case 'retailer':
+        return 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300 border-purple-300/30';
+      default:
+        return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300 border-gray-700/30';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-8 animate-pulse py-6">
+        <div className="text-center space-y-3">
+          <div className="h-10 bg-muted rounded-lg w-64 mx-auto"></div>
+          <div className="h-5 bg-muted rounded-lg w-96 mx-auto"></div>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <Card key={i} className="border-border bg-card">
+              <CardHeader className="h-24"></CardHeader>
+              <CardContent className="h-12"></CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-8 py-4">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 border-b border-border/40 pb-6">
+        <div className="flex items-center gap-3">
+          <div className="bg-blue-500/10 p-3 rounded-2xl">
+            <Truck className="h-8 w-8 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div className="text-left">
+            <h1 className="text-3xl font-bold tracking-tight text-foreground">Transporter Dashboard</h1>
+            <p className="text-sm text-muted-foreground">
+              Welcome back, <span className="font-semibold text-foreground">{user?.name || 'Transporter'}</span> — manage your active shipments
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={loadBatches} className="gap-1.5 bg-background/50">
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <Link href="/update-batch">
+            <Button size="sm" className="gap-1.5 bg-blue-600 hover:bg-blue-700 text-white">
+              <Navigation className="h-3.5 w-3.5" />
+              Update Location
+            </Button>
+          </Link>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Ready for Pickup</span>
+            <div className="bg-amber-500/10 p-2 rounded-xl">
+              <Clock className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.awaitingPickup}</div>
+            <p className="text-xs text-muted-foreground">Batches at mandi awaiting transport</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">In Transit</span>
+            <div className="bg-blue-500/10 p-2 rounded-xl">
+              <Truck className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">{stats.inTransit}</div>
+            <p className="text-xs text-muted-foreground">Batches currently en route</p>
+          </CardContent>
+        </Card>
+
+        <Card className="border border-border bg-card hover:shadow-md transition-shadow">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <span className="text-sm font-medium text-muted-foreground">Total Load</span>
+            <div className="bg-emerald-500/10 p-2 rounded-xl">
+              <Package className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-1 text-left">
+            <div className="text-3xl font-bold tracking-tight">
+              {stats.totalQuantity.toLocaleString()} <span className="text-lg font-medium text-muted-foreground">kg</span>
+            </div>
+            <p className="text-xs text-muted-foreground">Combined load across all active batches</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="grid sm:grid-cols-2 gap-4">
+        <Link href="/update-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-blue-300 dark:hover:border-blue-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-blue-500/10 p-3 rounded-xl group-hover:bg-blue-500/20 transition-colors">
+                <Navigation className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Update Transport Stage</p>
+                <p className="text-sm text-muted-foreground">Log pickup and update location for a batch</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/track-batch">
+          <Card className="border border-border bg-card hover:shadow-md hover:border-emerald-300 dark:hover:border-emerald-700 transition-all cursor-pointer group">
+            <CardContent className="flex items-center gap-4 py-5 px-6">
+              <div className="bg-emerald-500/10 p-3 rounded-xl group-hover:bg-emerald-500/20 transition-colors">
+                <Search className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <div className="text-left">
+                <p className="font-semibold text-foreground">Track a Batch</p>
+                <p className="text-sm text-muted-foreground">Verify the full journey of any shipment</p>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+
+      {/* Batches Table */}
+      <Card className="border border-border bg-card">
+        <CardHeader className="pb-3 border-b border-border/40">
+          <div className="flex items-center gap-2">
+            <Truck className="h-5 w-5 text-primary" />
+            <CardTitle className="text-lg font-semibold text-foreground">Shipments Overview</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          {batches.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center gap-4">
+              <div className="bg-muted p-4 rounded-full">
+                <Truck className="h-8 w-8 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="font-semibold text-foreground">No active shipments</p>
+                <p className="text-sm text-muted-foreground mt-1">Batches ready for transport will appear here</p>
+              </div>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="bg-muted/40 hover:bg-muted/40 border-b border-border/40">
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Batch ID</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Farmer</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Crop</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Quantity</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Origin</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Status</TableHead>
+                    <TableHead className="py-4 px-6 font-semibold text-foreground text-left">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {batches.map((batch) => (
+                    <TableRow key={batch.batchId} className="border-b border-border/40 hover:bg-muted/30 transition-colors text-left">
+                      <TableCell className="py-4 px-6">
+                        <span className="font-mono text-xs bg-muted text-muted-foreground px-2 py-1 rounded border border-border">
+                          {batch.batchId?.slice(0, 8)}...{batch.batchId?.slice(-4)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="font-medium text-foreground text-sm">{batch.farmerName}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="capitalize font-medium text-foreground text-sm">{batch.cropType}</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <span className="font-medium text-foreground text-sm">{batch.quantity?.toLocaleString()} kg</span>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                          <MapPin className="h-3.5 w-3.5" />
+                          {batch.origin}
+                        </div>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Badge variant="outline" className={`capitalize font-semibold border ${getStageColor(batch.currentStage)}`}>
+                          {batch.currentStage === 'mandi' ? 'Ready for Pickup' : 'In Transit'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="py-4 px-6">
+                        <Link href={`/update-batch?id=${batch.batchId}`}>
+                          <Button
+                            variant={batch.currentStage === 'mandi' ? 'default' : 'ghost'}
+                            size="sm"
+                            className="gap-1.5"
+                          >
+                            {batch.currentStage === 'mandi' ? (
+                              <>
+                                <Truck className="h-3.5 w-3.5" />
+                                Pick Up
+                              </>
+                            ) : (
+                              <>
+                                <CheckCircle className="h-3.5 w-3.5" />
+                                Deliver
+                              </>
+                            )}
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default function TransporterDashboardPage() {
+  return (
+    <ProtectedRoute allowedRoles={['transporter']}>
+      <TransporterDashboardComponent />
+    </ProtectedRoute>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -101,6 +101,62 @@ const Header: React.FC = () => {
                 {t('nav.smartPlanting')}
               </Link>
 
+              {isAuthenticated && user?.role === 'farmer' && (
+                <Link
+                  href="/farmer"
+                  className={`flex items-center gap-1 px-4 py-1.5 rounded-full text-xs font-semibold tracking-wide transition-all duration-200 ${
+                    pathname === '/farmer'
+                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/10'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  Dashboard
+                </Link>
+              )}
+
+              {isAuthenticated && user?.role === 'mandi' && (
+                <Link
+                  href="/mandi"
+                  className={`flex items-center gap-1 px-4 py-1.5 rounded-full text-xs font-semibold tracking-wide transition-all duration-200 ${
+                    pathname === '/mandi'
+                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/10'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  Dashboard
+                </Link>
+              )}
+
+              {isAuthenticated && user?.role === 'transporter' && (
+                <Link
+                  href="/transporter"
+                  className={`flex items-center gap-1 px-4 py-1.5 rounded-full text-xs font-semibold tracking-wide transition-all duration-200 ${
+                    pathname === '/transporter'
+                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/10'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  Dashboard
+                </Link>
+              )}
+
+              {isAuthenticated && user?.role === 'retailer' && (
+                <Link
+                  href="/retailer"
+                  className={`flex items-center gap-1 px-4 py-1.5 rounded-full text-xs font-semibold tracking-wide transition-all duration-200 ${
+                    pathname === '/retailer'
+                      ? 'bg-primary text-primary-foreground shadow-sm shadow-primary/10'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <User className="h-3.5 w-3.5" />
+                  Dashboard
+                </Link>
+              )}
+
               {isAuthenticated && user?.role === 'admin' && (
                 <>
                   <Link


### PR DESCRIPTION
## Summary
The application had role-based auth and navigation in place, but navigating to /farmer, /mandi, /transporter, or /retailer returned a 404. This PR creates all four missing Next.js pages, each tailored to the actions and data relevant to that role.

## Changes
## New pages

Route	Role	Key features
/farmer	farmer	Stats (batch count, total quantity, in-transit), quick-links to create/track batch, personal batch table
/mandi	mandi	Stats (pending arrival, accepted, total volume), accept-batch workflow, incoming + current batch table
/transporter	transporter	Stats (ready for pickup, in-transit, total load), pickup/deliver workflow, shipments table
/retailer	retailer	Stats (incoming shipments, received, total inventory), receive/sold workflow, inventory table with harvest dates

## Updated
- Header.tsx — adds a role-aware Dashboard nav link that routes each logged-in role to their own page

## Implementation details
- Every page is wrapped in <ProtectedRoute allowedRoles={[...]}>, so unauthenticated users are redirected to /login and wrong-role users go to /access-denied
- Uses existing useAuth, useRbac, realCropBatchService, and shared UI components (Card, Badge, Button, Table) — no new dependencies introduced
- Each dashboard filters the batch list to only show batches relevant to that role's

Closes #326 