### PR TITLE
fix(#640): add public batch tracking endpoint

### DIFF
--- a/backend/routes/batchRoutes.js
+++ b/backend/routes/batchRoutes.js
@@ -31,6 +31,33 @@ router.post('/', batchLimiter, protect, authorizeRoles('farmer'), validateReques
     }
 });
 
+// GET public batch tracking data - no authentication required
+router.get('/public/:batchId', batchLimiter, async (req, res) => {
+    try {
+        const { batchId } = req.params;
+        const result = await batchService.getPublicBatch(batchId);
+
+        if (!result.success) {
+            if (result.statusCode === 404) {
+                logger.warn('Public batch not found', { batchId, ip: req.ip });
+                const response = apiResponse.notFoundResponse('Batch', `ID: ${batchId}`);
+                return res.status(404).json(response);
+            }
+
+            const response = apiResponse.errorResponse(result.error, 'INVALID_BATCH_ID', result.statusCode || 400);
+            return res.status(response.statusCode).json(response);
+        }
+
+        const response = apiResponse.successResponse({ batch: result.batch }, 'Public batch tracking data retrieved successfully');
+        res.json(response);
+    } catch (error) {
+        notificationService.notifyError('public batch tracking fetch', error);
+        logger.error('Error fetching public batch tracking data', { error: error.message, stack: error.stack });
+        const response = apiResponse.errorResponse('Failed to fetch public batch tracking data', 'PUBLIC_BATCH_FETCH_ERROR', 500);
+        res.status(500).json(response);
+    }
+});
+
 // GET one batch - requires authentication
 router.get('/:batchId', batchLimiter, protect, async (req, res) => {
     try {

--- a/backend/server.js
+++ b/backend/server.js
@@ -392,6 +392,37 @@ app.post('/api/batches', batchLimiter, protect, authorizeRoles('farmer'), valida
     }
 });
 
+// GET public batch tracking data - no authentication required
+app.get('/api/batches/public/:batchId', batchLimiter, async (req, res) => {
+    try {
+        const { batchId } = req.params;
+        const result = await batchService.getPublicBatch(batchId);
+
+        if (!result.success) {
+            if (result.statusCode === 404) {
+                logger.warn('Public batch not found', { batchId, ip: req.ip });
+                const response = apiResponse.notFoundResponse('Batch', `ID: ${batchId}`);
+                return res.status(404).json(response);
+            }
+
+            const response = apiResponse.errorResponse(result.error, 'INVALID_BATCH_ID', result.statusCode || 400);
+            return res.status(response.statusCode).json(response);
+        }
+
+        const response = apiResponse.successResponse({ batch: result.batch }, 'Public batch tracking data retrieved successfully');
+        res.json(response);
+    } catch (error) {
+        notificationService.notifyError('public batch tracking fetch', error);
+        logger.error('Error fetching public batch tracking data', { error: error.message, stack: error.stack });
+        const response = apiResponse.errorResponse(
+            'Failed to fetch public batch tracking data',
+            'PUBLIC_BATCH_FETCH_ERROR',
+            500
+        );
+        res.status(500).json(response);
+    }
+});
+
 // GET one batch - requires authentication
 app.get('/api/batches/:batchId', batchLimiter, protect, async (req, res) => {
     try {

--- a/backend/services/batchService.js
+++ b/backend/services/batchService.js
@@ -218,6 +218,89 @@ class BatchService {
         }
     }
 
+    sanitizeBatchId(batchId) {
+        const sanitizedId = typeof batchId === 'string' ? batchId.trim() : '';
+        if (!sanitizedId || sanitizedId.length > 100 || !/^[A-Za-z0-9_-]+$/.test(sanitizedId)) {
+            return null;
+        }
+        return sanitizedId;
+    }
+
+    toPublicBatch(batch) {
+        const batchData = typeof batch.toJSON === 'function' ? batch.toJSON() : batch;
+        const iotData = batchData.iotData || {};
+
+        return {
+            batchId: batchData.batchId,
+            farmerName: batchData.farmerName,
+            cropType: batchData.cropType,
+            quantity: batchData.quantity,
+            harvestDate: batchData.harvestDate,
+            origin: batchData.origin,
+            certifications: batchData.certifications,
+            description: batchData.description,
+            createdAt: batchData.createdAt,
+            currentStage: batchData.currentStage,
+            status: batchData.status,
+            isRecalled: batchData.isRecalled,
+            updates: (batchData.updates || []).map(update => ({
+                stage: update.stage,
+                actor: update.actor,
+                location: update.location,
+                timestamp: update.timestamp
+            })),
+            qrCode: batchData.qrCode,
+            isSpoiled: batchData.isSpoiled ?? iotData.isSpoiled,
+            currentTemperature: batchData.currentTemperature ?? iotData.currentTemperature,
+            currentHumidity: batchData.currentHumidity ?? iotData.currentHumidity,
+            iotTimestamp: batchData.iotTimestamp ?? iotData.lastUpdated,
+            spoilageRisk: batchData.spoilageRisk ? {
+                riskLevel: batchData.spoilageRisk.riskLevel,
+                riskScore: batchData.spoilageRisk.riskScore,
+                factors: batchData.spoilageRisk.factors || [],
+                predictedAt: batchData.spoilageRisk.predictedAt
+            } : undefined
+        };
+    }
+
+    /**
+     * Get safe public tracking data for a batch.
+     * @param {string} batchId - Batch identifier
+     * @returns {Object} - Result with public batch data or error
+     */
+    async getPublicBatch(batchId) {
+        const sanitizedId = this.sanitizeBatchId(batchId);
+
+        if (!sanitizedId) {
+            return {
+                success: false,
+                error: 'Invalid batch ID',
+                statusCode: 400
+            };
+        }
+
+        try {
+            const batch = await Batch.findOne({ batchId: sanitizedId });
+
+            if (!batch) {
+                return {
+                    success: false,
+                    error: 'Batch not found',
+                    statusCode: 404
+                };
+            }
+
+            return {
+                success: true,
+                batch: this.toPublicBatch(batch),
+                message: 'Public batch tracking data retrieved successfully'
+            };
+        } catch (error) {
+            logger.error('Error fetching public batch:', error);
+            throw error;
+        }
+    }
+
     /**
      * Update a batch's stage
      * @param {string} batchId - Batch identifier

--- a/backend/tests/batch.test.js
+++ b/backend/tests/batch.test.js
@@ -96,9 +96,13 @@ jest.mock('mongoose', () => {
 jest.mock('../models/Counter', () => mockCounter);
 jest.mock('../models/Batch', () => mockBatch);
 jest.mock('../models/User', () => mockUser);
+jest.mock('../utils/shutdown', () => ({
+  gracefulShutdown: jest.fn()
+}));
 
 const app = require("../server");
 const mongoose = require("mongoose");
+const { protect } = require('../middleware/auth');
 
 describe("Batch API Endpoints", () => {
   beforeEach(() => {
@@ -141,6 +145,109 @@ describe("Batch API Endpoints", () => {
     expect(res.body.data).toBeDefined();
     expect(res.body.data.batch).toBeDefined();
     expect(res.body.data.batch).toHaveProperty("batchId");
+  });
+
+  it("should return safe public tracking data without authentication", async () => {
+    mockBatch.findOne.mockResolvedValue({
+      toJSON: () => ({
+        _id: 'mongo-internal-id',
+        batchId: 'BATCH000001',
+        farmerId: 'FARM123',
+        farmerName: 'Test Farmer',
+        farmerAddress: '123 Private Farm Lane',
+        farmerWalletAddress: '0xprivatewallet',
+        cropType: 'rice',
+        quantity: 50,
+        harvestDate: '2024-01-01T00:00:00.000Z',
+        origin: 'Test Origin',
+        certifications: 'Organic',
+        description: 'Good rice',
+        createdAt: '2024-01-02T00:00:00.000Z',
+        currentStage: 'farmer',
+        status: 'Active',
+        isRecalled: false,
+        qrCode: 'data:image/png;base64,qr',
+        blockchainHash: '0xprivatehash',
+        syncStatus: 'pending',
+        pendingApprovalId: 'approval-1',
+        approvalHistory: [{ requestId: 'approval-1' }],
+        updates: [{
+          _id: 'update-internal-id',
+          stage: 'farmer',
+          actor: 'Test Farmer',
+          location: 'Test Origin',
+          timestamp: '2024-01-01T00:00:00.000Z',
+          notes: 'Initial harvest recorded'
+        }],
+        currentTemperature: 72,
+        currentHumidity: 65,
+        isSpoiled: false,
+        iotTimestamp: '2024-01-03T00:00:00.000Z',
+        spoilageRisk: {
+          riskLevel: 'Low',
+          riskScore: 10,
+          factors: ['stable temperature'],
+          predictedAt: '2024-01-03T00:00:00.000Z'
+        }
+      })
+    });
+
+    const res = await request(app).get('/api/batches/public/BATCH000001');
+
+    expect(res.statusCode).toEqual(200);
+    expect(protect).not.toHaveBeenCalled();
+    expect(mockBatch.findOne).toHaveBeenCalledWith({ batchId: 'BATCH000001' });
+    expect(res.body.data.batch).toMatchObject({
+      batchId: 'BATCH000001',
+      farmerName: 'Test Farmer',
+      cropType: 'rice',
+      quantity: 50,
+      origin: 'Test Origin',
+      currentStage: 'farmer',
+      status: 'Active',
+      qrCode: 'data:image/png;base64,qr'
+    });
+    expect(res.body.data.batch).not.toHaveProperty('_id');
+    expect(res.body.data.batch).not.toHaveProperty('farmerId');
+    expect(res.body.data.batch).not.toHaveProperty('farmerAddress');
+    expect(res.body.data.batch).not.toHaveProperty('farmerWalletAddress');
+    expect(res.body.data.batch).not.toHaveProperty('blockchainHash');
+    expect(res.body.data.batch).not.toHaveProperty('syncStatus');
+    expect(res.body.data.batch).not.toHaveProperty('pendingApprovalId');
+    expect(res.body.data.batch).not.toHaveProperty('approvalHistory');
+    expect(res.body.data.batch.updates[0]).not.toHaveProperty('_id');
+    expect(res.body.data.batch.updates[0]).not.toHaveProperty('notes');
+  });
+
+  it("should return 404 for a missing public tracking batch", async () => {
+    mockBatch.findOne.mockResolvedValue(null);
+
+    const res = await request(app).get('/api/batches/public/MISSING001');
+
+    expect(res.statusCode).toEqual(404);
+    expect(protect).not.toHaveBeenCalled();
+  });
+
+  it("should return 400 for an invalid public tracking batch ID", async () => {
+    const res = await request(app).get('/api/batches/public/%20');
+
+    expect(res.statusCode).toEqual(400);
+    expect(mockBatch.findOne).not.toHaveBeenCalled();
+    expect(protect).not.toHaveBeenCalled();
+  });
+
+  it("should keep the existing batch detail route protected", async () => {
+    mockBatch.findOne.mockResolvedValue({
+      batchId: 'BATCH000001',
+      currentStage: 'farmer',
+      isRecalled: false,
+      updates: []
+    });
+
+    const res = await request(app).get('/api/batches/BATCH000001');
+
+    expect(res.statusCode).toEqual(200);
+    expect(protect).toHaveBeenCalled();
   });
 
   it("should allow a valid stage transition (farmer -> mandi)", async () => {

--- a/frontend/src/app/track-batch/__tests__/page.test.tsx
+++ b/frontend/src/app/track-batch/__tests__/page.test.tsx
@@ -17,8 +17,8 @@ const mockBatchData = {
   qrCode: '/qr/batch-001.png',
 };
 
-const { mockGetBatch, mockUseBatchSocket, mockPush } = vi.hoisted(() => ({
-  mockGetBatch: vi.fn(),
+const { mockGetPublicBatch, mockUseBatchSocket, mockPush } = vi.hoisted(() => ({
+  mockGetPublicBatch: vi.fn(),
   mockUseBatchSocket: vi.fn().mockReturnValue({ isConnected: false, lastUpdate: null }),
   mockPush: vi.fn(),
 }));
@@ -29,7 +29,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('../../../services/realCropBatchService', () => ({
-  realCropBatchService: { getBatch: mockGetBatch },
+  realCropBatchService: { getPublicBatch: mockGetPublicBatch },
 }));
 
 vi.mock('../../../hooks/useBatchSocket', () => ({
@@ -56,7 +56,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('shows searching state while searching', async () => {
-    mockGetBatch.mockImplementation(() => new Promise(() => {}));
+    mockGetPublicBatch.mockImplementation(() => new Promise(() => {}));
     const user = userEvent.setup();
     renderTrackBatch();
     const input = screen.getByPlaceholderText(/Enter Batch ID/);
@@ -68,7 +68,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('displays batch details on successful search', async () => {
-    mockGetBatch.mockResolvedValue(mockBatchData);
+    mockGetPublicBatch.mockResolvedValue(mockBatchData);
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'BATCH-001');
@@ -83,7 +83,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('displays IoT sensor data when available', async () => {
-    mockGetBatch.mockResolvedValue(mockBatchData);
+    mockGetPublicBatch.mockResolvedValue(mockBatchData);
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'BATCH-001');
@@ -95,7 +95,7 @@ describe('TrackBatch Page', () => {
 
   it('shows spoilage alert when batch is spoiled', async () => {
     const spoiledBatch = { ...mockBatchData, isSpoiled: true, currentTemperature: 95 };
-    mockGetBatch.mockResolvedValue(spoiledBatch);
+    mockGetPublicBatch.mockResolvedValue(spoiledBatch);
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'BATCH-001');
@@ -106,7 +106,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('shows EmptyState when batch is not found', async () => {
-    mockGetBatch.mockRejectedValue(new Error('not found'));
+    mockGetPublicBatch.mockRejectedValue(new Error('not found'));
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'INVALID-001');
@@ -117,7 +117,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('shows ErrorState on search error', async () => {
-    mockGetBatch.mockRejectedValue(new Error('Network error'));
+    mockGetPublicBatch.mockRejectedValue(new Error('Network error'));
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'BATCH-001');
@@ -128,8 +128,8 @@ describe('TrackBatch Page', () => {
   });
 
   it('allows retry from ErrorState', async () => {
-    mockGetBatch.mockRejectedValueOnce(new Error('Network error'));
-    mockGetBatch.mockResolvedValueOnce(mockBatchData);
+    mockGetPublicBatch.mockRejectedValueOnce(new Error('Network error'));
+    mockGetPublicBatch.mockResolvedValueOnce(mockBatchData);
     const user = userEvent.setup();
     renderTrackBatch();
     await user.type(screen.getByPlaceholderText(/Enter Batch ID/), 'BATCH-001');
@@ -144,7 +144,7 @@ describe('TrackBatch Page', () => {
   });
 
   it('shows LIVE indicator when WebSocket is connected', async () => {
-    mockGetBatch.mockResolvedValue(mockBatchData);
+    mockGetPublicBatch.mockResolvedValue(mockBatchData);
     mockUseBatchSocket.mockReturnValue({ isConnected: true, lastUpdate: new Date() });
     const user = userEvent.setup();
     renderTrackBatch();
@@ -159,6 +159,6 @@ describe('TrackBatch Page', () => {
     const user = userEvent.setup();
     renderTrackBatch();
     await user.click(screen.getByText('Track'));
-    expect(mockGetBatch).not.toHaveBeenCalled();
+    expect(mockGetPublicBatch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/track-batch/page.tsx
+++ b/frontend/src/app/track-batch/page.tsx
@@ -40,7 +40,7 @@ const TrackBatch: React.FC = () => {
     setErrorType(null);
 
     try {
-      const result = await realCropBatchService.getBatch(batchId);
+      const result = await realCropBatchService.getPublicBatch(batchId);
       setBatch(result);
     } catch (error: any) {
       console.error('Batch error:', error);

--- a/frontend/src/services/realCropBatchService.ts
+++ b/frontend/src/services/realCropBatchService.ts
@@ -51,6 +51,12 @@ export const realCropBatchService = {
     return response.data.data.batch;
   },
 
+  getPublicBatch: async (batchId: string): Promise<BatchData> => {
+    const sanitizedId = sanitizeString(batchId);
+    const response = await apiClient.get(`/batches/public/${sanitizedId}`);
+    return response.data.data.batch;
+  },
+
   updateBatch: async (batchId: string, updateData: Partial<BatchData>): Promise<BatchData> => {
     const sanitizedId = sanitizeString(batchId);
     const response = await apiClient.put(`/batches/${sanitizedId}`, updateData);


### PR DESCRIPTION
## 📌 Overview

This PR fixes the public batch tracking flow by introducing a dedicated public tracking endpoint that does not require authentication.

### Changes Made

* Added a new public endpoint: `GET /api/batches/public/:batchId`
* Kept the existing `GET /api/batches/:batchId` route protected with authentication
* Added batch ID sanitization and validation for public requests
* Implemented a public-safe batch response that excludes sensitive/internal fields
* Updated the Track Batch page to use the new public endpoint
* Added backend tests covering:

  * Public access without authentication
  * Missing batch handling (404)
  * Invalid batch ID validation (400)
  * Verification that the protected batch detail route remains protected
* Ensured public timeline entries do not expose internal notes

## 🛠️ Type of Change

* [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #640

---

## 🧪 Testing & Verification

* [x] **Smart Contracts:** NA
* [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Frontend dependencies not available locally)
* [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Not applicable)

### Test Results

```bash
npx.cmd jest tests/batch.test.js --runInBand --watchAll=false -t "public tracking|existing batch detail"
```

**Result:** Passed (4 tests)

---

## 📸 Screenshots / Demos

N/A – Backend/API functionality change.

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

The public endpoint returns only consumer-facing tracking information and intentionally excludes sensitive/internal fields such as internal IDs, wallet information, approval metadata, and private timeline notes. Existing authenticated batch management flows remain unchanged.

This should fit the repository's PR template and clearly show the security considerations behind the change.