### PR TITLE
fix(#638): correct self-outbid balance deduction

### DIFF
--- a/backend/services/socketService.js
+++ b/backend/services/socketService.js
@@ -100,10 +100,6 @@ function initializeSocketIO(httpServer) {
             return socket.emit('bid_error', { message: 'User not found' });
           }
 
-          if (user.balance < bidAmount) {
-            return socket.emit('bid_error', { message: `Insufficient funds. Your balance is ${user.balance} credits.` });
-          }
-
           // 2. Fetch auction to verify state
           const auction = await Auction.findById(auctionId);
           if (!auction) {
@@ -126,6 +122,12 @@ function initializeSocketIO(httpServer) {
           // Optimistic locking approach using conditions
           const previousHighestBidder = auction.highestBidder;
           const previousHighestBid = auction.currentHighestBid;
+          const isSelfOutbid = previousHighestBidder && previousHighestBidder.toString() === bidderId;
+          const amountToDeduct = isSelfOutbid ? bidAmount - previousHighestBid : bidAmount;
+
+          if (user.balance < amountToDeduct) {
+            return socket.emit('bid_error', { message: `Insufficient funds. Your balance is ${user.balance} credits.` });
+          }
 
           const updatedAuction = await Auction.findOneAndUpdate(
             {
@@ -148,14 +150,15 @@ function initializeSocketIO(httpServer) {
           }
 
           // 4. Refund previous highest bidder (if any) and deduct new highest bidder's balance
-          if (previousHighestBidder) {
+          if (previousHighestBidder && !isSelfOutbid) {
             await User.findByIdAndUpdate(previousHighestBidder, {
               $inc: { balance: previousHighestBid }
             });
           }
 
-          user.balance -= bidAmount;
-          await user.save();
+          await User.findByIdAndUpdate(bidderId, {
+            $inc: { balance: -amountToDeduct }
+          });
 
           // 5. Create new Bid record
           const newBid = new Bid({

--- a/backend/tests/socket.test.js
+++ b/backend/tests/socket.test.js
@@ -2,6 +2,25 @@ process.env.JWT_SECRET = 'test_secret_key_for_jwt';
 
 const jwt = require('jsonwebtoken');
 
+const mockAuction = {
+  findById: jest.fn(),
+  findOneAndUpdate: jest.fn()
+};
+
+const mockUser = {
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn()
+};
+
+const mockBidSave = jest.fn();
+const mockBid = jest.fn().mockImplementation(() => ({
+  save: mockBidSave
+}));
+
+jest.mock('../models/Auction', () => mockAuction);
+jest.mock('../models/User', () => mockUser);
+jest.mock('../models/Bid', () => mockBid);
+
 jest.mock('socket.io', () => {
   const useCallback = jest.fn();
   const onCallback = jest.fn();
@@ -42,9 +61,11 @@ describe('Socket.IO Service', () => {
         auth: {},
         headers: {},
       },
+      user: undefined,
       join: jest.fn(),
       leave: jest.fn(),
       on: jest.fn(),
+      emit: jest.fn(),
     };
     mockNext = jest.fn();
   });
@@ -157,6 +178,149 @@ describe('Socket.IO Service', () => {
       socketService.emitToBatchRoom('BATCH001', 'batch:created', eventData);
 
       expect(mockIo.to).toHaveBeenCalledWith('batch:BATCH001');
+    });
+  });
+
+  describe('Auction Bidding', () => {
+    let mockIo;
+    let placeBidHandler;
+
+    beforeEach(() => {
+      const { Server } = require('socket.io');
+      socketService.initializeSocketIO({});
+      mockIo = Server.mockIo;
+
+      const connectionHandler = Server.onCallback.mock.calls.find(([eventName]) => eventName === 'connection')[1];
+      mockSocket.user = { id: 'user-a', name: 'User A' };
+      connectionHandler(mockSocket);
+      placeBidHandler = mockSocket.on.mock.calls.find(([eventName]) => eventName === 'place_bid')[1];
+
+      mockAuction.findById.mockReset();
+      mockAuction.findOneAndUpdate.mockReset();
+      mockUser.findById.mockReset();
+      mockUser.findByIdAndUpdate.mockReset();
+      mockBid.mockClear();
+      mockBidSave.mockReset();
+      mockBidSave.mockResolvedValue({});
+    });
+
+    test('charges only the bid difference when the highest bidder raises their own bid', async () => {
+      const balances = { 'user-a': 1000 };
+      const auctionState = {
+        _id: 'auction-1',
+        farmerId: { toString: () => 'farmer-1' },
+        batchId: 'BATCH001',
+        status: 'active',
+        endTime: new Date(Date.now() + 60000),
+        currentHighestBid: 0,
+        highestBidder: null
+      };
+
+      let findUserCallCount = 0;
+      mockUser.findById.mockImplementation((userId) => {
+        findUserCallCount += 1;
+        if (userId === 'user-a' && findUserCallCount % 2 === 1) {
+          return Promise.resolve({ _id: 'user-a', name: 'User A', balance: balances['user-a'] });
+        }
+
+        return {
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue({ name: 'User A' })
+          })
+        };
+      });
+      mockUser.findByIdAndUpdate.mockImplementation((userId, update) => {
+        balances[userId] += update.$inc.balance;
+        return Promise.resolve({ _id: userId, balance: balances[userId] });
+      });
+      mockAuction.findById.mockImplementation(() => Promise.resolve({
+        ...auctionState,
+        highestBidder: auctionState.highestBidder
+          ? { toString: () => auctionState.highestBidder }
+          : null
+      }));
+      mockAuction.findOneAndUpdate.mockImplementation((_query, update) => {
+        auctionState.currentHighestBid = update.$set.currentHighestBid;
+        auctionState.highestBidder = update.$set.highestBidder;
+
+        return Promise.resolve({
+          ...auctionState,
+          toObject: () => ({ ...auctionState })
+        });
+      });
+
+      await placeBidHandler({ auctionId: 'auction-1', bidAmount: 100 });
+      await placeBidHandler({ auctionId: 'auction-1', bidAmount: 150 });
+
+      expect(balances['user-a']).toBe(850);
+      expect(auctionState.currentHighestBid).toBe(150);
+      expect(auctionState.highestBidder).toBe('user-a');
+      expect(mockUser.findByIdAndUpdate).toHaveBeenNthCalledWith(1, 'user-a', {
+        $inc: { balance: -100 }
+      });
+      expect(mockUser.findByIdAndUpdate).toHaveBeenNthCalledWith(2, 'user-a', {
+        $inc: { balance: -50 }
+      });
+      expect(mockAuction.findOneAndUpdate).toHaveBeenLastCalledWith(
+        expect.any(Object),
+        { $set: { currentHighestBid: 150, highestBidder: 'user-a' } },
+        { new: true }
+      );
+      expect(mockBid).toHaveBeenCalledWith(expect.objectContaining({
+        auctionId: 'auction-1',
+        userId: 'user-a',
+        bidAmount: 150
+      }));
+      expect(mockIo.to).toHaveBeenCalledWith('auction:auction-1');
+      expect(mockSocket.emit).not.toHaveBeenCalledWith('bid_error', expect.any(Object));
+    });
+
+    test('refunds the previous highest bidder and charges the full bid for a normal outbid', async () => {
+      mockSocket.user = { id: 'user-b', name: 'User B' };
+      mockUser.findById
+        .mockResolvedValueOnce({ _id: 'user-b', name: 'User B', balance: 1000 })
+        .mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            lean: jest.fn().mockResolvedValue({ name: 'User B' })
+          })
+        });
+      mockUser.findByIdAndUpdate.mockResolvedValue({});
+
+      mockAuction.findById.mockResolvedValue({
+        _id: 'auction-1',
+        farmerId: { toString: () => 'farmer-1' },
+        batchId: 'BATCH001',
+        status: 'active',
+        endTime: new Date(Date.now() + 60000),
+        currentHighestBid: 100,
+        highestBidder: { toString: () => 'user-a' }
+      });
+
+      mockAuction.findOneAndUpdate.mockResolvedValue({
+        _id: 'auction-1',
+        currentHighestBid: 150,
+        highestBidder: 'user-b',
+        toObject: () => ({
+          _id: 'auction-1',
+          currentHighestBid: 150,
+          highestBidder: 'user-b'
+        })
+      });
+
+      await placeBidHandler({ auctionId: 'auction-1', bidAmount: 150 });
+
+      expect(mockUser.findByIdAndUpdate).toHaveBeenNthCalledWith(1, expect.any(Object), {
+        $inc: { balance: 100 }
+      });
+      expect(mockUser.findByIdAndUpdate).toHaveBeenNthCalledWith(2, 'user-b', {
+        $inc: { balance: -150 }
+      });
+      expect(mockAuction.findOneAndUpdate).toHaveBeenCalledWith(
+        expect.any(Object),
+        { $set: { currentHighestBid: 150, highestBidder: 'user-b' } },
+        { new: true }
+      );
+      expect(mockSocket.emit).not.toHaveBeenCalledWith('bid_error', expect.any(Object));
     });
   });
 });


