### PR TITLE
fix: add missing JWT_SECRET and JWT_REFRESH_SECRET to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ MONGODB_URI=mongodb://db:27017/cropchain
 FRONTEND_URL=http://localhost:3000
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Authentication (required by backend)
+JWT_SECRET=your-jwt-secret-minimum-16-chars-generate-with-openssl-rand-hex-32
+JWT_REFRESH_SECRET=your-refresh-secret-minimum-16-chars-must-differ-from-jwt-secret
+
 # Blockchain (required by backend)
 INFURA_URL=https://polygon-mainnet.infura.io/v3/YOUR_PROJECT_ID
 CONTRACT_ADDRESS=0x2c79F3f6b448270ADF667CA5d23d23feC4d15Fa4


### PR DESCRIPTION
## Summary
Adds missing `JWT_SECRET` and `JWT_REFRESH_SECRET` variables to `.env.example` so new contributors are not hit with an immediate server crash on first setup.

## Problem
`.env.example` had no JWT variables at all, but `backend/utils/envValidator.js` marks both `JWT_SECRET` and `JWT_REFRESH_SECRET` as required and calls `process.exit(1)` if either is missing.

New contributors copying `.env.example` to `.env` would get an immediate server crash on startup with no clear indication that JWT secrets need to be configured.

## Changes
- `.env.example` → Added `JWT_SECRET` with placeholder value and generation hint
- `.env.example` → Added `JWT_REFRESH_SECRET` with placeholder value and note that it must differ from `JWT_SECRET`

## Testing
- Verified changes with `Select-String -Path ".env.example" -Pattern "JWT"`

Closes #521 