### PR TITLE
fix: Add mandi and retailer to allowed roles in validateRegistration middleware

### DIFF
--- a/backend/middleware/validateRegistration.js
+++ b/backend/middleware/validateRegistration.js
@@ -2,11 +2,11 @@ const validateRegistration = (req, res, next) => {
     const { role } = req.body;
 
     // Restrict role creation
-    const allowedRoles = ['farmer', 'transporter'];
+    const allowedRoles = ['farmer', 'transporter', 'mandi', 'retailer'];
     if (role && !allowedRoles.includes(role)) {
         return res.status(400).json({
             error: 'Registration failed',
-            message: 'Invalid role selected. Only farmer and transporter accounts can be created publicly.'
+            message: 'Invalid role selected. Only farmer, transporter, mandi and retailer accounts can be created publicly.'
         });
     }
 


### PR DESCRIPTION
## Summary
Updates `backend/middleware/validateRegistration.js` to include `mandi` and `retailer` in the list of publicly registerable roles, fixing a bug where core supply chain actors were completely locked out of the platform.

## Problem
`validateRegistration.js` only allowed `farmer` and `transporter` roles to register publicly. However `mandi` and `retailer` are fully implemented roles throughout the codebase:
- Defined in `middleware/auth.js` stage permissions
- Defined in `constants/permissions.js`
- Used in `middleware/rateLimiters.js`

Mandi operators and retailers had no way to create accounts — the only workaround would have been direct database manipulation.

## Changes
- `backend/middleware/validateRegistration.js` → Added `mandi` and `retailer` to `allowedRoles` array
- Updated error message to reflect the new allowed roles

## Testing
- Verified changes with `Get-Content "backend\middleware\validateRegistration.js"`

Closes #539