### PR TITLE
fix: resolve incomplete role revocation bug allowing privilege retention

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -145,13 +145,13 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // Admin role must be managed exclusively through transferOwnership
         require(role != ActorRole.Admin, "Use transferOwnership to assign Admin");
 
-        // Revoke the previous OZ AccessControl role for this user if one was set
-        ActorRole previousRole = roles[user];
-        if (previousRole == ActorRole.Farmer) _revokeRole(FARMER_ROLE, user);
-        else if (previousRole == ActorRole.Mandi) _revokeRole(MANDI_ROLE, user);
-        else if (previousRole == ActorRole.Transporter) _revokeRole(TRANSPORTER_ROLE, user);
-        else if (previousRole == ActorRole.Retailer) _revokeRole(RETAILER_ROLE, user);
-        else if (previousRole == ActorRole.Oracle) _revokeRole(ORACLE_ROLE, user);
+        // Revoke all possible OZ AccessControl stakeholder roles for this user
+        // to ensure complete revocation even if multiple roles were previously granted
+        _revokeRole(FARMER_ROLE, user);
+        _revokeRole(MANDI_ROLE, user);
+        _revokeRole(TRANSPORTER_ROLE, user);
+        _revokeRole(RETAILER_ROLE, user);
+        _revokeRole(ORACLE_ROLE, user);
 
         roles[user] = role;
 


### PR DESCRIPTION
## 📌 Overview
This PR fixes a critical privilege retention bug in the `setRole` function within `CropChain.sol`. Previously, when a user had multiple roles granted via `AccessControl`, revoking their access only removed the single role tracked in the legacy `roles` mapping, leaving other OpenZeppelin roles active and creating a privilege escalation vulnerability. This update explicitly revokes all possible stakeholder roles before assigning the new role to ensure complete and secure access revocation.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #569 

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
*(N/A - Smart Contract logic fix only)*

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
By explicitly calling `_revokeRole()` for all stakeholder roles (FARMER_ROLE, MANDI_ROLE, TRANSPORTER_ROLE, RETAILER_ROLE, ORACLE_ROLE) within `setRole`, we guarantee that no orphaned privileges remain in the `AccessControl` registry, regardless of how many roles were assigned via `grantStakeholderRole()`.
