### PR TITLE
fix: Replace console.log/warn/error with winston logger in notificationService.js

### DIFF
--- a/backend/services/notificationService.js
+++ b/backend/services/notificationService.js
@@ -1,9 +1,10 @@
-/**
+﻿/**
  * NotificationService - Handles all notifications and alerts
  * Extracted from server.js to follow Separation of Concerns principle
  */
 
 const emailProvider = require('../config/email');
+const logger = require('../utils/logger');
 const User = require('../models/User');
 const Notification = require('../models/Notification');
 
@@ -37,13 +38,13 @@ class NotificationService {
         switch (type) {
             case 'alert':
             case 'recall':
-                console.warn(`[${type.toUpperCase()}] ${message}`, metadata);
+                logger.warn(`[${type.toUpperCase()}] ${message}`, metadata);
                 break;
             case 'error':
-                console.error(`[${type.toUpperCase()}] ${message}`, metadata);
+                logger.error(`[${type.toUpperCase()}] ${message}`, metadata);
                 break;
             default:
-                console.log(`[${type.toUpperCase()}] ${message}`, metadata);
+                logger.info(`[${type.toUpperCase()}] ${message}`, metadata);
         }
 
         return notification;
@@ -63,7 +64,7 @@ class NotificationService {
                 data
             });
         } catch (error) {
-            console.error('[NotificationService] Failed to create in-app notification:', error.message);
+            logger.error('[NotificationService] Failed to create in-app notification:', error.message);
             return null;
         }
     }
@@ -261,7 +262,7 @@ class NotificationService {
      */
     async sendPushNotification(userId, title, body) {
         // Placeholder for push notifications (e.g., Firebase Cloud Messaging)
-        console.log(`[PUSH] Would send push to user ${userId}: ${title}`);
+        logger.info(`[PUSH] Would send push to user ${userId}: ${title}`);
         
         this.log('push', `Push notification: ${title}`, { userId, title, body });
     }
@@ -276,7 +277,7 @@ class NotificationService {
             const { emitGlobal } = require('./socketService');
             emitGlobal(event, data);
         } catch (err) {
-            console.warn('[WS] Socket.IO not available for broadcast:', err.message);
+            logger.warn('[WS] Socket.IO not available for broadcast:', err.message);
         }
 
         this.log('broadcast', `WebSocket broadcast: ${event}`, { event, data });
@@ -285,3 +286,5 @@ class NotificationService {
 
 // Export singleton instance
 module.exports = new NotificationService();
+
+


### PR DESCRIPTION
## Summary
Replaces all `console.warn`, `console.error`, and `console.log` calls in `backend/services/notificationService.js` with the centralized Winston logger already used throughout the rest of the backend.

## Problem
`backend/services/notificationService.js` was using raw console methods in multiple places while every other backend file uses the Winston logger from `utils/logger.js`:
- `log()` method used `console.warn`, `console.error`, and `console.log` for all notification logging
- `sendPushNotification()` used `console.log`
- `broadcast()` used `console.warn`

This meant notification logs, security events, and email delivery failures were not captured in `logs/combined.log` or `logs/error.log` and would be missed by production monitoring tools.

## Changes
- `backend/services/notificationService.js` → Added `logger` import from `../utils/logger`
- Replaced `console.warn` → `logger.warn` (2 instances)
- Replaced `console.error` → `logger.error` (2 instances)
- Replaced `console.log` → `logger.info` (2 instances)

## Testing
- Verified no console statements remain with `Select-String -Path "backend\services\notificationService.js" -Pattern "console\.|logger"`

Closes #534