### PR TITLE
docs: fix spacing typo in license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,7 @@ I welcome contributions!
 
 ## License
 
-This project is licensed under the Apache License 2.0- see the [LICENSE](LICENSE) file for further details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for further details.
 
 ---
 


### PR DESCRIPTION
## 📌 Overview
Fixed a minor typographical error in the README.md by adding a missing space in the License section (`Apache License 2.0- see` changed to `Apache License 2.0 - see`).

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [x] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #None (just a documentation quick fix)

---

## 🧪 Testing & Verification
- [NA] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [NA] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [NA] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---

## 📸 Screenshots / Demos
N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
N/A