### PR TITLE
fix(#641): attach mobile auth token to API requests

### DIFF
--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,4 +1,7 @@
+import * as SecureStore from 'expo-secure-store';
+
 const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3001/api';
+const TOKEN_KEY = 'auth_token';
 
 interface RequestOptions {
   method?: string;
@@ -6,15 +9,22 @@ interface RequestOptions {
   headers?: Record<string, string>;
 }
 
+async function getHeaders(headers: Record<string, string> = {}): Promise<Record<string, string>> {
+  const token = await SecureStore.getItemAsync(TOKEN_KEY).catch(() => null);
+
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...headers,
+  };
+}
+
 async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
   const { method = 'GET', body, headers = {} } = options;
 
   const config: RequestInit = {
     method,
-    headers: {
-      'Content-Type': 'application/json',
-      ...headers,
-    },
+    headers: await getHeaders(headers),
   };
 
   if (body) config.body = JSON.stringify(body);


### PR DESCRIPTION
## 📌 Overview

This PR fixes a mobile authentication issue where the shared API client did not attach the JWT stored in Expo SecureStore to outgoing requests.

The mobile app successfully stores the authentication token under `auth_token`, but requests made through `mobile/src/services/api.ts` were sent without an `Authorization` header. As a result, protected endpoints such as batches and notifications could receive unauthenticated requests and return `401 Unauthorized`.

This change updates the shared API client to automatically read the stored token and attach:

`Authorization: Bearer <token>`

when a token is available.

---

## 🛠️ Type of Change

* [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
* [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [ ] 📄 **Documentation** (README, Roadmap updates)
* [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #641

---

## 🧪 Testing & Verification

* [ ] **Smart Contracts:** `npx hardhat test` passed? (NA)
* [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
* [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

### Verification Performed

* Confirmed `auth.service.ts` stores the JWT using Expo SecureStore under `auth_token`.
* Confirmed batch and notification services use the shared API client.
* Confirmed protected backend routes require authentication.
* Verified the API client now:

  * Reads the stored token from SecureStore.
  * Adds `Authorization: Bearer <token>` when a token exists.
  * Preserves existing headers including `Content-Type`.
  * Continues to work for requests when no token is stored.

---

## 📸 Screenshots / Demos

N/A (service-layer change with no UI modifications)

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

Modified file:

* `mobile/src/services/api.ts`

Implementation details:

* Added SecureStore token retrieval to the shared API client.
* Automatically injects the JWT into request headers.
* Uses safe header precedence so explicitly supplied headers can override defaults when necessary.
* No backend authentication logic was changed.