### PR TITLE
Fix: Smart Contract: batchListedQuantity reset on stage transition completely bypasses over-allocation prevention

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -297,8 +297,12 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // Clear approval after use
         nextCustodianApproval[batchId] = address(0);
 
-        // Reset batchListedQuantity to invalidate active ghost listings from previous custodian
-        batchListedQuantity[batchId] = 0;
+        // batchListedQuantity is intentionally NOT reset here. The tracker accumulates
+        // across custodian transitions so the over-allocation guard in createListing()
+        // always reflects the total quantity ever listed minus what has been sold.
+        // Resetting would let a new custodian re-list the full batch quantity while
+        // prior custodians' listings remain active, allowing total listed quantity
+        // to exceed the physical batch quantity.
 
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");


### PR DESCRIPTION

## 📌 Overview

This PR fixes an over-allocation vulnerability in CropChain.sol:301 where updateBatch() unconditionally reset batchListedQuantity[batchId] to zero on every stage transition. This cleared the accumulated listing tracker, allowing the new custodian to create listings whose quantity — combined with still-active listings from prior custodians — could collectively exceed the physical batch quantity, completely bypassing the over-allocation guard in createListing() (lines 356–361).

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #687 

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---



## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

