### PR TITLE
feat(#210): add centralized environment variable validation at startup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -17,6 +17,7 @@ const errorHandlerMiddleware = require('./middleware/errorHandler');
 const { createBatchSchema, updateBatchSchema } = require("./validations/batchSchema");
 const { protect, adminOnly, authorizeBatchOwner, authorizeRoles, authorizeStageTransition, authorizeBlockchainTransaction } = require('./middleware/auth');
 const { generalLimiter, authLimiter, batchLimiter, rateLimitWindowMs, rateLimitMaxRequests } = require('./middleware/rateLimiters');
+const { validateEnv } = require('./utils/envValidator');
 const mongoose = require('mongoose');
 const apiResponse = require('./utils/apiResponse');
 const oracleService = require('./services/oracleService');
@@ -262,28 +263,9 @@ app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
 }));
 
 
-// Blockchain configuration
-const REQUIRED_ENV_VARS = [
-    'INFURA_URL',
-    'CONTRACT_ADDRESS',
-    'PRIVATE_KEY'
-];
-
+// Validate environment variables at startup
 if (process.env.NODE_ENV !== 'test') {
-    REQUIRED_ENV_VARS.forEach((key) => {
-        if (!process.env[key]) {
-            throw new Error(`Missing required environment variable: ${key}`);
-        }
-    });
-
-    let privateKey = process.env.PRIVATE_KEY;
-    if (!/^(0x)?[a-fA-F0-9]{64}$/.test(privateKey)) {
-        throw new Error('Invalid PRIVATE_KEY format. Expected a 64-character hex string (with or without 0x prefix)');
-    }
-    if (!privateKey.startsWith('0x')) {
-        privateKey = '0x' + privateKey;
-    }
-    process.env.PRIVATE_KEY = privateKey;
+    validateEnv();
 }
 
 const PROVIDER_URL = process.env.INFURA_URL;

--- a/backend/utils/envValidator.js
+++ b/backend/utils/envValidator.js
@@ -1,0 +1,105 @@
+/**
+ * Environment variable validation utility.
+ * Ensures required env vars are set and have valid formats at startup.
+ * Prevents cryptic runtime errors due to misconfiguration.
+ */
+
+const REQUIRED_VARS = {
+  MONGODB_URI: {
+    description: "MongoDB connection string",
+    validate: (v) => v.startsWith("mongodb://") || v.startsWith("mongodb+srv://"),
+    hint: "Expected format: mongodb://host:port/db or mongodb+srv://...",
+  },
+  JWT_SECRET: {
+    description: "JWT signing secret",
+    validate: (v) => v.length >= 16,
+    hint: "Minimum 16 characters. Generate with: openssl rand -hex 32",
+  },
+  JWT_REFRESH_SECRET: {
+    description: "JWT refresh token secret (must differ from JWT_SECRET)",
+    validate: (v) => v.length >= 16,
+    hint: "Minimum 16 characters. Must NOT be the same as JWT_SECRET",
+  },
+  INFURA_URL: {
+    description: "Infura RPC URL for blockchain interaction",
+    validate: (v) => v.startsWith("https://") || v.startsWith("http://"),
+    hint: "Expected format: https://polygon-mumbai.infura.io/v3/YOUR_KEY",
+  },
+  CONTRACT_ADDRESS: {
+    description: "Deployed smart contract address",
+    validate: (v) => /^0x[a-fA-F0-9]{40}$/.test(v),
+    hint: "Expected format: 0x followed by 40 hexadecimal characters",
+  },
+  PRIVATE_KEY: {
+    description: "Private key for blockchain transactions",
+    validate: (v) => /^(0x)?[a-fA-F0-9]{64}$/.test(v),
+    hint: "Expected a 64-character hex string (with or without 0x prefix)",
+  },
+};
+
+const OPTIONAL_VARS_WARN = {
+  REDIS_HOST: {
+    description: "Redis host (required for BullMQ job queue)",
+    hint: "Set REDIS_HOST if you need async blockchain transaction processing",
+  },
+  GEMINI_API_KEY: {
+    description: "Google Gemini API key (needed for AI chatbot)",
+    hint: "Set GEMINI_API_KEY to enable AI features",
+  },
+  OPENAI_API_KEY: {
+    description: "OpenAI API key (alternative AI provider)",
+    hint: "Set OPENAI_API_KEY if using OpenAI instead of Gemini",
+  },
+};
+
+const validateEnv = () => {
+  const errors = [];
+  const warnings = [];
+
+  Object.entries(REQUIRED_VARS).forEach(([key, { description, validate, hint }]) => {
+    const value = process.env[key];
+    if (!value) {
+      errors.push(`  - ${key}: ${description}\n    ${hint}`);
+    } else if (typeof validate === "function" && !validate(value)) {
+      errors.push(`  - ${key}: value "${value}" has invalid format\n    ${hint}`);
+    }
+  });
+
+  if (process.env.JWT_SECRET && process.env.JWT_REFRESH_SECRET) {
+    if (process.env.JWT_SECRET === process.env.JWT_REFRESH_SECRET) {
+      errors.push(
+        `  - JWT_SECRET and JWT_REFRESH_SECRET must be different values for security.`
+      );
+    }
+  }
+
+  Object.entries(OPTIONAL_VARS_WARN).forEach(([key, { description, hint }]) => {
+    if (!process.env[key]) {
+      warnings.push(`  - ${key} (optional): ${description}\n    ${hint}`);
+    }
+  });
+
+  if (errors.length > 0) {
+    console.error("\n============================================");
+    console.error("  ENVIRONMENT VARIABLE VALIDATION FAILED");
+    console.error("============================================");
+    console.error("  The following required variables are missing or invalid:\n");
+    errors.forEach((e) => console.error(e));
+    console.error("\n  Please configure these in your .env file.");
+    console.error("  Refer to backend/.env.example for guidance.\n");
+    process.exit(1);
+  }
+
+  if (warnings.length > 0) {
+    console.warn("\n--------------------------------------------");
+    console.warn("  ENVIRONMENT VARIABLE WARNINGS");
+    console.warn("--------------------------------------------");
+    console.warn("  The following optional variables are not set:\n");
+    warnings.forEach((w) => console.warn(w));
+    console.warn("\n  Some features may not be available.\n");
+  } else {
+    console.log("[envValidator] All required environment variables are valid.");
+  }
+};
+
+module.exports = { validateEnv };


### PR DESCRIPTION
Adds backend/utils/envValidator.js that validates required environment variables (MONGODB_URI, JWT_SECRET, JWT_REFRESH_SECRET, INFURA_URL, CONTRACT_ADDRESS, PRIVATE_KEY) at server startup with clear error messages and format validation. Replaces the ad-hoc inline validation in server.js.

Closes #210