### PR TITLE
fix(docker): install frontend dependencies from frontend directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # MongoDB Service
   mongodb:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -2,15 +2,16 @@
 FROM node:18-alpine
 
 # Set working directory
+WORKDIR /usr/src/app
+
+# Copy frontend directory
+COPY frontend/ ./frontend/
+
+# Set working directory to frontend for npm install
 WORKDIR /usr/src/app/frontend
 
-# Copy package files
-COPY package*.json ../
-RUN cd .. && npm ci
-
-# Copy the rest of the frontend code
-COPY frontend/ .
-COPY package*.json ../
+# Install dependencies
+RUN npm install
 
 # Create non-root user
 RUN addgroup -g 1001 -S nodejs


### PR DESCRIPTION
## 📌 Overview

Fix frontend Docker build failure by correcting dependency installation location in `docker/Dockerfile.dev`.

The previous configuration attempted to install dependencies from the repository root, causing Docker builds to fail because `package-lock.json` and frontend dependencies are maintained inside the `frontend/` directory.

Updated Docker configuration to install dependencies directly inside the frontend workspace and allow successful frontend image creation.

---

## 🛠️ Type of Change

* [x] 💻 **Frontend** (UI/UX, React components, Tailwind)

---

## 🔗 Related Issue

Closes #440

---

## 🧪 Testing & Verification

* [ ] **Smart Contracts:** NA
* [x] **Frontend:** Yes — frontend Docker image builds successfully
* [ ] **Integration:** NA

Verification steps:

1. Clone repository
2. Configure `.env`
3. Run:

   ```bash
   docker compose up --build
   ```
4. Confirm frontend image builds successfully without package installation failure

---

## 📸 Screenshots / Demos

<img width="1178" height="330" alt="image" src="https://github.com/user-attachments/assets/88c36dcb-9c95-443a-9e8c-e696dec17b14" />

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [ ] I have commented my code, particularly in complex areas (not applicable)
* [ ] I have updated the documentation accordingly (if not required, leave unchecked)
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This PR only addresses frontend Docker dependency installation and build failure.

Runtime issues related to Node version compatibility, Hardhat execution, or container startup behavior are intentionally kept out of scope and should be handled separately if needed.
