### PR TITLE
fix: replace console.log with winston logger in rbacService.js

### DIFF
--- a/backend/services/rbacService.js
+++ b/backend/services/rbacService.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * RBAC Service
  */
 
@@ -6,6 +6,7 @@ const {
     PERMISSIONS, ROLES, hasPermission, hasAnyPermission, hasAllPermissions,
     isMultisigAction, getMultisigConfig, canApproveMultisig, getRoleLevel, isRoleHigher
 } = require('../constants/permissions');
+const logger = require('../utils/logger');
 
 class RBACService {
     static checkPermission(user, permission) {
@@ -126,7 +127,7 @@ class RBACService {
             if (!req.user) return res.status(401).json({ error: 'Unauthorized', message: 'Authentication required' });
             const hasAuth = requireAll ? this.checkAllPermissions(req.user, permArray) : this.checkAnyPermission(req.user, permArray);
             if (!hasAuth) {
-                console.log(`[RBAC] Permission denied for user ${req.user.email}: needs ${permArray.join(', ')}`);
+                logger.warn(`[RBAC] Permission denied for user ${req.user.email}: needs ${permArray.join(', ')}`);
                 return res.status(403).json({ error: 'Forbidden', message: `Missing required permission(s): ${permArray.join(', ')}` });
             }
             next();
@@ -135,3 +136,4 @@ class RBACService {
 }
 
 module.exports = RBACService;
+


### PR DESCRIPTION
## Summary
Replaces `console.log` in `backend/services/rbacService.js` with the centralized Winston logger already used throughout the rest of the backend, using `logger.warn` as permission denial is a security-relevant event.

## Problem
`backend/services/rbacService.js` line 129 was using `console.log` for RBAC permission denial events while every other backend file uses the Winston logger from `utils/logger.js`.

This meant security-relevant access control events were not captured in `logs/combined.log` or `logs/error.log` and would be missed by production monitoring tools.

## Changes
- `backend/services/rbacService.js` → Added `logger` import from `../utils/logger`
- Replaced `console.log` → `logger.warn` (permission denial is a security event, warn level is more appropriate)

## Testing
- Verified no console statements remain with `Select-String -Path "backend\services\rbacService.js" -Pattern "console\.|logger"`

Closes #629