### PR TITLE
feat: add transaction lock for blockchain requests

### DIFF
--- a/frontend/src/app/update-batch/page.tsx
+++ b/frontend/src/app/update-batch/page.tsx
@@ -24,6 +24,7 @@ const UpdateBatch: React.FC = () => {
   });
   const [isUpdating, setIsUpdating] = useState(false);
   const [isRequestingIoT, setIsRequestingIoT] = useState(false);
+  const [transactionLocked, setTransactionLocked] = useState(false);
   const [transactionDetails, setTransactionDetails] = useState<{
   hash: string;
   status: 'Confirmed' | 'Pending';
@@ -65,7 +66,10 @@ const UpdateBatch: React.FC = () => {
 
   const handleUpdate = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!batch) return;
+   if (!batch) {
+  setTransactionLocked(false);
+  return;
+}
     
     // RBAC Check: Verify user can update to this stage
     if (!canUpdateToStage(updateData.stage)) {
@@ -111,6 +115,12 @@ const UpdateBatch: React.FC = () => {
   };
 
   const handleRequestIoTVerification = async () => {
+    if (transactionLocked) {
+       toast.error("Transaction already in progress.");
+  return;
+}
+
+setTransactionLocked(true);
     if (!batch || !batch.batchId) {
       toast.error('Please search for a batch first');
       return;
@@ -178,6 +188,7 @@ const UpdateBatch: React.FC = () => {
   toast.error('Failed to request IoT verification. Please try again.');
 }finally {
       setIsRequestingIoT(false);
+      setTransactionLocked(false);
     }
   };
 
@@ -471,7 +482,7 @@ const handleCopyTransactionHash = async () => {
                     <button
                       type="button"
                       onClick={handleRequestIoTVerification}
-                      disabled={isRequestingIoT || !batch.batchId}
+                     disabled={isRequestingIoT || transactionLocked}
                       className={`px-6 py-3 rounded-lg font-medium transition-all duration-200 flex items-center space-x-2 ${
                         isRequestingIoT || !batch.batchId
                           ? 'bg-gray-400 cursor-not-allowed'


### PR DESCRIPTION
## 📌 Overview

Implemented a transaction locking mechanism to prevent duplicate blockchain requests while a transaction is already in progress.

### Features
- Locks the transaction immediately after the first click.
- Prevents duplicate blockchain submissions.
- Ignores repeated clicks until the transaction completes.
- Automatically unlocks after success or failure.
- Displays a notification when users attempt another transaction while one is already running.

---

## 🛠️ Type of Change
- [ ] ⛓️ Smart Contract
- [x] 💻 Frontend
- [ ] ⚙️ Backend
- [ ] 📄 Documentation
- [ ] 🧪 Testing

---

## 🔗 Related Issue

Closes #597

---

## 🧪 Testing & Verification

- [x] Frontend verified locally.
- [x] Production build passed (`npm run build`).
- [x] Duplicate transaction attempts are prevented while a transaction is in progress.

---

## 📸 Screenshots / Demos

(Add screenshots here.)

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] My changes generate no new warnings.
- [ ] Documentation update not required.

---

## 💬 Additional Notes

Implemented a dedicated transaction lock that guards the blockchain transaction handler and releases the lock after the transaction succeeds or fails, reducing the risk of accidental duplicate submissions.