### PR TITLE
fix: SSE “rowResult” emitting has a logic gap / broken conditional

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -16,8 +16,8 @@ const {
 } = require('../utils/verificationControllerHelpers');
 
 const {
-    handleIdempotencyOnly,
-} = require('../utils/verificationIdempotency');
+    handleIdempotencyOnly: handleRevokeIdempotency,
+} = require('../utils/verificationIdempotencyRevoke');
 const apiResponse = require('../utils/apiResponse');
 const { ROLES } = require('../constants/permissions');
 const {
@@ -281,13 +281,13 @@ const revokeCredential = async (req, res) => {
         const idempotencyKey = requireIdempotencyKey(req, res);
         if (!idempotencyKey) return;
 
-        return await handleIdempotencyOnly({
+        return await handleRevokeIdempotency({
             req,
             res,
             action: 'CREDENTIAL_REVOKE',
             actorId: adminId,
             userId,
-            walletAddress: undefined,
+            reason,
             idempotencyKey,
             execute: async () => {
                 const result = await didService.revokeCredential(userId, adminId, reason);

--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -772,8 +772,8 @@ const streamBulkJobEvents = async (req, res) => {
                 for (let i = lastRowIndexEmitted + 1; i < availableCount; i++) {
                     const row = job.results[i];
                     if (!row) continue;
-                    if (typeof row.rowNumber === 'number' && row.rowNumber - 2 <= i) {
-                        // emit
+                    if (typeof row.rowNumber === 'number' && row.rowNumber - 2 > i) {
+                        continue;
                     }
                     writeEvent('rowResult', {
                         jobId,

--- a/backend/tests/verificationController.replayRevoke.test.js
+++ b/backend/tests/verificationController.replayRevoke.test.js
@@ -21,14 +21,14 @@ jest.mock('../utils/verificationControllerHelpers', () => ({
     handleVerificationWithIdempotency: jest.fn(),
 }));
 
-jest.mock('../utils/verificationIdempotency', () => ({
+jest.mock('../utils/verificationIdempotencyRevoke', () => ({
     handleIdempotencyOnly: jest.fn(),
     requireIdempotencyKey: jest.fn(),
 }));
 
 const didService = require('../services/didService');
 const controllerHelpers = require('../utils/verificationControllerHelpers');
-const { handleIdempotencyOnly } = require('../utils/verificationIdempotency');
+const { handleIdempotencyOnly } = require('../utils/verificationIdempotencyRevoke');
 
 const { revokeCredential } = require('../controllers/verificationController');
 

--- a/backend/tests/verificationIdempotencyRevoke.test.js
+++ b/backend/tests/verificationIdempotencyRevoke.test.js
@@ -1,0 +1,227 @@
+jest.mock('../services/verificationSecurityService', () => ({
+    getIdempotencyRecord: jest.fn(),
+    reserveIdempotencyKey: jest.fn(),
+    storeCompletedIdempotencyRecord: jest.fn(),
+    deleteIdempotencyRecord: jest.fn(),
+}));
+
+const securityService = require('../services/verificationSecurityService');
+const {
+    handleIdempotencyOnly,
+    requireIdempotencyKey,
+} = require('../utils/verificationIdempotencyRevoke');
+
+const createResponse = () => {
+    const response = {
+        statusCode: 200,
+        body: null,
+        status: jest.fn(function status(code) {
+            this.statusCode = code;
+            return this;
+        }),
+        json: jest.fn(function json(payload) {
+            this.body = payload;
+            return this;
+        }),
+    };
+    return response;
+};
+
+describe('verification idempotency revoke helper', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('replays a completed idempotency record without reprocessing when fingerprint matches', async () => {
+        const crypto = require('crypto');
+        const expectedFingerprint = crypto.createHash('sha256').update(JSON.stringify({
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules'
+        })).digest('hex');
+
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            fingerprint: expectedFingerprint,
+            state: 'completed',
+            statusCode: 200,
+            response: {
+                success: true,
+                message: 'Credential revoked successfully',
+            },
+        });
+
+        const res = createResponse();
+        const execute = jest.fn();
+
+        await handleIdempotencyOnly({
+            res,
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules',
+            idempotencyKey: 'idem-1',
+            execute,
+        });
+
+        expect(res.statusCode).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            message: 'Credential revoked successfully',
+        });
+        expect(execute).not.toHaveBeenCalled();
+        expect(securityService.reserveIdempotencyKey).not.toHaveBeenCalled();
+    });
+
+    test('rejects replay and returns conflict when reason is different (fingerprint mismatch)', async () => {
+        const crypto = require('crypto');
+        const previousFingerprint = crypto.createHash('sha256').update(JSON.stringify({
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules'
+        })).digest('hex');
+
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            fingerprint: previousFingerprint,
+            state: 'completed',
+            statusCode: 200,
+            response: {
+                success: true,
+                message: 'Credential revoked successfully',
+            },
+        });
+
+        const res = createResponse();
+        const execute = jest.fn();
+
+        await handleIdempotencyOnly({
+            res,
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'different reason',
+            idempotencyKey: 'idem-1',
+            execute,
+        });
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body.error).toContain('Idempotency-Key was already used for a different request');
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    test('executes and stores the completed idempotency result', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue(null);
+        securityService.reserveIdempotencyKey.mockResolvedValue({
+            reserved: true,
+            record: {
+                state: 'pending',
+            },
+        });
+
+        const execute = jest.fn().mockResolvedValue({
+            success: true,
+            message: 'Credential revoked successfully',
+        });
+        const res = createResponse();
+
+        await handleIdempotencyOnly({
+            res,
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules',
+            idempotencyKey: 'idem-2',
+            execute,
+        });
+
+        expect(execute).toHaveBeenCalled();
+        expect(securityService.storeCompletedIdempotencyRecord).toHaveBeenCalledWith({
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            key: 'idem-2',
+            fingerprint: expect.any(String),
+            response: {
+                success: true,
+                message: 'Credential revoked successfully',
+            },
+            statusCode: 200,
+        });
+        expect(res.body).toEqual({
+            success: true,
+            message: 'Credential revoked successfully',
+        });
+    });
+
+    test('deletes the idempotency record when execution fails', async () => {
+        securityService.getIdempotencyRecord.mockResolvedValue(null);
+        securityService.reserveIdempotencyKey.mockResolvedValue({
+            reserved: true,
+            record: {
+                state: 'pending',
+            },
+        });
+
+        const execute = jest.fn().mockRejectedValue(new Error('database error'));
+        const res = createResponse();
+
+        await expect(handleIdempotencyOnly({
+            res,
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules',
+            idempotencyKey: 'idem-3',
+            execute,
+        })).rejects.toThrow('database error');
+
+        expect(securityService.deleteIdempotencyRecord).toHaveBeenCalledWith({
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            key: 'idem-3',
+        });
+    });
+
+    test('rejects request with conflict if key is already in progress', async () => {
+        const crypto = require('crypto');
+        const expectedFingerprint = crypto.createHash('sha256').update(JSON.stringify({
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules'
+        })).digest('hex');
+
+        securityService.getIdempotencyRecord.mockResolvedValue({
+            fingerprint: expectedFingerprint,
+            state: 'pending',
+        });
+
+        const res = createResponse();
+        const execute = jest.fn();
+
+        await handleIdempotencyOnly({
+            res,
+            action: 'CREDENTIAL_REVOKE',
+            actorId: 'admin-1',
+            userId: 'user-1',
+            reason: 'violating rules',
+            idempotencyKey: 'idem-4',
+            execute,
+        });
+
+        expect(res.statusCode).toBe(409);
+        expect(res.body.error).toContain('Request with this Idempotency-Key is already in progress');
+        expect(execute).not.toHaveBeenCalled();
+    });
+
+    test('requires Idempotency-Key header', () => {
+        const req = {
+            get: jest.fn().mockReturnValue(''),
+        };
+        const res = createResponse();
+
+        const result = requireIdempotencyKey(req, res);
+        expect(result).toBeNull();
+        expect(res.statusCode).toBe(400);
+    });
+});

--- a/backend/utils/verificationIdempotencyRevoke.js
+++ b/backend/utils/verificationIdempotencyRevoke.js
@@ -1,3 +1,151 @@
-// Deprecated placeholder (kept for backward compatibility if referenced elsewhere).
-module.exports = require('./verificationIdempotency');
+const crypto = require('crypto');
+const apiResponse = require('./apiResponse');
+const {
+    getIdempotencyRecord,
+    reserveIdempotencyKey,
+    storeCompletedIdempotencyRecord,
+    deleteIdempotencyRecord,
+} = require('../services/verificationSecurityService');
 
+const handleIdempotencyReplay = (res, record) => {
+    return res.status(record.statusCode || 200).json(record.response);
+};
+
+const handleDuplicateIdempotencyKey = (res, message) => {
+    return res.status(409).json(apiResponse.conflictResponse(message));
+};
+
+const createRevokeFingerprint = ({ action, actorId, userId, reason }) => {
+    const payload = {
+        action,
+        actorId,
+        userId,
+        reason,
+    };
+    return crypto.createHash('sha256').update(JSON.stringify(payload)).digest('hex');
+};
+
+const getFingerprintAndExistingRecord = async ({ action, actorId, userId, reason, idempotencyKey }) => {
+    const fingerprint = createRevokeFingerprint({ action, actorId, userId, reason });
+    const existingRecord = await getIdempotencyRecord({ action, actorId, key: idempotencyKey });
+    return { fingerprint, existingRecord };
+};
+
+const handleExistingIdempotencyRecord = (res, existingRecord, fingerprint) => {
+    if (!existingRecord) {
+        return null;
+    }
+
+    if (existingRecord.fingerprint !== fingerprint) {
+        return handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request');
+    }
+
+    if (existingRecord.state === 'completed') {
+        return handleIdempotencyReplay(res, existingRecord);
+    }
+
+    return handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress');
+};
+
+const reserveOrHandleReservationOutcome = async ({ res, action, actorId, idempotencyKey, fingerprint }) => {
+    const reservation = await reserveIdempotencyKey({
+        action,
+        actorId,
+        key: idempotencyKey,
+        fingerprint,
+    });
+
+    if (reservation.reserved) {
+        return { reservation };
+    }
+
+    if (!reservation.record) {
+        return { response: handleDuplicateIdempotencyKey(res, 'Unable to reserve the idempotency key') };
+    }
+
+    if (reservation.record.fingerprint !== fingerprint) {
+        return {
+            response: handleDuplicateIdempotencyKey(res, 'Idempotency-Key was already used for a different request'),
+        };
+    }
+
+    if (reservation.record.state === 'completed') {
+        return { response: handleIdempotencyReplay(res, reservation.record) };
+    }
+
+    return { response: handleDuplicateIdempotencyKey(res, 'Request with this Idempotency-Key is already in progress') };
+};
+
+/**
+ * Idempotency helper for revocation endpoint.
+ */
+const handleIdempotencyOnly = async ({
+    req,
+    res,
+    action,
+    actorId,
+    userId,
+    reason,
+    idempotencyKey,
+    execute,
+}) => {
+    const { fingerprint, existingRecord } = await getFingerprintAndExistingRecord({
+        action,
+        actorId,
+        userId,
+        reason,
+        idempotencyKey,
+    });
+
+    const existingRecordOutcome = handleExistingIdempotencyRecord(res, existingRecord, fingerprint);
+    if (existingRecordOutcome) {
+        return existingRecordOutcome;
+    }
+
+    const reservationOutcome = await reserveOrHandleReservationOutcome({
+        res,
+        action,
+        actorId,
+        idempotencyKey,
+        fingerprint,
+    });
+
+    if (reservationOutcome.response) {
+        return reservationOutcome.response;
+    }
+
+    try {
+        const result = await execute();
+        await storeCompletedIdempotencyRecord({
+            action,
+            actorId,
+            key: idempotencyKey,
+            fingerprint,
+            response: result,
+            statusCode: 200,
+        });
+        return res.json(result);
+    } catch (error) {
+        try {
+            await deleteIdempotencyRecord({ action, actorId, key: idempotencyKey });
+        } catch (_) {
+            // ignore
+        }
+        // Let controller error handler map this.
+        throw error;
+    }
+};
+
+const requireIdempotencyKey = (req, res) => {
+    const idempotencyKey = req.get('Idempotency-Key');
+    if (!idempotencyKey || !idempotencyKey.trim()) {
+        res.status(400).json(apiResponse.validationErrorResponse(['Idempotency-Key header is required']));
+        return null;
+    }
+    return idempotencyKey.trim();
+};
+
+module.exports = {
+    requireIdempotencyKey,
+    handleIdempotencyOnly,
+};


### PR DESCRIPTION
I have completed both tasks and verified the changes. Here is a summary of the work:

Revoke Idempotency Logic:

Replaced the placeholder in 

verificationIdempotencyRevoke.js
 with a custom handleIdempotencyOnly helper that includes the revocation reason in the request fingerprint hash.
Updated the revokeCredential method in 

verificationController.js
 to call the custom helper with the reason parameter.
Updated the controller tests in 

verificationController.replayRevoke.test.js
 and added a new unit test suite in 

verificationIdempotencyRevoke.test.js
.
SSE rowResult Emitting Logic Gap:

Modified streamBulkJobEvents in 

verificationController.js
 to skip emitting events and advancing pointers when row.rowNumber - 2 > i by introducing a continue gate.
Verified the SSE fix by running the unit tests in verificationBulkSse.test.js.


closes #468