### PR TITLE
fix: useEffect for the verification socket re‑subscribes on every user‑list change

### DIFF
--- a/frontend/src/app/verification/page.tsx
+++ b/frontend/src/app/verification/page.tsx
@@ -121,15 +121,21 @@ const VerificationDashboardComponent: React.FC = () => {
         }
     };
 
-    // Memoize all active user IDs to join room subscriptions for
+    // Keep socket subscription IDs stable across directory refreshes.
+    // IDs are computed once per admin role session (not on every unverified/verified list change).
     const allUserIds = useMemo(() => {
+        if (user?.role !== 'admin') return [];
         return [
             ...unverifiedUsers.map(u => u._id),
             ...verifiedUsers.map(u => u._id)
         ];
-    }, [unverifiedUsers, verifiedUsers]);
+        // Intentionally NOT dependent on unverifiedUsers/verifiedUsers to prevent
+        // disconnect/reconnect on every directory refresh.
+    }, [user?.role]);
 
     // Handle incoming socket status updates
+
+
     const handleVerificationSocketUpdate = useCallback((data: any) => {
         console.log('[SOCKET EVENT] Verification update:', data);
         if (data?.userId && data?.newState) {


### PR DESCRIPTION
Implemented stable websocket subscription IDs to prevent verification socket re-subscribe/disconnect-reconnect on every unverified/verified list refresh.

Change made:

File: frontend/src/app/verification/page.tsx
Updated allUserIds to depend only on user?.role (admin/non-admin) so it no longer changes when unverifiedUsers / verifiedUsers are refreshed.
This keeps useVerificationSocket({ userIds: allUserIds, ... }) from tearing down and recreating the socket on every directory update.


closes #625