### PR TITLE
fix: Update Node.js prerequisite from v14+ to v18.18+ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ docker images
 ## Quick Start
 
 ### Prerequisites
-- Node.js (v14+)
+- Node.js (v18.18+)
 - npm or yarn
 - MetaMask wallet
 - Infura/Alchemy account (for blockchain)


### PR DESCRIPTION
## Summary
Updates the Node.js prerequisite in README.md from `v14+` to `v18.18+` to reflect the actual minimum version required by the project's dependencies.

## Problem
README.md line 218 listed `Node.js (v14+)` as a prerequisite, but the frontend dependencies require a significantly higher version:
- `next: ^16.2.6` → Next.js 15+ requires Node.js 18.18+ minimum
- `react: ^19.0.0` → React 19 requires Node.js 18+

Contributors running Node v14 or v16 would get cryptic errors during `npm install` or `next build` with no clear indication that their Node version is the cause.

## Changes
- `README.md` → Updated Node.js prerequisite from `v14+` to `v18.18+`

## Testing
- Verified change with `Select-String -Path "README.md" -Pattern "v18"`

Closes #487 