### PR TITLE
fix: clear reset password redirect timeout on unmount

### DIFF
--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, Suspense } from 'react';
+import React, { useState, useEffect, useRef, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { Loader2, Lock, Eye, EyeOff, AlertCircle, CheckCircle2, ArrowLeft, Check, X } from 'lucide-react';
@@ -19,6 +19,10 @@ const ResetPasswordContent = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
+
+  // Holds the id of the pending redirect timeout so it can be cleared
+  // if the component unmounts before the redirect fires.
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Password requirements validation state
   const [validations, setValidations] = useState({
@@ -40,6 +44,17 @@ const ResetPasswordContent = () => {
       match: password.length > 0 && password === confirmPassword,
     });
   }, [password, confirmPassword]);
+
+  // Clear any pending redirect timer when the component unmounts,
+  // so a stale timer can't redirect the user after they've navigated away.
+  useEffect(() => {
+    return () => {
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+        redirectTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const isFormValid = 
     validations.minLength && 
@@ -66,7 +81,13 @@ const ResetPasswordContent = () => {
       await authService.resetPassword(token, password);
       setSuccess(true);
       toast.success('Password reset successfully!');
-      setTimeout(() => {
+
+      // Clear any existing timer before scheduling a new one, then store
+      // the new timer's id so it can be cancelled on unmount.
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+      redirectTimerRef.current = setTimeout(() => {
         router.push('/login');
       }, 3000);
     } catch (err: any) {


### PR DESCRIPTION
## Related Issue

Closes #649

---

## Description

Fixed an issue where the reset password page started a redirect timer after a successful password reset but did not clear it when the component unmounted.

Previously, if a user navigated away before the 3-second timeout completed, the pending timer could still execute and unexpectedly redirect the user to the login page.

This fix stores the timeout ID using `useRef` and clears it in a cleanup `useEffect`, ensuring no stale timers remain after the component unmounts.

---

## Changes Made

- Stored the redirect timeout ID using `useRef`.
- Added a cleanup `useEffect` to clear the timeout when the component unmounts.
- Prevented unexpected redirects after navigating away from the page.
- Preserved the existing redirect behavior after a successful password reset.

---

## Steps to Test

1. Open a valid password reset link.
2. Reset the password successfully.
3. Before the 3-second redirect occurs, navigate to another page.
4. Wait for more than 3 seconds.
5. Verify that no unexpected redirect to `/login` occurs.
6. Repeat the flow without leaving the page and confirm the redirect still happens after 3 seconds.

---

## Expected Result

- The redirect timer is cleared when the component unmounts.
- Users are not redirected unexpectedly after leaving the page.
- The normal 3-second redirect still works when the user remains on the page.

---

## Files Changed

- `frontend/src/app/reset-password/page.tsx`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update