### PR TITLE
[Security] Prevent self-role assignment to admin in wallet registration

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -443,9 +443,9 @@ const walletRegisterSchema = z.object({
     signature: z.string()
         .min(1, 'Signature is required'),
     nonce: z.string().optional(),
-    role: z.enum(VALID_ROLES, {
+    role: z.enum(['farmer', 'transporter'], {
         errorMap: () => ({ 
-            message: `Invalid role. Must be one of: ${VALID_ROLES.join(', ')}` 
+            message: 'Invalid role. Only farmer and transporter accounts can be created publicly.' 
         })
     }).default(ROLES.FARMER)
 });

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -25,7 +25,7 @@ router.post('/reset-password/:token', resetPassword);
 // Wallet authentication routes
 router.get('/nonce', getNonce);
 router.post('/wallet-login', walletLogin);
-router.post('/wallet-register', walletRegister);
+router.post('/wallet-register', validateRegistration, walletRegister);
 router.put('/profile', protect, updateProfile);
 
 module.exports = router;


### PR DESCRIPTION
## Description

The `POST /auth/wallet-register` endpoint allowed users to set their own role to any value in `VALID_ROLES` (including `admin` and `super_admin`). The email/password `/auth/register` route correctly uses `validateRegistration` middleware (restricting roles to `farmer`/`transporter`), but this middleware was **not applied** to the wallet registration route.

**Fixes issue #436**

## Vulnerability

- **CVSS 9.8 (Critical)**
- Any user with a crypto wallet can register as admin/super_admin
- Grants full access to all platform features and user data

## Changes Made

1. **`backend/routes/authRoutes.js`**: Added `validateRegistration` middleware to the `/wallet-register` route
2. **`backend/controllers/authController.js`**: Restricted the Zod schema to only accept `'farmer'` or `'transporter'` roles (defense in depth)

## Testing

- Wallet registration with `role: 'admin'` now returns 400 error
- Wallet registration with `role: 'farmer'` still works as expected
- Email/password registration behavior unchanged
