### PR TITLE
fix(security): add dedicated rate limiter to /api/recommend to prevent AI cost abuse

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -61,6 +61,12 @@ AUTH_RATE_LIMIT_MAX=5
 # Source: Set based on expected batch creation frequency (default: 20)
 BATCH_RATE_LIMIT_MAX=20
 
+# Description: Maximum AI recommendation requests per window (per IP)
+# Requirement: [Optional] — applies a dedicated throttle to /api/recommend to prevent AI cost abuse
+# Format: Integer (number of requests)
+# Source: Each request calls an external AI provider (Gemini/OpenAI) and incurs token cost; keep low (default: 10)
+AI_RATE_LIMIT_MAX=10
+
 ### Database Configuration
 
 # Description: MongoDB connection string for the database

--- a/backend/middleware/rateLimiters.js
+++ b/backend/middleware/rateLimiters.js
@@ -35,6 +35,11 @@ const batchLimiter = createLimiter(
     'Too many batch operations from this IP, please try again later.'
 );
 
+const aiLimiter = createLimiter(
+    parseInt(process.env.AI_RATE_LIMIT_MAX, 10) || 10,
+    'Too many AI requests from this IP, please try again later.'
+);
+
 // ==================== Sensitive Abuse-Aware Limiters ====================
 // Window configuration (per-route windows)
 const CHALLENGE_WINDOW_MS = parseInt(process.env.CHALLENGE_RATE_LIMIT_WINDOW_MS, 10) || 10 * 60 * 1000; // 10 minutes
@@ -130,6 +135,7 @@ module.exports = {
     generalLimiter,
     authLimiter,
     batchLimiter,
+    aiLimiter,
     rateLimitWindowMs,
     rateLimitMaxRequests,
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -16,7 +16,7 @@ const aiService = require('./services/aiService');
 const errorHandlerMiddleware = require('./middleware/errorHandler');
 const { createBatchSchema, updateBatchSchema } = require("./validations/batchSchema");
 const { protect, adminOnly, authorizeBatchOwner, authorizeRoles, authorizeStageTransition, authorizeBlockchainTransaction } = require('./middleware/auth');
-const { generalLimiter, authLimiter, batchLimiter, rateLimitWindowMs, rateLimitMaxRequests } = require('./middleware/rateLimiters');
+const { generalLimiter, authLimiter, batchLimiter, aiLimiter, rateLimitWindowMs, rateLimitMaxRequests } = require('./middleware/rateLimiters');
 const { validateEnv } = require('./utils/envValidator');
 const mongoose = require('mongoose');
 const apiResponse = require('./utils/apiResponse');
@@ -321,7 +321,7 @@ app.use('/api/auth', authLimiter, authRoutes);
 app.use('/api/verification', generalLimiter, verificationRoutes);
 
 // Mount Recommendation Routes
-app.use('/api/recommend', recommendRoutes);
+app.use('/api/recommend', aiLimiter, recommendRoutes);
 
 
 // Mount Approval Routes (Multi-signature for high-stakes actions)


### PR DESCRIPTION
## 📌 Overview

The \`/api/recommend\` route was the only route in the application mounted without a dedicated rate limiter. Every other sensitive route group (\`/api/auth\`, \`/api/batches\`, \`/api/approvals\`) had an explicit per-route limiter applied. Because \`/api/recommend\` calls an external AI provider (Gemini or OpenAI) billed per token, the absence of a limiter meant any authenticated user could make up to 100 AI inference calls per 15-minute window with no specific throttle — a direct financial risk.

This PR adds a dedicated \`aiLimiter\` (10 req / window by default, configurable via \`AI_RATE_LIMIT_MAX\`) and applies it to the route mount.

## 🛠️ Type of Change
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)

---

## 🔗 Related Issue
Closes #427

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? NA
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? NA
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? NA

Module loads cleanly; `aiLimiter` is exported as a function and mounted correctly.

---

## 📸 Screenshots / Demos

**Before:**
```js
app.use('/api/recommend', recommendRoutes); // ❌ no limiter
```

**After:**
```js
app.use('/api/recommend', aiLimiter, recommendRoutes); // ✅ 10 req / 15 min
```

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- The default limit of 10 requests per window matches the existing `BLOCKCHAIN_RATE_LIMIT_MAX` default and is conservative enough to prevent runaway AI billing while still allowing normal usage.
- `AI_RATE_LIMIT_MAX` is now documented in `backend/.env.example` alongside the other per-route limit variables, with a note explaining the cost-abuse rationale.
- No change to the general limiter (100 req / window) — `aiLimiter` is applied as an additional, stricter layer only on the AI endpoint.