### PR TITLE
Fix/reversible spoilage status

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -145,13 +145,13 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // Admin role must be managed exclusively through transferOwnership
         require(role != ActorRole.Admin, "Use transferOwnership to assign Admin");
 
-        // Revoke the previous OZ AccessControl role for this user if one was set
-        ActorRole previousRole = roles[user];
-        if (previousRole == ActorRole.Farmer) _revokeRole(FARMER_ROLE, user);
-        else if (previousRole == ActorRole.Mandi) _revokeRole(MANDI_ROLE, user);
-        else if (previousRole == ActorRole.Transporter) _revokeRole(TRANSPORTER_ROLE, user);
-        else if (previousRole == ActorRole.Retailer) _revokeRole(RETAILER_ROLE, user);
-        else if (previousRole == ActorRole.Oracle) _revokeRole(ORACLE_ROLE, user);
+        // Revoke all possible OZ AccessControl stakeholder roles for this user
+        // to ensure complete revocation even if multiple roles were previously granted
+        _revokeRole(FARMER_ROLE, user);
+        _revokeRole(MANDI_ROLE, user);
+        _revokeRole(TRANSPORTER_ROLE, user);
+        _revokeRole(RETAILER_ROLE, user);
+        _revokeRole(ORACLE_ROLE, user);
 
         roles[user] = role;
 

--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -661,10 +661,11 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         
         // Check if batch is spoiled based on temperature thresholds
         // Temperature is in hundredths of degree: 800 = 80.0°F, 320 = 32.0°F
-        bool isSpoiled = (temperature > 800 || temperature < 320);
-        cropBatches[batchId].isSpoiled = isSpoiled;
+        if (temperature > 800 || temperature < 320) {
+            cropBatches[batchId].isSpoiled = true;
+        }
         
-        emit IoTDataFulfilled(batchId, temperature, humidity, isSpoiled);
+        emit IoTDataFulfilled(batchId, temperature, humidity, cropBatches[batchId].isSpoiled);
     }
 
     /**


### PR DESCRIPTION
## 📌 Overview
This PR fixes a logical vulnerability in the `fulfillIoTData` function where a crop batch's `isSpoiled` status could be incorrectly reversed. Previously, the contract overwrote the boolean `isSpoiled` with the evaluation of the current temperature reading. This meant a physically spoiled crop (e.g. from extreme heat) would magically be marked as "un-spoiled" if a subsequent reading returned a normal temperature, allowing rotten crops to be listed and sold. The logic now permanently latches `isSpoiled` to `true` once thresholds are breached, ensuring accurate quality control tracking.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #570

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
*(N/A - Smart Contract logic fix only)*

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
The `IoTDataFulfilled` event now emits the persisted state `cropBatches[batchId].isSpoiled` rather than the local evaluation, meaning indexers will correctly observe that the batch remains spoiled even if the current temperature reading is normal.

