### PR TITLE
Fix #616: Remove hardcoded fallback HMAC secret that defeats audit trail integrity

### DIFF
--- a/backend/utils/auditLogger.js
+++ b/backend/utils/auditLogger.js
@@ -57,7 +57,7 @@ const computeEventHash = ({ previousHash, event }) => {
         createdAt: event.createdAt,
     };
 
-    const secret = process.env.AUDIT_EVENT_HMAC_SECRET || 'dev-audit-secret-change-me';
+    const secret = process.env.AUDIT_EVENT_HMAC_SECRET;
     const canonical = stableStringify(payload);
     return crypto.createHmac('sha256', secret).update(canonical).digest('hex');
 };

--- a/backend/utils/envValidator.js
+++ b/backend/utils/envValidator.js
@@ -37,6 +37,11 @@ const REQUIRED_VARS = {
     validate: (v) => /^(0x)?[a-fA-F0-9]{64}$/.test(v),
     hint: "Expected a 64-character hex string (with or without 0x prefix)",
   },
+  AUDIT_EVENT_HMAC_SECRET: {
+    description: "HMAC secret for audit event hash-chain integrity",
+    validate: (v) => v.length >= 32,
+    hint: "Minimum 32 characters. Generate with: openssl rand -hex 32",
+  },
 };
 
 const OPTIONAL_VARS_WARN = {


### PR DESCRIPTION
Fixes #616

## Bug
In \ackend/utils/auditLogger.js:60\, the HMAC secret fell back to \'dev-audit-secret-change-me'\ when env var was not set.

## Fix
1. Removed the hardcoded fallback in \uditLogger.js\
2. Added \AUDIT_EVENT_HMAC_SECRET\ as a required env var in \envValidator.js\ with 32-char minimum validation