### PR TITLE
Fix/issue 2 ghost listings

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -78,6 +78,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     /// @dev Tracks the total quantity currently committed across all active listings for a batch.
     ///      Prevents double-listing and over-allocation beyond the physical batch quantity.
     mapping(bytes32 => uint256) public batchListedQuantity;
+    mapping(bytes32 => address) public nextCustodianApproval;
 
     bytes32[] public allBatchIds;
 
@@ -99,6 +100,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     event TwapConfigUpdated(uint256 twapWindowSeconds, uint256 maxPriceDeviationBps);
     event IoTDataRequested(bytes32 indexed batchId, address requester);
     event IoTDataFulfilled(bytes32 indexed batchId, int256 temperature, int256 humidity, bool isSpoiled);
+    event CustodianApproved(bytes32 indexed batchId, address indexed approver, address indexed nextCustodian);
 
     modifier onlyOwner() {
         require(msg.sender == owner, "Only owner");
@@ -260,6 +262,28 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         emit BatchCreated(batchId, ipfsCID, quantity, msg.sender);
     }
 
+    function approveCustodian(bytes32 batchId, address nextCustodian) external whenNotPaused nonReentrant batchExists(batchId) {
+        SupplyChainUpdate[] storage updates = _batchUpdates[batchId];
+        
+        address currentCustodian;
+        if (updates.length == 0) {
+            currentCustodian = cropBatches[batchId].creator;
+        } else {
+            SupplyChainUpdate storage latestUpdate = updates[updates.length - 1];
+            if (latestUpdate.stage == Stage.Farmer) {
+                currentCustodian = cropBatches[batchId].creator;
+            } else {
+                currentCustodian = latestUpdate.updatedBy;
+            }
+        }
+        
+        require(msg.sender == currentCustodian || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized to approve");
+        require(nextCustodian != address(0), "Invalid address");
+        
+        nextCustodianApproval[batchId] = nextCustodian;
+        emit CustodianApproved(batchId, msg.sender, nextCustodian);
+    }
+
     function updateBatch(
         bytes32 batchId,
         Stage stage,
@@ -276,6 +300,14 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         require(bytes(actorName).length > 0, "Actor required");
         require(bytes(location).length > 0, "Location required");
         require(_isNextStage(batchId, stage), "Invalid stage transition");
+
+        // Ensure the caller is approved by the current custodian to take over the batch
+        require(
+            nextCustodianApproval[batchId] == msg.sender || hasRole(DEFAULT_ADMIN_ROLE, msg.sender),
+            "Not approved by current custodian"
+        );
+        // Clear approval after use
+        nextCustodianApproval[batchId] = address(0);
 
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");

--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -263,19 +263,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     }
 
     function approveCustodian(bytes32 batchId, address nextCustodian) external whenNotPaused nonReentrant batchExists(batchId) {
-        SupplyChainUpdate[] storage updates = _batchUpdates[batchId];
-        
-        address currentCustodian;
-        if (updates.length == 0) {
-            currentCustodian = cropBatches[batchId].creator;
-        } else {
-            SupplyChainUpdate storage latestUpdate = updates[updates.length - 1];
-            if (latestUpdate.stage == Stage.Farmer) {
-                currentCustodian = cropBatches[batchId].creator;
-            } else {
-                currentCustodian = latestUpdate.updatedBy;
-            }
-        }
+        address currentCustodian = _getCurrentCustodian(batchId);
         
         require(msg.sender == currentCustodian || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized to approve");
         require(nextCustodian != address(0), "Invalid address");
@@ -308,6 +296,9 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         );
         // Clear approval after use
         nextCustodianApproval[batchId] = address(0);
+
+        // Reset batchListedQuantity to invalidate active ghost listings from previous custodian
+        batchListedQuantity[batchId] = 0;
 
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");
@@ -401,6 +392,8 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         CropBatch storage batch = cropBatches[listing.batchId];
         require(batch.exists && !batch.isRecalled, "Batch unavailable");
         require(!batch.isSpoiled, "Batch is spoiled");
+        
+        require(listing.seller == _getCurrentCustodian(listing.batchId), "Seller is no longer the custodian");
 
         uint256 twapPrice = getTwapPrice(batch.cropTypeHash, twapWindow);
         if (twapPrice > 0) {
@@ -435,9 +428,11 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         require(listing.active, "Listing inactive");
         require(msg.sender == listing.seller || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not allowed");
 
-        // FIX: Restore the listing's remaining available quantity back to the batch's
-        // listed-quantity tracker so those units can be re-listed or sold via a new listing.
-        batchListedQuantity[listing.batchId] -= listing.quantityAvailable;
+        // Restore the listing's remaining available quantity back to the batch's tracker
+        // ONLY if the seller is still the current custodian.
+        if (listing.seller == _getCurrentCustodian(listing.batchId)) {
+            batchListedQuantity[listing.batchId] -= listing.quantityAvailable;
+        }
 
         listing.active = false;
         listing.quantityAvailable = 0;
@@ -584,6 +579,18 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         if (stage == Stage.Transport && role == ActorRole.Transporter) return true;
         if (stage == Stage.Retailer && role == ActorRole.Retailer) return true;
         return false;
+    }
+
+    function _getCurrentCustodian(bytes32 batchId) internal view returns (address) {
+        SupplyChainUpdate[] storage updates = _batchUpdates[batchId];
+        if (updates.length == 0) {
+            return cropBatches[batchId].creator;
+        }
+        SupplyChainUpdate storage latestUpdate = updates[updates.length - 1];
+        if (latestUpdate.stage == Stage.Farmer) {
+            return cropBatches[batchId].creator;
+        }
+        return latestUpdate.updatedBy;
     }
 
     function _canUpdateStage(bytes32 batchId, Stage newStage) internal view returns (bool) {


### PR DESCRIPTION
## 📌 Overview
This PR fixes a critical vulnerability where market listings created by a previous batch custodian remained active and purchasable even after custody of the batch was transferred to a new party (Ghost Listings). 

**Fix details:**
- Extracted a `_getCurrentCustodian` helper function to cleanly identify the current batch owner.
- Reset the `batchListedQuantity` tracker to `0` whenever `updateBatch` is called, ensuring the new custodian's inventory is accurate.
- Added strict validation in `buyFromListing` to block any purchases if the `listing.seller` is no longer the active custodian of the batch.
- Safely wrapped the quantity decrement in `cancelListing` so that previous custodians can cancel their stale listings without causing arithmetic underflows.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #580

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
*N/A - Smart contract backend changes only.*

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
This update transparently handles state without resorting to heavy iterative loops over listings. Old listings from previous custodians will remain in the `listings` mapping with `active = true` (unless manually cancelled), but they are cryptographically locked and impossible to purchase from. Frontends may want to update their queries to filter out listings where `seller != _getCurrentCustodian(batchId)`.
