### PR TITLE
fix: getAllBatches Computes totalFarmers Only From Fetched Limit

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -459,19 +459,31 @@ exports.getBatches = async (req, res) => {
             }
         }
 
-        const totalItems = await Batch.countDocuments(query);
+        const [totalItems, statsAggregation] = await Promise.all([
+            Batch.countDocuments(query),
+            Batch.aggregate([
+                { $match: query },
+                {
+                    $group: {
+                        _id: null,
+                        totalFarmers: { $addToSet: '$farmerId' },
+                        totalQuantity: { $sum: { $ifNull: ['$quantity', 0] } }
+                    }
+                }
+            ])
+        ]);
 
-        // Fetch slim batch data for calculating statistics
-        const allMatchingBatches = await Batch.find(query).select('farmerName quantity').lean();
-        const totalFarmers = new Set(allMatchingBatches.map(b => b.farmerName)).size;
-        const totalQuantity = allMatchingBatches.reduce((sum, b) => sum + (b.quantity || 0), 0);
+        const aggregateStats = statsAggregation[0] || {
+            totalFarmers: [],
+            totalQuantity: 0
+        };
 
         res.json(apiResponse.successResponse({
             batches,
             stats: {
                 totalBatches: totalItems,
-                totalFarmers,
-                totalQuantity,
+                totalFarmers: aggregateStats.totalFarmers.length,
+                totalQuantity: aggregateStats.totalQuantity,
                 recentBatches: batches.slice(0, 5)
             },
             pagination: {

--- a/backend/services/batchService.js
+++ b/backend/services/batchService.js
@@ -428,18 +428,32 @@ class BatchService {
             const allBatches = await Batch.find().sort({ createdAt: -1 }).limit(limit).lean();
 
             // Compute stats efficiently without loading full dataset
-            const [totalBatches, recalledBatches, recentBatches] = await Promise.all([
+            const [totalBatches, recalledBatches, recentBatches, batchStats] = await Promise.all([
                 Batch.countDocuments(),
                 Batch.countDocuments({ isRecalled: true }),
-                Batch.countDocuments({ createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } })
+                Batch.countDocuments({ createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) } }),
+                Batch.aggregate([
+                    {
+                        $group: {
+                            _id: null,
+                            totalFarmers: { $addToSet: '$farmerId' },
+                            totalQuantity: { $sum: { $ifNull: ['$quantity', 0] } }
+                        }
+                    }
+                ])
             ]);
+
+            const aggregateStats = batchStats[0] || {
+                totalFarmers: [],
+                totalQuantity: 0
+            };
 
             const stats = {
                 totalBatches,
                 recalledBatches,
                 recentBatches,
-                totalFarmers: new Set(allBatches.map(b => b.farmerName)).size,
-                totalQuantity: allBatches.reduce((sum, b) => sum + (b.quantity || 0), 0)
+                totalFarmers: aggregateStats.totalFarmers.length,
+                totalQuantity: aggregateStats.totalQuantity
             };
 
             return {

--- a/backend/tests/batch.test.js
+++ b/backend/tests/batch.test.js
@@ -11,6 +11,7 @@ const mockCounter = {
 const mockBatch = {
   create: jest.fn(),
   countDocuments: jest.fn(),
+  aggregate: jest.fn(),
   findOne: jest.fn(),
   findOneAndUpdate: jest.fn(),
   find: jest.fn()

--- a/backend/tests/batchSearchRegex.test.js
+++ b/backend/tests/batchSearchRegex.test.js
@@ -7,6 +7,7 @@ const mockCounter = {
 const mockBatch = {
   create: jest.fn(),
   countDocuments: jest.fn(),
+  aggregate: jest.fn(),
   findOne: jest.fn(),
   findOneAndUpdate: jest.fn(),
   find: jest.fn()
@@ -78,6 +79,7 @@ describe('batch search regex safety', () => {
 
     mockBatch.find.mockReturnValue(queryChain);
     mockBatch.countDocuments.mockResolvedValue(0);
+    mockBatch.aggregate.mockResolvedValue([]);
 
     const req = {
       query: {
@@ -108,5 +110,55 @@ describe('batch search regex safety', () => {
       cropType: '[rice]',
       status: 'Active'
     });
+  });
+
+  it('uses aggregation for unique farmer stats instead of the limited batch page', async () => {
+    const queryChain = {
+      lean: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue([
+        { batchId: 'BATCH001', farmerId: 'FARM1', farmerName: 'Farmer One', quantity: 10 },
+        { batchId: 'BATCH002', farmerId: 'FARM1', farmerName: 'Farmer One', quantity: 20 }
+      ])
+    };
+
+    mockBatch.find.mockReturnValue(queryChain);
+    mockBatch.countDocuments.mockResolvedValue(125);
+    mockBatch.aggregate.mockResolvedValue([
+      {
+        _id: null,
+        totalFarmers: ['FARM1', 'FARM2', 'FARM3', 'FARM4', 'FARM5'],
+        totalQuantity: 500
+      }
+    ]);
+
+    const req = {
+      query: {
+        limit: '2'
+      }
+    };
+
+    const res = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis()
+    };
+
+    await getBatches(req, res);
+
+    expect(mockBatch.aggregate).toHaveBeenCalledWith([
+      { $match: {} },
+      {
+        $group: {
+          _id: null,
+          totalFarmers: { $addToSet: '$farmerId' },
+          totalQuantity: { $sum: { $ifNull: ['$quantity', 0] } }
+        }
+      }
+    ]);
+
+    const responseBody = res.json.mock.calls[0][0];
+    expect(responseBody.data.stats.totalFarmers).toBe(5);
+    expect(responseBody.data.stats.totalQuantity).toBe(500);
   });
 });

--- a/backend/tests/batchServiceStats.test.js
+++ b/backend/tests/batchServiceStats.test.js
@@ -1,0 +1,72 @@
+process.env.NODE_ENV = 'test';
+
+const mockBatch = {
+  find: jest.fn(),
+  countDocuments: jest.fn(),
+  aggregate: jest.fn()
+};
+
+jest.mock('../models/Batch', () => mockBatch);
+jest.mock('../models/Counter', () => ({
+  findOneAndUpdate: jest.fn()
+}));
+jest.mock('../services/blockchainService', () => ({}));
+jest.mock('../services/blockchainQueue', () => ({}));
+jest.mock('../services/notificationService', () => ({}));
+jest.mock('../services/socketService', () => ({
+  emitToBatchRoom: jest.fn(),
+  emitGlobal: jest.fn()
+}));
+jest.mock('../services/activityService', () => ({}));
+jest.mock('../utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+}));
+
+const batchService = require('../services/batchService');
+
+describe('BatchService statistics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('counts unique farmers with aggregation instead of the limited result set', async () => {
+    const queryChain = {
+      sort: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue([
+        { batchId: 'BATCH001', farmerId: 'FARM1', farmerName: 'Farmer One', quantity: 10 },
+        { batchId: 'BATCH002', farmerId: 'FARM1', farmerName: 'Farmer One', quantity: 20 }
+      ])
+    };
+
+    mockBatch.find.mockReturnValue(queryChain);
+    mockBatch.countDocuments
+      .mockResolvedValueOnce(125)
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(12);
+    mockBatch.aggregate.mockResolvedValue([
+      {
+        _id: null,
+        totalFarmers: ['FARM1', 'FARM2', 'FARM3', 'FARM4', 'FARM5'],
+        totalQuantity: 500
+      }
+    ]);
+
+    const result = await batchService.getAllBatches(2);
+
+    expect(mockBatch.aggregate).toHaveBeenCalledWith([
+      {
+        $group: {
+          _id: null,
+          totalFarmers: { $addToSet: '$farmerId' },
+          totalQuantity: { $sum: { $ifNull: ['$quantity', 0] } }
+        }
+      }
+    ]);
+    expect(result.stats.totalBatches).toBe(125);
+    expect(result.stats.totalFarmers).toBe(5);
+    expect(result.stats.totalQuantity).toBe(500);
+  });
+});


### PR DESCRIPTION
## 📌 Overview

This PR fixes the batch dashboard stats bug where `totalFarmers` could be computed from only the limited batch result set. Batch stats now use MongoDB aggregation with `$addToSet` on `farmerId`, so the unique farmer count reflects all matching batches instead of only the most recent page of results.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #584 

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)


---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change adds regression coverage around batch stats calculation to ensure `totalFarmers` is counted by MongoDB across all matching batches instead of being derived from a limited in-memory batch page.
