### PR TITLE
Fix #618: Remove duplicate removeOnFail key in blockchain queue config

### DIFF
--- a/backend/services/blockchainQueue.js
+++ b/backend/services/blockchainQueue.js
@@ -50,9 +50,7 @@ const DEFAULT_JOB_OPTIONS = {
     },
     removeOnFail: {
         age: 7 * 24 * 3600 // Keep failed jobs for 7 days for debugging
-    },
-    // Don't remove job on failure - we want to track it
-    removeOnFail: false
+    }
 };
 
 // Queue instance (singleton)


### PR DESCRIPTION
Fixes #618

## Bug
\DEFAULT_JOB_OPTIONS\ had \emoveOnFail\ defined **twice**. The second value (\alse\) silently overwrote the first (\{ age: 604800 }\).

## Fix
- Removed the duplicate \emoveOnFail: false\ entry
- Kept \emoveOnFail: { age: 7 * 24 * 3600 }\ (7-day retention for debugging)