### PR TITLE
fix: map blockchain stage enum to stage name string

### DIFF
--- a/backend/services/blockchainListener.js
+++ b/backend/services/blockchainListener.js
@@ -8,17 +8,18 @@ function startListener(contract) {
     try {
 
       const id = batchId.toString();
-
+      const stageMap = ['farmer', 'mandi', 'transport', 'retailer'];
+      const stageStr = stageMap[Number(stage)] || 'unknown';
       await Batch.updateOne(
         { batchId: id },
         {
-          currentStage: stage,
+          currentStage: stageStr,
           syncStatus: 'synced'
         },
         { upsert: true }
       );
 
-      console.log(`[SYNC] Batch ${id} → ${stage} by ${actor}`);
+      console.log(`[SYNC] Batch ${id} → ${stageStr} by ${actor}`);
 
       // Emit real-time update to all clients watching this batch
       const batchData = await Batch.findOne({ batchId: id }).lean();
@@ -26,7 +27,7 @@ function startListener(contract) {
       if (batchData) {
         socketService.emitToBatchRoom(id, 'batch-updated', {
           batchId: id,
-          stage,
+          stage: stageStr,
           actor,
           timestamp: new Date().toISOString(),
           batch: batchData
@@ -35,7 +36,7 @@ function startListener(contract) {
         // Also emit global event for dashboards
         socketService.emitGlobal('batch-stage-changed', {
           batchId: id,
-          stage,
+          stage: stageStr,
           actor,
           timestamp: new Date().toISOString()
         });


### PR DESCRIPTION
## Related Issue

Closes #395

## Description

This PR fixes a critical blockchain synchronization issue where the listener stored raw Solidity enum values (`0-3`) instead of the corresponding stage name strings expected by the database schema.

### Problem

The `BatchUpdated` blockchain event emits the stage as a `uint8` enum value:

* 0 → farmer
* 1 → mandi
* 2 → transport
* 3 → retailer

Previously, the listener stored the numeric value directly in `currentStage`, causing:

* Incorrect stage labels in the frontend
* Broken stage-based filtering
* Failed stage transition validation
* Inconsistent blockchain-to-database synchronization

### Changes Made

* Added stage enum to string mapping:

  * `0 → farmer`
  * `1 → mandi`
  * `2 → transport`
  * `3 → retailer`
* Store the mapped stage string in the database.
* Updated synchronization logs to display stage names.
* Updated emitted socket events to use stage names instead of raw enum values.

### Result

The blockchain listener now stores and emits stage values consistent with the database schema and frontend expectations.

### Testing

* Verified stage values are mapped before database updates.
* Confirmed emitted socket events use stage names.
* Reviewed synchronization flow to ensure consistency across the pipeline.
