### PR TITLE
[UI] Add 'use client' directive to context files for Next.js 16 SSR compatibility

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import toast from 'react-hot-toast';
 import { authService, LoginCredentials, RegisterCredentials, User } from '../services/auth.service';

--- a/frontend/src/context/CurrencyContext.tsx
+++ b/frontend/src/context/CurrencyContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   createContext,
   useContext,

--- a/frontend/src/context/ThemeContext.tsx
+++ b/frontend/src/context/ThemeContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
 type Theme = 'light' | 'dark';


### PR DESCRIPTION
## Description

Three context files (ThemeContext, CurrencyContext, AuthContext) use React hooks (`useState`, `useEffect`, `useContext`) without the `"use client"` directive. In Next.js 16 App Router, any module using hooks must be a Client Component. If a Server Component imports these contexts, it will throw a runtime error.

**Fixes issue #435**

## Changes Made

Added `"use client";` as the first line of:
- `frontend/src/context/ThemeContext.tsx`
- `frontend/src/context/CurrencyContext.tsx`
- `frontend/src/context/AuthContext.tsx`

## Testing

- Verified that hooks are only used in client components
- No breaking changes to existing functionality
