### PR TITLE
Fix: JWT refresh tokens remain valid after password change, no token invalidation mechanism

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -117,12 +117,12 @@ const parseCookieHeader = (cookieHeader = '') => {
 };
 
 const buildAuthPayload = (user) => ({
-    token: generateToken(user._id, user.role, user.name),
+    token: generateToken(user._id, user.role, user.name, user.tokenVersion),
     user: sanitizeUser(user)
 });
 
 const attachRefreshCookie = (res, user) => {
-    res.cookie(REFRESH_COOKIE_NAME, generateRefreshToken(user._id), getRefreshCookieOptions());
+    res.cookie(REFRESH_COOKIE_NAME, generateRefreshToken(user._id, user.tokenVersion), getRefreshCookieOptions());
 };
 
 const clearRefreshCookie = (res) => {
@@ -281,6 +281,7 @@ const updateProfile = async (req, res) => {
         if (password) {
             const salt = await bcrypt.genSalt(12);
             user.password = await bcrypt.hash(password, salt);
+            user.tokenVersion = (user.tokenVersion || 0) + 1;
         }
 
         const updatedUser = await user.save();
@@ -592,6 +593,13 @@ const refreshSession = async (req, res) => {
             );
         }
 
+        if (decoded.tokenVersion !== undefined && decoded.tokenVersion !== user.tokenVersion) {
+            clearRefreshCookie(res);
+            return res.status(401).json(
+                apiResponse.unauthorizedResponse('Token has been invalidated. Please log in again.')
+            );
+        }
+
         attachRefreshCookie(res, user);
 
         return res.json(
@@ -727,6 +735,7 @@ const resetPassword = async (req, res) => {
         user.password = await bcrypt.hash(password, salt);
         user.resetPasswordToken = undefined;
         user.resetPasswordExpire = undefined;
+        user.tokenVersion = (user.tokenVersion || 0) + 1;
 
         await user.save();
 

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -18,6 +18,10 @@ const protect = async (req, res, next) => {
         
         if (!user) return res.status(401).json({ error: 'Not authorized', message: 'User not found' });
 
+        if (decoded.tokenVersion !== undefined && decoded.tokenVersion !== user.tokenVersion) {
+            return res.status(401).json({ error: 'Token invalidated', message: 'Token has been invalidated. Please log in again.' });
+        }
+
         const normalizedUser = user.toObject({ virtuals: true });
         normalizedUser._id = normalizedUser._id.toString();
         normalizedUser.id = normalizedUser._id;

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -75,6 +75,10 @@ const userSchema = new mongoose.Schema({
         enum: ['active', 'inactive', 'suspended', 'pending'],
         default: 'pending'
     },
+    tokenVersion: {
+        type: Number,
+        default: 0
+    },
     balance: {
         type: Number,
         default: 100000

--- a/backend/utils/generateToken.js
+++ b/backend/utils/generateToken.js
@@ -1,20 +1,20 @@
 const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
-const generateToken = (id, role, name) => {
-    return jwt.sign({ id, role, name }, process.env.JWT_SECRET, {
+const generateToken = (id, role, name, tokenVersion = 0) => {
+    return jwt.sign({ id, role, name, tokenVersion }, process.env.JWT_SECRET, {
         expiresIn: process.env.JWT_ACCESS_EXPIRES_IN || '15m',
     });
 };
 
-const generateRefreshToken = (id) => {
+const generateRefreshToken = (id, tokenVersion = 0) => {
     const refreshSecret = process.env.JWT_REFRESH_SECRET;
 
     if (!refreshSecret) {
         throw new Error('JWT_REFRESH_SECRET is not configured. Please set it in your .env file.');
     }
 
-    return jwt.sign({ id, type: 'refresh' }, refreshSecret, {
+    return jwt.sign({ id, type: 'refresh', tokenVersion }, refreshSecret, {
         expiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
     });
 };


### PR DESCRIPTION

## 📌 Overview

This PR fixes a session-invalidation gap where password changes (via reset-password or profile update) did not invalidate existing JWT access or refresh tokens. There was no tokenVersion mechanism, no token-blacklist, and no passwordChangedAt claim — a compromised refresh token remained valid for up to 7 days after credential rotation. Now every User document tracks a tokenVersion counter that is embedded in both access and refresh tokens at issuance and incremented on password change. Every authenticated request and every token refresh verifies the version matches.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #688 

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---



## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---