### PR DESCRIPTION
## 📌 Overview

Fixed a balance calculation bug in the auction bidding flow when the current highest bidder raises their own bid.

Previously, the handler refunded the previous bid using an atomic database update and then deducted the full new bid from a stale in-memory user document. In self-outbid scenarios, this could overwrite the refund and overcharge the bidder.

The fix:

* Deducts only the bid difference for self-outbids.
* Preserves the existing behavior for normal outbids.
* Replaces stale document balance updates with atomic `$inc` operations.
* Adds regression tests covering the self-outbid balance scenario.

## 🛠️ Type of Change

* [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
* [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [ ] 📄 **Documentation** (README, Roadmap updates)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #638

---

## 🧪 Testing & Verification

* [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)

  * NA
* [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)

  * NA
* [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

  * NA

Validation performed:

```bash
npx.cmd jest tests/socket.test.js --runInBand --watchAll=false
```

Result: ✅ Passed (8 tests)

Additional verification:

```bash
npx.cmd jest tests/socket.test.js tests/auction.test.js tests/auctionSettlement.test.js --runInBand --watchAll=false
```

* ✅ `socket.test.js` passed
* ✅ `auctionSettlement.test.js` passed
* ⚠️ `auction.test.js` is currently blocked by an unrelated existing missing import:
  `../services/notificationQueue` from `backend/utils/shutdown.js`

---

## 📸 Screenshots / Demos

N/A (Backend-only change)

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

Files modified:

* `backend/services/socketService.js`
* `backend/tests/socket.test.js`

A regression test was added to ensure self-outbids only deduct the bid difference and do not overwrite refunded balances through stale document saves.