### PR TITLE
Fix: Require current custodian approval for batch stage transitions

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -78,6 +78,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     /// @dev Tracks the total quantity currently committed across all active listings for a batch.
     ///      Prevents double-listing and over-allocation beyond the physical batch quantity.
     mapping(bytes32 => uint256) public batchListedQuantity;
+    mapping(bytes32 => address) public nextCustodianApproval;
 
     bytes32[] public allBatchIds;
 
@@ -99,6 +100,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     event TwapConfigUpdated(uint256 twapWindowSeconds, uint256 maxPriceDeviationBps);
     event IoTDataRequested(bytes32 indexed batchId, address requester);
     event IoTDataFulfilled(bytes32 indexed batchId, int256 temperature, int256 humidity, bool isSpoiled);
+    event CustodianApproved(bytes32 indexed batchId, address indexed approver, address indexed nextCustodian);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Only owner");
@@ -260,6 +262,28 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         emit BatchCreated(batchId, ipfsCID, quantity, msg.sender);
     }
 
+    function approveCustodian(bytes32 batchId, address nextCustodian) external whenNotPaused nonReentrant batchExists(batchId) {
+        SupplyChainUpdate[] storage updates = _batchUpdates[batchId];
+        
+        address currentCustodian;
+        if (updates.length == 0) {
+            currentCustodian = cropBatches[batchId].creator;
+        } else {
+            SupplyChainUpdate storage latestUpdate = updates[updates.length - 1];
+            if (latestUpdate.stage == Stage.Farmer) {
+                currentCustodian = cropBatches[batchId].creator;
+            } else {
+                currentCustodian = latestUpdate.updatedBy;
+            }
+        }
+        
+        require(msg.sender == currentCustodian || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized to approve");
+        require(nextCustodian != address(0), "Invalid address");
+        
+        nextCustodianApproval[batchId] = nextCustodian;
+        emit CustodianApproved(batchId, msg.sender, nextCustodian);
+    }
+
     function updateBatch(
         bytes32 batchId,
         Stage stage,
@@ -276,6 +300,14 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         require(bytes(actorName).length > 0, "Actor required");
         require(bytes(location).length > 0, "Location required");
         require(_isNextStage(batchId, stage), "Invalid stage transition");
+
+        // Ensure the caller is approved by the current custodian to take over the batch
+        require(
+            nextCustodianApproval[batchId] == msg.sender || hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            "Not approved by current custodian"
+        );
+        // Clear approval after use
+        nextCustodianApproval[batchId] = address(0);
 
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");


### PR DESCRIPTION
## 📌 Overview
This PR fixes a critical vulnerability where any user with a downstream role (like `MANDI_ROLE` or `TRANSPORTER_ROLE`) could unilaterally hijack custody of a crop batch using the `updateBatch` function without the current custodian's consent. 

**Fix details:**
- Added a `nextCustodianApproval` mapping to track authorized transfers.
- Introduced a new `approveCustodian` function allowing only the current batch custodian (or an Admin) to authorize the next custodian.
- Updated `updateBatch` to strictly verify that `msg.sender` holds a valid approval from the current custodian before processing the stage transition.
- Implemented automatic clearing of the approval mapping post-transition to prevent double-use.
- Emitted a new `CustodianApproved` event for off-chain tracking.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #579

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
*N/A - Smart contract logic fix only.*

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
Frontend teams or integration scripts interacting with the smart contracts will need to be updated. Before calling `updateBatch` to advance the supply chain stage, the **current custodian** must now first call the `approveCustodian(batchId, nextCustodianAddress)` function.

