### PR TITLE
fix: Replace console.log/error/warn with winston logger in db.js

### DIFF
--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,22 +1,22 @@
 const mongoose = require('mongoose');
+const logger = require('../utils/logger');
 
 const connectDB = async () => {
     if (process.env.NODE_ENV === 'test') {
-        console.log('MongoDB connection skipped for tests');
+        logger.info('MongoDB connection skipped for tests');
         return;
     }
-
     try {
         const conn = await mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/cropchain', {
              serverSelectionTimeoutMS: 5000 // Timeout after 5s instead of 30s
         });
-        console.log(`MongoDB Connected: ${conn.connection.host}`);
+        logger.info('MongoDB Connected', { host: conn.connection.host });
     } catch (error) {
-        console.error(`Error: ${error.message}`);
+        logger.error('MongoDB connection error', { error: error.message });
         if (process.env.NODE_ENV !== 'test') {
             process.exit(1);
         }
-        console.warn('Running in development mode - server will continue without database');
+        logger.warn('Running in development mode - server will continue without database');
     }
 };
 


### PR DESCRIPTION
## Summary
Replaces all `console.log`, `console.error`, and `console.warn` calls in `backend/config/db.js` with the centralized Winston logger already used throughout the rest of the backend.

## Problem
`backend/config/db.js` was using raw console methods for logging while every other backend file uses the Winston logger from `utils/logger.js`. This meant MongoDB connection events were not captured in structured log files (`logs/combined.log`, `logs/error.log`) and would be missed by production monitoring tools.

## Changes
- `backend/config/db.js` → Added `logger` import from `../utils/logger`
- Replaced `console.log` → `logger.info`
- Replaced `console.error` → `logger.error`
- Replaced `console.warn` → `logger.warn`

## Testing
- Verified changes with `Get-Content "backend\config\db.js"`

Closes #514 