### PR TITLE
security: Add warning comments for PRIVATE_KEY in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,11 @@ ALLOWED_ORIGINS=http://localhost:3000
 # Blockchain (required by backend)
 INFURA_URL=https://polygon-mainnet.infura.io/v3/YOUR_PROJECT_ID
 CONTRACT_ADDRESS=0x2c79F3f6b448270ADF667CA5d23d23feC4d15Fa4
-PRIVATE_KEY=0xsdusdhjsdi
+# WARNING: Never use a real mainnet wallet private key here.
+# Create a dedicated deployer wallet for development/testing only.
+# Never commit your actual .env file — it is gitignored for a reason.
+# If this key is ever exposed, consider it compromised immediately.
+PRIVATE_KEY=0xYOUR_DEDICATED_DEPLOYER_WALLET_PRIVATE_KEY
 
 # Email / SMTP (for notification emails)
 SMTP_HOST=smtp.gmail.com


### PR DESCRIPTION
## Summary
Adds clear security warning comments above the `PRIVATE_KEY` field in `.env.example` to prevent contributors from accidentally using a real mainnet wallet private key.

## Problem
`.env.example` contained `PRIVATE_KEY=0xsdusdhjsdi` with zero guidance or warnings. The file also contains a real-looking Polygon mainnet contract address (`CONTRACT_ADDRESS=0x2c79F3f6b448270ADF667CA5d23d23feC4d15Fa4`).

New contributors might:
1. Use their real MetaMask wallet private key here
2. Accidentally expose it via git if `.env` is not properly gitignored
3. Lose real funds if this key controls a mainnet wallet

## Changes
- `.env.example` → Added 4 security warning comments above `PRIVATE_KEY` field
- Updated placeholder value from `0xsdusdhjsdi` to `0xYOUR_DEDICATED_DEPLOYER_WALLET_PRIVATE_KEY` for clarity

## Testing
- Verified change with `Get-Content ".env.example"`

Closes #488 