### PR TITLE
fix: safely access navigator in SyncStatusIndicator

### DIFF
--- a/frontend/src/components/SyncStatusIndicator.tsx
+++ b/frontend/src/components/SyncStatusIndicator.tsx
@@ -6,7 +6,10 @@ import { ConflictResolutionModal } from './ConflictResolutionModal';
 
 const SyncStatusIndicator: React.FC = () => {
   const { t } = useTranslation();
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
+  // Safe default for pre-render/SSR environments where `navigator` may not
+  // exist yet. The real value is read in useEffect, which only runs on
+  // the client after mount.
+  const [isOnline, setIsOnline] = useState(true);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
   const [pendingCount, setPendingCount] = useState({ batches: 0, updates: 0 });
   const [isInitialLoading, setIsInitialLoading] = useState(true);
@@ -18,6 +21,12 @@ const SyncStatusIndicator: React.FC = () => {
   const [showConflictModal, setShowConflictModal] = useState(false);
 
   useEffect(() => {
+    // Now that we're safely on the client, sync isOnline with the actual
+    // browser state before wiring up the online/offline listeners.
+    if (typeof navigator !== 'undefined') {
+      setIsOnline(navigator.onLine);
+    }
+
     // Listen for online/offline events
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);


### PR DESCRIPTION
## Related Issue

Closes #647

---

## Description

Fixed an issue where `SyncStatusIndicator` accessed `navigator.onLine` directly during the initial render using `useState`.

In Next.js, components may be pre-rendered before browser APIs are available. Accessing `navigator` during the initial render can result in a `navigator is not defined` error during server-side rendering or the build process.

This fix initializes the online state with a safe default and reads `navigator.onLine` inside a `useEffect` after confirming that `navigator` is available.

---

## Changes Made

- Initialized the online state with a safe default value.
- Moved `navigator.onLine` access into `useEffect`.
- Added a `typeof navigator !== 'undefined'` check before accessing browser APIs.
- Prevented SSR/build-time errors while preserving existing online/offline functionality.

---

## Steps to Test

1. Run the frontend development server or production build.
2. Open a page that renders `SyncStatusIndicator`.
3. Verify there are no `navigator is not defined` errors during rendering or build.
4. Disconnect and reconnect the network.
5. Confirm the online/offline status updates correctly.

---

## Expected Result

- The application renders successfully without SSR or build errors.
- `navigator` is accessed only in the browser.
- Online/offline status continues to update correctly after the component mounts.

---

## Files Changed

- `frontend/src/components/SyncStatusIndicator.tsx`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update