### PR TITLE
fix(#637): support batch tracking deep links

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -43,7 +43,7 @@ const generateBatchId = async (session) => {
 const generateQRCode = async (batchId) => {
     try {
         const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-        const trackingUrl = `${frontendUrl}/track/${batchId}`;
+        const trackingUrl = `${frontendUrl}/track-batch?id=${encodeURIComponent(batchId)}`;
         return await QRCode.toDataURL(trackingUrl, {
             width: 400,
             margin: 2,

--- a/backend/services/batchService.js
+++ b/backend/services/batchService.js
@@ -47,7 +47,7 @@ class BatchService {
     async generateQRCode(batchId) {
         try {
             const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-            const trackingUrl = `${frontendUrl}/track/${encodeURIComponent(batchId)}`;
+            const trackingUrl = `${frontendUrl}/track-batch?id=${encodeURIComponent(batchId)}`;
             return await QRCode.toDataURL(trackingUrl, {
                 width: 400,
                 margin: 2,

--- a/frontend/src/app/track-batch/__tests__/page.test.tsx
+++ b/frontend/src/app/track-batch/__tests__/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const mockBatchData = {
@@ -17,15 +17,16 @@ const mockBatchData = {
   qrCode: '/qr/batch-001.png',
 };
 
-const { mockGetBatch, mockUseBatchSocket, mockPush } = vi.hoisted(() => ({
+const { mockGetBatch, mockUseBatchSocket, mockPush, mockUseSearchParams } = vi.hoisted(() => ({
   mockGetBatch: vi.fn(),
   mockUseBatchSocket: vi.fn().mockReturnValue({ isConnected: false, lastUpdate: null }),
   mockPush: vi.fn(),
+  mockUseSearchParams: vi.fn(() => new URLSearchParams()),
 }));
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockUseSearchParams(),
 }));
 
 vi.mock('../../../services/realCropBatchService', () => ({
@@ -46,6 +47,7 @@ describe('TrackBatch Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseBatchSocket.mockReturnValue({ isConnected: false, lastUpdate: null });
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
   it('renders the search form', () => {
@@ -79,6 +81,19 @@ describe('TrackBatch Page', () => {
       expect(screen.getByText('John Farmer')).toBeInTheDocument();
       expect(screen.getByText('500 kg')).toBeInTheDocument();
       expect(screen.getByText('Punjab')).toBeInTheDocument();
+    });
+  });
+
+  it('automatically searches when batch ID is provided in query params', async () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams('id=BATCH-001'));
+    mockGetBatch.mockResolvedValue(mockBatchData);
+
+    renderTrackBatch();
+
+    await waitFor(() => {
+      expect(mockGetBatch).toHaveBeenCalledWith('BATCH-001');
+      expect(screen.getByDisplayValue('BATCH-001')).toBeInTheDocument();
+      expect(screen.getByText('BATCH-001')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/track-batch/page.tsx
+++ b/frontend/src/app/track-batch/page.tsx
@@ -1,6 +1,7 @@
 "use client";
-import React, { useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
+import { useSearchParams } from 'next/navigation';
 import { Search, Package, ArrowRight, Thermometer, AlertTriangle, CheckCircle, Wifi, AlertOctagon, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { realCropBatchService } from '../../services/realCropBatchService';
@@ -11,11 +12,13 @@ import { TrackBatchSkeleton } from '../../components/skeletons';
 import { useBatchSocket } from '../../hooks/useBatchSocket';
 import { JourneyPreview } from '../../components/journey/JourneyPreview';
 
-const TrackBatch: React.FC = () => {
+const TrackBatchContent: React.FC = () => {
+  const searchParams = useSearchParams();
   const [batchId, setBatchId] = useState('');
   const [batch, setBatch] = useState<any>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [errorType, setErrorType] = useState<'not-found' | 'error' | null>(null);
+  const lastAutoSearchedId = useRef<string | null>(null);
 
   const { t } = useTranslation();
 
@@ -31,16 +34,16 @@ const TrackBatch: React.FC = () => {
     }
   });
 
-  const handleSearch = async (e?: React.FormEvent<HTMLFormElement>) => {
-    if (e) e.preventDefault();
-    if (!batchId.trim()) return;
+  const searchBatch = useCallback(async (id: string) => {
+    const trimmedId = id.trim();
+    if (!trimmedId) return;
 
     setIsSearching(true);
     setBatch(null);
     setErrorType(null);
 
     try {
-      const result = await realCropBatchService.getBatch(batchId);
+      const result = await realCropBatchService.getBatch(trimmedId);
       setBatch(result);
     } catch (error: any) {
       console.error('Batch error:', error);
@@ -53,6 +56,20 @@ const TrackBatch: React.FC = () => {
     } finally {
       setIsSearching(false);
     }
+  }, []);
+
+  useEffect(() => {
+    const queryBatchId = searchParams.get('id')?.trim();
+    if (!queryBatchId || lastAutoSearchedId.current === queryBatchId) return;
+
+    lastAutoSearchedId.current = queryBatchId;
+    setBatchId(queryBatchId);
+    searchBatch(queryBatchId);
+  }, [searchBatch, searchParams]);
+
+  const handleSearch = async (e?: React.FormEvent<HTMLFormElement>) => {
+    if (e) e.preventDefault();
+    await searchBatch(batchId);
   };
 
   const getTimelineEvents = (batchData: any) => {
@@ -329,5 +346,11 @@ const TrackBatch: React.FC = () => {
     </div>
   );
 };
+
+const TrackBatch: React.FC = () => (
+  <Suspense fallback={null}>
+    <TrackBatchContent />
+  </Suspense>
+);
 
 export default TrackBatch;


### PR DESCRIPTION
## 📌 Overview

This PR fixes broken batch tracking deep links by unifying tracking URLs across the application.

### Changes Made

* Updated the Track Batch page to read the `id` query parameter from `/track-batch?id=<batchId>`.
* Automatically pre-fills and loads the batch when a valid batch ID is provided in the URL.
* Preserved the existing manual batch search workflow.
* Updated QR code generation to use `/track-batch?id=<batchId>` instead of the non-existent `/track/<batchId>` route.
* Added test coverage for automatic batch loading from query parameters.

## 🛠️ Type of Change

* [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
* [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [ ] 📄 **Documentation** (README, Roadmap updates)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #637

---

## 🧪 Testing & Verification

* [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA) → NA
* [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes)
* [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA) → NA

Additional validation:

* Passed track-batch page tests (11 tests).
* ESLint passed for modified frontend files.
* Frontend build completed successfully.

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

A repository lint script issue was observed where `next lint` is treated as an invalid project directory by the installed Next.js CLI. This is unrelated to the changes in this PR. Modified files passed targeted ESLint checks successfully.