### PR TITLE
fix: “bulk retry failed rows” endpoint

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -628,20 +628,23 @@ const bulkIssueCredentials = async (req, res) => {
         }
 
         const adminId = req.user.id;
+        const dryRun = req.query.dryRun === 'true' || req.body?.dryRun === true;
         const job = await BulkVerificationJob.create({
             status: 'pending',
+            mode: dryRun ? 'dry-run' : 'bulk',
             totalRows: normalizedRecords.length,
             actorId: adminId,
         });
 
         // Background processing (service re-validates again)
-        bulkVerificationService.processJob(job._id, normalizedRecords, adminId).catch((err) => {
+        bulkVerificationService.processJob(job._id, normalizedRecords, adminId, { dryRun }).catch((err) => {
             console.error(`Error processing bulk verification job ${job._id}:`, err);
         });
 
         res.status(202).json(apiResponse.successResponse({
             jobId: job._id,
             status: job.status,
+            mode: job.mode,
             totalRows: job.totalRows,
         }, 'Bulk verification job initiated successfully'));
         return;

--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -680,7 +680,52 @@ const getBulkJobStatus = async (req, res) => {
     }
 };
 
+const retryBulkFailedRows = async (req, res) => {
+    try {
+        const { jobId } = req.params;
+        if (!mongoose.Types.ObjectId.isValid(jobId)) {
+            return res.status(400).json(apiResponse.validationErrorResponse(['Invalid job ID format']));
+        }
+
+        const job = await BulkVerificationJob.findById(jobId);
+        if (!job) {
+            return res.status(404).json(apiResponse.errorResponse('Bulk verification job not found', 404));
+        }
+
+        if (job.status !== 'completed') {
+            return res.status(400).json(apiResponse.errorResponse('Bulk verification job must be completed before retry', 400));
+        }
+
+        const adminId = req.user.id;
+        const failedRows = Array.isArray(job.results) ? job.results.filter((r) => r?.status === 'failure') : [];
+
+        if (!failedRows.length) {
+            return res.status(400).json(apiResponse.errorResponse('No failed rows found for this job', 400));
+        }
+
+        const retryJob = await bulkVerificationService.retryJob(jobId, failedRows, adminId);
+        if (!retryJob) {
+            return res.status(400).json(apiResponse.errorResponse('Retry could not be created (missing originalInput)', 400));
+        }
+
+        return res.status(202).json(apiResponse.successResponse({
+            jobId: retryJob._id,
+            status: retryJob.status,
+            mode: retryJob.mode,
+            totalRows: retryJob.totalRows,
+            retriedFromJobId: job._id,
+            failedRowsCount: failedRows.length,
+        }, 'Bulk retry job initiated successfully'));
+    } catch (error) {
+        return handleServerError(res, error, {
+            code: 'BULK_RETRY_FAILED_ROWS_ERROR',
+            message: 'Failed to initiate bulk retry of failed rows',
+        });
+    }
+};
+
 module.exports = {
+
     generateLinkWalletChallenge,
     generateIssueCredentialChallenge,
     linkWallet,
@@ -694,4 +739,7 @@ module.exports = {
     exportVerifiedUsers,
     bulkIssueCredentials,
     getBulkJobStatus,
+    retryBulkFailedRows,
 };
+
+

--- a/backend/models/BulkVerificationJob.js
+++ b/backend/models/BulkVerificationJob.js
@@ -23,13 +23,22 @@ const bulkVerificationJobSchema = new mongoose.Schema({
         type: Number,
         default: 0,
     },
+    mode: {
+        type: String,
+        enum: ['bulk', 'dry-run'],
+        default: 'bulk',
+    },
     results: [{
         rowNumber: { type: Number, required: true },
         userId: { type: String, trim: true },
         walletAddress: { type: String, lowercase: true, trim: true },
         action: { type: String, trim: true },
         idempotencyKey: { type: String, trim: true },
-        status: { type: String, enum: ['success', 'failure', 'skipped'], required: true },
+        status: {
+            type: String,
+            enum: ['success', 'failure', 'skipped', 'dry-run-success', 'dry-run-failure', 'dry-run-skipped'],
+            required: true,
+        },
         error: { type: String },
         details: { type: mongoose.Schema.Types.Mixed, default: {} },
     }],

--- a/backend/models/BulkVerificationJob.js
+++ b/backend/models/BulkVerificationJob.js
@@ -41,7 +41,14 @@ const bulkVerificationJobSchema = new mongoose.Schema({
         },
         error: { type: String },
         details: { type: mongoose.Schema.Types.Mixed, default: {} },
+        // Minimal normalized record-like input captured during initial processing.
+        // Used for admin retry of failed rows without requiring CSV re-upload.
+        originalInput: {
+            type: mongoose.Schema.Types.Mixed,
+            default: {},
+        },
     }],
+
     actorId: {
         type: String,
         required: true,

--- a/backend/routes/verification.js
+++ b/backend/routes/verification.js
@@ -15,7 +15,9 @@ const {
     exportVerifiedUsers,
     bulkIssueCredentials,
     getBulkJobStatus,
+    retryBulkFailedRows,
 } = require('../controllers/verificationController');
+
 const { protect, adminOnly, authorizeRoles } = require('../middleware/auth');
 const {
     challengeLinkWalletLimiter,
@@ -131,5 +133,7 @@ router.post(
 );
 router.get('/bulk/:jobId', protect, adminOnly, getBulkJobStatus);
 
+router.post('/bulk/:jobId/retry-failed', protect, adminOnly, retryFailedBulkRows);
 
 module.exports = router;
+

--- a/backend/services/bulkVerificationService.js
+++ b/backend/services/bulkVerificationService.js
@@ -30,11 +30,9 @@ const parseCSV = (csvText) => {
 
         if (char === '"') {
             if (inQuotes && nextChar === '"') {
-                // Escaped double quote ("") -> actual double quote character
                 currentField += '"';
-                i++; // Skip next quote
+                i++;
             } else {
-                // Toggle quote state
                 inQuotes = !inQuotes;
             }
         } else if (char === ',' && !inQuotes) {
@@ -42,7 +40,7 @@ const parseCSV = (csvText) => {
             currentField = '';
         } else if ((char === '\n' || char === '\r') && !inQuotes) {
             if (char === '\r' && nextChar === '\n') {
-                i++; // Skip \n
+                i++;
             }
             currentLine.push(currentField.trim());
             if (currentLine.length > 0 && (currentLine.length > 1 || currentLine[0] !== '')) {
@@ -57,7 +55,9 @@ const parseCSV = (csvText) => {
 
     if (currentField || currentLine.length > 0) {
         currentLine.push(currentField.trim());
-        lines.push(currentLine);
+        if (currentLine.length > 0 && (currentLine.length > 1 || currentLine[0] !== '')) {
+            lines.push(currentLine);
+        }
     }
 
     if (lines.length === 0) return [];
@@ -67,10 +67,7 @@ const parseCSV = (csvText) => {
 
     for (let i = 1; i < lines.length; i++) {
         const line = lines[i];
-        // Skip entirely empty lines
-        if (line.length === 0 || (line.length === 1 && line[0] === '')) {
-            continue;
-        }
+        if (line.length === 0 || (line.length === 1 && line[0] === '')) continue;
 
         const record = {};
         headers.forEach((header, index) => {
@@ -82,20 +79,27 @@ const parseCSV = (csvText) => {
     return records;
 };
 
+const statusFor = ({ dryRun, outcomeType }) => {
+    if (!dryRun) return outcomeType;
+    if (outcomeType === 'success') return 'dry-run-success';
+    if (outcomeType === 'skipped') return 'dry-run-skipped';
+    if (outcomeType === 'failure') return 'dry-run-failure';
+    return outcomeType;
+};
+
 /**
  * Background processor for bulk verification jobs
  * @param {string} jobId - Database BulkVerificationJob ObjectId
  * @param {Array<Object>} records - List of parsed records from CSV
  * @param {string} adminId - Admin/actor user ID
  */
-const processJob = async (jobId, records, adminId) => {
+const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
     const job = await BulkVerificationJob.findById(jobId);
     if (!job) return;
 
     job.status = 'processing';
     await job.save();
 
-    // Audit bulk job initiated
     try {
         await appendAuditEvent({
             action: 'bulk_job_initiated',
@@ -114,7 +118,8 @@ const processJob = async (jobId, records, adminId) => {
 
     for (let i = 0; i < records.length; i++) {
         const record = records[i];
-        const rowNumber = i + 2; // CSV is 1-indexed, header is row 1
+        const rowNumber = i + 2;
+
         const inputUserId = record.userid || '';
         const email = record.email || '';
         const walletAddress = record.walletaddress || '';
@@ -127,42 +132,29 @@ const processJob = async (jobId, records, adminId) => {
         const action = CHALLENGE_ACTIONS[actionStr] || CHALLENGE_ACTIONS.ISSUE_CREDENTIAL;
 
         try {
-            // 1. Resolve User
+            // Resolve user
             let user = null;
-            if (userId) {
-                if (/^[a-fA-F0-9]{24}$/.test(userId)) {
-                    user = await User.findById(userId);
-                }
-            } else if (email) {
+            if (userId && /^[a-fA-F0-9]{24}$/.test(userId)) {
+                user = await User.findById(userId);
+            } else if (!userId && email) {
                 user = await User.findOne({ email });
-                if (user) {
-                    userId = user._id.toString();
-                }
+                if (user) userId = user._id.toString();
             }
 
-            if (!user) {
-                throw new Error('User not found');
-            }
-
-
-            if (!user) {
-                throw new Error('User not found');
-            }
-
+            if (!user) throw new Error('User not found');
             userId = user._id.toString();
 
-            // 2. Validate walletAddress
+            // Validate wallet
             if (!walletAddress || !/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
                 throw new Error('Invalid wallet address');
             }
 
-            // 3. Derive Idempotency Key
+            // Derive idempotency key
             const idempotencyKey = crypto
                 .createHash('sha256')
                 .update(`${userId}:${walletAddress.toLowerCase()}:${action}`)
                 .digest('hex');
 
-            // 4. Reserve Idempotency Key
             const fingerprint = createFingerprint({ action, actorId: adminId, userId, walletAddress });
             const reservation = await reserveIdempotencyKey({
                 action,
@@ -171,89 +163,91 @@ const processJob = async (jobId, records, adminId) => {
                 fingerprint,
             });
 
+            // Idempotency record already completed
             if (!reservation.reserved) {
                 if (reservation.record && reservation.record.state === 'completed') {
-                results.push({
-                    rowNumber,
-                    userId,
-
-
+                    const status = statusFor({ dryRun, outcomeType: 'skipped' });
+                    results.push({
+                        rowNumber,
+                        userId,
                         walletAddress,
                         action,
                         idempotencyKey,
-                        status: 'skipped',
+                        status,
                         details: { message: 'Request already processed (idempotency)' },
                     });
-
-                    // Audit minimal per-row summary (success)
-                    try {
-                        await appendAuditEvent({
-                            action: 'bulk_row_processed',
-                            actorId: adminId,
-                            targetUserId: userId,
-                            walletAddress,
-                            status: 'success',
-                            metadata: {
-                                rowNumber,
-                                bulkStatus: 'skipped',
-                                bulkAction: action,
-                            },
-                            req: {},
-                        });
-                    } catch (_) {
-                        // best-effort
-                    }
                     successCount++;
                     continue;
-                } else {
-                    throw new Error('Request already in progress or duplicate idempotency key');
                 }
-            }
 
-            // 5. Check if user is already verified (for ISSUE_CREDENTIAL)
-            if (action === CHALLENGE_ACTIONS.ISSUE_CREDENTIAL && user.verification?.isVerified) {
+                // Reserved but not completed
+                const status = statusFor({ dryRun, outcomeType: 'failure' });
                 results.push({
                     rowNumber,
                     userId,
-
                     walletAddress,
                     action,
                     idempotencyKey,
-                    status: 'skipped',
-                    details: { message: 'User is already verified' },
+                    status,
+                    details: { message: 'Request already in progress or duplicate idempotency key' },
                 });
-
-                try {
-                    await appendAuditEvent({
-                        action: 'bulk_row_processed',
-                        actorId: adminId,
-                        targetUserId: userId,
-                        walletAddress,
-                        status: 'success',
-                        metadata: {
-                            rowNumber,
-                            bulkStatus: 'skipped',
-                            bulkAction: action,
-                        },
-                        req: {},
-                    });
-                } catch (_) {
-                    // best-effort
-                }
-
-                successCount++;
-                await storeCompletedIdempotencyRecord({
-                    action,
-                    actorId: adminId,
-                    key: idempotencyKey,
-                    fingerprint,
-                    response: { success: true, message: 'User already verified' },
-                });
+                failureCount += dryRun ? 1 : 1;
                 continue;
             }
 
-            // 6. Process Action
+            // Already verified (issue credential only)
+            if (action === CHALLENGE_ACTIONS.ISSUE_CREDENTIAL && user.verification?.isVerified) {
+                const status = statusFor({ dryRun, outcomeType: 'skipped' });
+                results.push({
+                    rowNumber,
+                    userId,
+                    walletAddress,
+                    action,
+                    idempotencyKey,
+                    status,
+                    details: { message: 'User is already verified' },
+                });
+                if (!dryRun) {
+                    await storeCompletedIdempotencyRecord({
+                        action,
+                        actorId: adminId,
+                        key: idempotencyKey,
+                        fingerprint,
+                        response: { success: true, message: 'User already verified' },
+                    });
+                }
+                successCount++;
+                continue;
+            }
+
+            if (dryRun) {
+                const predictedDetails = {
+                    predicted: true,
+                    message: 'Dry-run prediction: would execute side effects if dryRun=false',
+                    willExecute: {
+                        action,
+                        signaturePresent: Boolean(signature),
+                        nonceRequired: Boolean(signature),
+                        idempotencyReserved: true,
+                    },
+                };
+
+                results.push({
+                    rowNumber,
+                    userId,
+                    walletAddress,
+                    action,
+                    idempotencyKey,
+                    status: statusFor({ dryRun, outcomeType: 'success' }),
+                    details: predictedDetails,
+                });
+                successCount++;
+                continue;
+            }
+
+            // Execute real side effects
             let outcome = null;
+
             if (signature) {
                 if (!nonce || !expiresAtVal) {
                     throw new Error('Nonce and expiresAt are required when signature is provided');
@@ -291,7 +285,6 @@ const processJob = async (jobId, records, adminId) => {
                 });
             }
 
-            // 7. Store Completed Idempotency Record
             await storeCompletedIdempotencyRecord({
                 action,
                 actorId: adminId,
@@ -310,19 +303,19 @@ const processJob = async (jobId, records, adminId) => {
                 details: outcome,
             });
             successCount++;
-
         } catch (error) {
+            const status = statusFor({ dryRun, outcomeType: 'failure' });
             results.push({
                 rowNumber,
                 userId: userId || undefined,
                 walletAddress: walletAddress || undefined,
                 action,
-                status: 'failure',
+                idempotencyKey: undefined,
+                status,
                 error: error.message || error.toString(),
             });
             failureCount++;
 
-            // Audit minimal per-row summary (failure)
             try {
                 await appendAuditEvent({
                     action: 'bulk_row_processed',
@@ -343,8 +336,6 @@ const processJob = async (jobId, records, adminId) => {
             }
         }
 
-
-        // Update progress after each row
         job.processedRows = i + 1;
         await job.save();
     }
@@ -355,7 +346,6 @@ const processJob = async (jobId, records, adminId) => {
     job.results = results;
     await job.save();
 
-    // Audit bulk job completed
     try {
         await appendAuditEvent({
             action: 'bulk_job_completed',
@@ -369,10 +359,8 @@ const processJob = async (jobId, records, adminId) => {
     }
 };
 
-
 module.exports = {
     parseCSV,
     processJob,
 };
-
 

--- a/backend/services/bulkVerificationService.js
+++ b/backend/services/bulkVerificationService.js
@@ -87,6 +87,24 @@ const statusFor = ({ dryRun, outcomeType }) => {
     return outcomeType;
 };
 
+const reconstructRetryRecords = (failedRows = []) => {
+    return failedRows
+        .map((r) => r?.originalInput)
+        .filter(Boolean)
+        .map((input) => {
+            const records = {
+                userid: input.userid || '',
+                email: input.email || '',
+                walletaddress: input.walletaddress || '',
+                action: (input.action || 'ISSUE_CREDENTIAL').toString(),
+                signature: input.signature || '',
+                nonce: input.nonce || '',
+                expiresat: input.expiresat || '',
+            };
+            return records;
+        });
+};
+
 /**
  * Background processor for bulk verification jobs
  * @param {string} jobId - Database BulkVerificationJob ObjectId
@@ -95,6 +113,7 @@ const statusFor = ({ dryRun, outcomeType }) => {
  */
 const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
     const job = await BulkVerificationJob.findById(jobId);
+
     if (!job) return;
 
     job.status = 'processing';
@@ -128,8 +147,20 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
         const nonce = record.nonce || '';
         const expiresAtVal = record.expiresat ? parseInt(record.expiresat, 10) : undefined;
 
+        // Store minimal retry inputs so admin can re-run failed rows without CSV re-upload.
+        const originalInput = {
+            userid: inputUserId,
+            email,
+            walletaddress: walletAddress,
+            action: actionStr,
+            signature,
+            nonce,
+            expiresat: record.expiresat || '',
+        };
+
         let userId = inputUserId;
         const action = CHALLENGE_ACTIONS[actionStr] || CHALLENGE_ACTIONS.ISSUE_CREDENTIAL;
+
 
         try {
             // Resolve user
@@ -175,9 +206,11 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                         idempotencyKey,
                         status,
                         details: { message: 'Request already processed (idempotency)' },
+                        originalInput,
                     });
                     successCount++;
                     continue;
+
                 }
 
                 // Reserved but not completed
@@ -190,9 +223,11 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                     idempotencyKey,
                     status,
                     details: { message: 'Request already in progress or duplicate idempotency key' },
+                    originalInput,
                 });
                 failureCount += dryRun ? 1 : 1;
                 continue;
+
             }
 
             // Already verified (issue credential only)
@@ -206,8 +241,10 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                     idempotencyKey,
                     status,
                     details: { message: 'User is already verified' },
+                    originalInput,
                 });
                 if (!dryRun) {
+
                     await storeCompletedIdempotencyRecord({
                         action,
                         actorId: adminId,
@@ -240,9 +277,11 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                     idempotencyKey,
                     status: statusFor({ dryRun, outcomeType: 'success' }),
                     details: predictedDetails,
+                    originalInput,
                 });
                 successCount++;
                 continue;
+
             }
 
             // Execute real side effects
@@ -301,8 +340,10 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                 idempotencyKey,
                 status: 'success',
                 details: outcome,
+                originalInput,
             });
             successCount++;
+
         } catch (error) {
             const status = statusFor({ dryRun, outcomeType: 'failure' });
             results.push({
@@ -313,8 +354,10 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
                 idempotencyKey: undefined,
                 status,
                 error: error.message || error.toString(),
+                originalInput,
             });
             failureCount++;
+
 
             try {
                 await appendAuditEvent({
@@ -359,8 +402,34 @@ const processJob = async (jobId, records, adminId, { dryRun } = {}) => {
     }
 };
 
+const retryJob = async (jobId, failedRows, adminId) => {
+    // Reconstruct records from stored originalInput.
+    const retryRecords = reconstructRetryRecords(failedRows);
+
+    if (!retryRecords.length) {
+        return null;
+    }
+
+    const retryJob = await BulkVerificationJob.create({
+        status: 'pending',
+        mode: 'bulk',
+        totalRows: retryRecords.length,
+        actorId: adminId,
+    });
+
+    processJob(retryJob._id, retryRecords, adminId, { dryRun: false }).catch((err) => {
+        console.error(`Error processing bulk retry job ${retryJob._id}:`, err);
+    });
+
+    return retryJob;
+};
+
+
 module.exports = {
     parseCSV,
     processJob,
+    retryJob,
+    reconstructRetryRecords,
 };
+
 


### PR DESCRIPTION
What changed
1) Schema: store retry inputs per row
File: backend/models/BulkVerificationJob.js
Change: added results[].originalInput (minimal record-like data: userid/email/walletaddress/action/signature/nonce/expiresat).
2) Persist original normalized inputs while processing
File: backend/services/bulkVerificationService.js
Change: each results.push(...) now includes originalInput (including for failures).
Added: reconstructRetryRecords(failedRows) to transform stored originalInput back into the records shape expected by processJob().
3) Retry service
File: backend/services/bulkVerificationService.js
Added: retryJob(jobId, failedRows, adminId)
creates a new BulkVerificationJob for the retry
calls processJob(retryJobId, retryRecords, adminId, { dryRun:false }) in background
4) Controller + route
File: backend/controllers/verificationController.js
Added controller: retryBulkFailedRows
validates jobId
ensures original job exists and status === 'completed'
selects job.results where status === 'failure'
calls bulkVerificationService.retryJob(...)
returns 202 with the new retry job id and counts


closes #444