### PR TITLE
fix: Return 503 instead of 200 OK on AI chat service failure

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -616,8 +616,8 @@ app.post('/api/ai/chat', batchLimiter, protect, validateRequest(chatSchema), asy
             'Chat response generated successfully (fallback)'
         );
 
-        // Use 200 to keep chatbot UX stable and avoid frontend connection-error fallback.
-        res.status(200).json(response);
+        // Return 503 so clients can detect AI service degradation programmatically.
+        res.status(503).json(response);
     }
 });
 


### PR DESCRIPTION
## Summary
Updates the AI chat endpoint (`POST /api/ai/chat`) to return `503 Service Unavailable` when the AI service fails and a fallback response is served, instead of masking the failure with `200 OK`.

## Problem
In `backend/server.js` line 620, the error handler for `/api/ai/chat` was returning `res.status(200).json(response)` even on AI service failure, with a comment saying "Use 200 to keep chatbot UX stable".

This causes:
- Frontend clients cannot detect AI service failures programmatically
- Monitoring tools and health checks will not flag AI service degradation
- Error rates appear as 0% even when AI is consistently failing
- Breaks standard REST API contract expected by API consumers

## Changes
- `backend/server.js` → Changed `res.status(200)` to `res.status(503)` in AI chat error handler
- Updated comment to reflect the correct intent

## Testing
- Verified change with `Select-String -Path "backend\server.js" -Pattern "503"`

Closes #490 