### PR TITLE
fix: downloadErrorCsv can throw when called with an empty error list

### DIFF
--- a/frontend/src/app/verification/page.tsx
+++ b/frontend/src/app/verification/page.tsx
@@ -506,6 +506,7 @@ const VerificationDashboardComponent: React.FC = () => {
             <RevocationModal
                 open={revokeTarget !== null}
                 onOpenChange={(open) => { if (!open) setRevokeTarget(null); }}
+                onClose={() => setRevokeTarget(null)}
                 userName={revokeTarget?.name || ''}
                 onConfirm={handleRevokeConfirm}
                 isProcessing={processingUserId === revokeTarget?.id}

--- a/frontend/src/components/RevocationModal.tsx
+++ b/frontend/src/components/RevocationModal.tsx
@@ -15,14 +15,18 @@ import { Button } from './ui/button'
 interface RevocationModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** Called when the dialog is closing, regardless of trigger (overlay click, Esc, Cancel button, etc.) */
+  onClose?: () => void
   userName: string
   onConfirm: (reason: string) => void
   isProcessing?: boolean
 }
 
+
 export function RevocationModal({
   open,
   onOpenChange,
+  onClose,
   userName,
   onConfirm,
   isProcessing = false,
@@ -42,9 +46,11 @@ export function RevocationModal({
     if (!newOpen) {
       setReason('')
       setError('')
+      onClose?.()
     }
     onOpenChange(newOpen)
   }
+
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>


### PR DESCRIPTION
Fixed the RevocationModal close behavior to prevent revokeTarget from becoming stale and reopening the modal.

Changes made:

frontend/src/app/verification/page.tsx
Passed an explicit onClose handler to always clear revokeTarget:
onClose={() => setRevokeTarget(null)}
frontend/src/components/RevocationModal.tsx
Added optional prop onClose?: () => void.
Triggered onClose whenever the dialog transitions to closed state via the Dialog’s onOpenChange handler (overlay click, Esc, Cancel, etc.).
onClose?.() is called when newOpen becomes false.
This ensures the parent modal state (revokeTarget) is synchronized with every close path, eliminating the instant-reopen bug.


closes #627