### PR TITLE
fix: Replace console.log/error with winston logger in blockchainListener.js

### DIFF
--- a/backend/services/blockchainListener.js
+++ b/backend/services/blockchainListener.js
@@ -1,5 +1,6 @@
-const Batch = require('../models/Batch');
+﻿const Batch = require('../models/Batch');
 const socketService = require('./socketService');
+const logger = require('../utils/logger');
 
 function startListener(contract) {
 
@@ -19,7 +20,7 @@ function startListener(contract) {
         { upsert: true }
       );
 
-      console.log(`[SYNC] Batch ${id} → ${stageStr} by ${actor}`);
+      logger.info(`[SYNC] Batch ${id} → ${stageStr} by ${actor}`);
 
       // Emit real-time update to all clients watching this batch
       const batchData = await Batch.findOne({ batchId: id }).lean();
@@ -43,10 +44,11 @@ function startListener(contract) {
       }
 
     } catch (err) {
-      console.error('[SYNC ERROR]', err);
+      logger.error('[SYNC ERROR]', err);
     }
   });
 
 }
 
 module.exports = startListener;
+


### PR DESCRIPTION
## Summary
Replaces `console.log` and `console.error` calls in `backend/services/blockchainListener.js` with the centralized Winston logger already used throughout the rest of the backend.

## Problem
`backend/services/blockchainListener.js` was using raw console methods while every other backend file uses the Winston logger from `utils/logger.js`:
- `console.log('[SYNC] Batch...')` — blockchain sync events not captured in log files
- `console.error('[SYNC ERROR]', err)` — sync errors not captured in error logs

This meant blockchain sync events and errors were not captured in `logs/combined.log` or `logs/error.log` and would be missed by production monitoring tools.

## Changes
- `backend/services/blockchainListener.js` → Added `logger` import from `../utils/logger`
- Replaced `console.log` → `logger.info` (1 instance)
- Replaced `console.error` → `logger.error` (1 instance)

## Testing
- Verified no console statements remain with `Select-String -Path "backend\services\blockchainListener.js" -Pattern "console\.|logger"`

Closes #589