### PR TITLE
fix: Differentiate between expired and invalid JWT token errors in auth middleware

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -30,7 +30,13 @@ const protect = async (req, res, next) => {
         }
         next();
     } catch (error) {
-        return res.status(401).json({ error: 'Not authorized', message: 'Invalid token' });
+        if (error.name === 'TokenExpiredError') {
+            return res.status(401).json({ error: 'Not authorized', message: 'Token has expired, please log in again' });
+        }
+        if (error.name === 'JsonWebTokenError') {
+            return res.status(401).json({ error: 'Not authorized', message: 'Invalid token' });
+        }
+        return res.status(500).json({ error: 'Server Error', message: 'Authentication check failed' });
     }
 };
 
@@ -264,3 +270,4 @@ module.exports = {
     requireMultisigOrAdmin,
     checkBatchSafetyStatus
 };
+


### PR DESCRIPTION
## Summary
Updates the `protect` middleware in `backend/middleware/auth.js` to handle JWT errors separately instead of returning a generic 'Invalid token' message for all authentication failures.

## Problem
The catch block in the `protect` middleware was returning the same `401 'Invalid token'` response for all JWT errors — whether the token was expired, malformed, or something else entirely.

This meant:
- Frontend clients could not distinguish between an expired session (needs re-login) and a tampered/invalid token (potential security event)
- Debugging authentication issues was harder with no differentiation in error messages
- Poor UX — user gets same error whether their session simply expired or something else went wrong

## Changes
`backend/middleware/auth.js` catch block now handles:
- `TokenExpiredError` → 401 with message `'Token has expired, please log in again'`
- `JsonWebTokenError` → 401 with message `'Invalid token'`
- Any other unexpected error → 500 with message `'Authentication check failed'`

## Testing
- Verified changes with `Select-String -Path "backend\middleware\auth.js" -Pattern "TokenExpiredError|JsonWebTokenError"`

Closes #515 