### PR TITLE
Stale rowStatuses are never cleared when the component unmounts

### DIFF
--- a/frontend/src/app/verification/page.tsx
+++ b/frontend/src/app/verification/page.tsx
@@ -129,6 +129,16 @@ const VerificationDashboardComponent: React.FC = () => {
         ];
     }, [unverifiedUsers, verifiedUsers]);
 
+    // Reset rowStatuses on unmount (prevents stale badges on later mounts)
+    useEffect(() => {
+        return () => {
+            setRowStatuses({});
+        };
+    }, []);
+
+
+
+
     // Handle incoming socket status updates
     const handleVerificationSocketUpdate = useCallback((data: any) => {
         console.log('[SOCKET EVENT] Verification update:', data);
@@ -152,6 +162,7 @@ const VerificationDashboardComponent: React.FC = () => {
             }
         }
     }, [unverifiedUsers, verifiedUsers]);
+
 
     const { isConnected: socketConnected } = useVerificationSocket({
         userIds: allUserIds,


### PR DESCRIPTION
Implemented cleanup of the temporary UI state rowStatuses to prevent stale badges after navigation.

Change made:

File: frontend/src/app/verification/page.tsx
Added a useEffect cleanup that resets rowStatuses on component unmount:
useEffect(() => () => setRowStatuses({}), []);


closes #626