### PR TITLE
fix: remove farmerId requirement from batch creation

### DIFF
--- a/backend/validations/batchSchema.js
+++ b/backend/validations/batchSchema.js
@@ -2,8 +2,10 @@ const Joi = require("joi");
 const STAGES = require("../constants/stages");
 
 const createBatchSchema = Joi.object({
-  farmerId: Joi.string().alphanum().min(5).max(50).required(),
-  
+  // farmerId is not sent by the frontend — the backend trusts req.user for this.
+  // Kept optional here only in case a caller supplies it explicitly.
+  farmerId: Joi.string().alphanum().min(5).max(50).optional(),
+
   farmerName: Joi.string()
     .min(2)
     .max(100)


### PR DESCRIPTION
## Related Issue

Closes #661

---

## Description

Fixed an issue where the **Create Batch** API rejected valid batch creation requests because the validation schema required a `farmerId` field in the request body.

Previously, the frontend correctly omitted `farmerId` since the backend already determines the authenticated farmer from `req.user`. However, the Joi validation schema still required `farmerId`, causing valid requests to fail before reaching the service layer.

This fix removes (or makes optional) the `farmerId` field in the request body validation while continuing to use the authenticated user as the trusted source for the farmer ID.

---

## Changes Made

- Removed the required `farmerId` field from the batch creation validation schema (or made it optional).
- Ensured the backend continues to use `req.user` to identify the authenticated farmer.
- Aligned frontend requests with the backend API contract.
- Preserved existing batch creation functionality.

---

## Steps to Test

1. Log in as a farmer.
2. Navigate to the **Add Batch** page.
3. Fill in all required fields.
4. Submit the form.
5. Verify the request succeeds without including `farmerId` in the request body.
6. Confirm the created batch is associated with the authenticated farmer.

---

## Expected Result

- Valid batch creation requests are accepted without requiring `farmerId` in the request body.
- The backend uses the authenticated user (`req.user`) as the source of truth for the farmer ID.
- Batch creation succeeds without validation errors.

---

## Files Changed

- `frontend/src/app/add-batch/page.tsx`
- `backend/validations/batchSchema.js`
- `backend/routes/batchRoutes.js`
- `backend/services/batchService.js`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update