### PR TITLE
[FIX] #356: Compute isAuthenticated from user role to exclude wallet-only connections

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -207,7 +207,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       walletLogin, 
       logout, 
       isLoading,
-      isAuthenticated: !!user,
+      isAuthenticated: !!user && !!user.role,
       isWalletConnected,
       updateUser
     }}>


### PR DESCRIPTION
## Description
The \isAuthenticated\ property in AuthContext was computed as \!!user\, which returns \	rue\ even when only a wallet is connected (user object with empty \id\, \
ame\, \email\, \ole\). This made \ProtectedRoute\ incorrectly grant access to wallet-only users who haven't completed authentication.

## Root Cause
When \connectWallet()\ is called, it sets a partial user object \{ id: '', name: '', email: '', role: '', walletAddress: ... }\. Since this object is truthy, \!!user\ evaluates to \	rue\, causing \isAuthenticated\ to be \	rue\ for unauthenticated wallet connections.

## Fix
Changed \isAuthenticated: !!user\ to \isAuthenticated: !!user && !!user.role\ so that only users with a valid role assigned by the backend are considered authenticated.

## Related Issue
Closes #356