### PR TITLE
Fix #617: Dead-code branch in batchController prevents shipment_created audit event

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -221,6 +221,7 @@ exports.updateBatch = async (req, res) => {
         }
 
         // Update batch fields
+        const previousStage = batch.currentStage;
         batch.currentStage = normalizedStage;
         
         // Add update entry
@@ -244,7 +245,7 @@ exports.updateBatch = async (req, res) => {
             eventType = 'ownership_transferred';
             description = `Batch ownership transferred to Mandi at ${validatedData.location}`;
         } else if (normalizedStage === 'transport') {
-            if (batch.currentStage === 'transport') {
+            if (previousStage === 'transport') {
                 eventType = 'shipment_status_updated';
                 description = `Shipment status updated: batch is at ${validatedData.location}`;
             } else {


### PR DESCRIPTION
Fixes #617

## Bug
In \ackend/controllers/batchController.js\, \atch.currentStage\ was overwritten **before** the event-type determination logic, making the \shipment_created\ audit event unreachable.

## Fix
- Save \previousStage\ from \atch.currentStage\ **before** overwriting
- Use \previousStage\ in the transport event-type check