### PR TITLE
fix(backend): bound activity pagination limits to prevent DoS attacks

### DIFF
--- a/backend/controllers/activityController.js
+++ b/backend/controllers/activityController.js
@@ -96,7 +96,8 @@ exports.getActivities = async (req, res) => {
         }
 
         const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
-        const limitNumber = Math.max(parseInt(limit, 10) || 10, 1);
+        const MAX_LIMIT = 100;
+        const limitNumber = Math.min(Math.max(parseInt(limit, 10) || 10, 1), MAX_LIMIT);
         const skip = (pageNumber - 1) * limitNumber;
 
         const activities = await Activity.find(query)
@@ -142,7 +143,8 @@ exports.getActivityFeed = async (req, res) => {
         }
 
         const pageNumber = Math.max(parseInt(page, 10) || 1, 1);
-        const limitNumber = Math.max(parseInt(limit, 10) || 10, 1);
+        const MAX_LIMIT = 100;
+        const limitNumber = Math.min(Math.max(parseInt(limit, 10) || 10, 1), MAX_LIMIT);
         const skip = (pageNumber - 1) * limitNumber;
 
         const activities = await Activity.find(query)


### PR DESCRIPTION
# Description

## 🐛 Problem Statement

The `getActivities` and `getActivityFeed` endpoints currently allow the client to supply an unbounded `limit` query parameter.

The existing implementation is similar to:

```javascript
const limitNumber = Math.max(parseInt(limit, 10) || 10, 1);
```

While this prevents values below `1`, it does **not** restrict excessively large values.

An attacker can therefore issue requests such as:

```http
GET /api/activities?limit=10000000
```

or

```http
GET /api/activities/feed?limit=10000000
```

which may force MongoDB to retrieve an enormous number of documents, consuming excessive memory and CPU resources. Under sufficient load, this can lead to **resource exhaustion** and potentially crash the Node.js backend, creating a **Denial of Service (DoS)** vulnerability.

---

## 💡 Proposed Solution

Introduce a maximum pagination limit for activity-related endpoints.

For example:

```javascript
const MAX_LIMIT = 100;

const limitNumber = Math.min(
    Math.max(parseInt(limit, 10) || 10, 1),
    MAX_LIMIT
);
```

Apply this change consistently in:

* `getActivities`
* `getActivityFeed`

located in:

```text
backend/controllers/activityController.js
```

---

## 🎯 Expected Behavior

* Default pagination remains **10**
* Minimum allowed value remains **1**
* Maximum allowed value becomes **100**
* Requests exceeding the maximum are safely clamped instead of causing large database queries

---

## 🚀 Benefits

* Prevents Denial of Service attacks through oversized pagination requests.
* Protects MongoDB and the Node.js server from excessive memory consumption.
* Improves backend stability and scalability.
* Follows standard REST API pagination security best practices.
* Keeps API behavior consistent and predictable.

---

## 📂 Files Likely to be Modified

```text
backend/controllers/activityController.js
```

---

## ✅ Acceptance Criteria

* [ ] Introduce a `MAX_LIMIT` constant (recommended value: `100`).
* [ ] Apply the maximum limit in `getActivities`.
* [ ] Apply the maximum limit in `getActivityFeed`.
* [ ] Preserve the existing default value (`10`).
* [ ] Preserve the existing minimum value (`1`).
* [ ] Requests with values greater than `100` should return at most `100` records.
* [ ] Existing pagination behavior remains unchanged for valid requests.

---

## 🧪 Steps to Reproduce

1. Run the backend.
2. Authenticate as a user with access to the activity endpoints.
3. Send:

```http
GET /api/activities?limit=9999999
```

or

```http
GET /api/activities/feed?limit=9999999
```

4. Observe that the server attempts to process an excessively large query.

---

## ✅ Expected Result After Fix

* The API should gracefully cap the requested limit to `100`.
* The response pagination metadata should reflect the bounded limit.
* Server memory usage should remain stable.
* No backend slowdown or crash should occur.

---

## 📌 Difficulty

* **Difficulty:** Easy
* **Estimated Code Change:** Small (<10 lines)
* **Suitable for:** First-time contributors & GSSoC'26 participants

---

### 🏷️ Suggested Labels

* `bug`
* `security`
* `backend`
* `good first issue`
* `GSSoC'26`

---

### 🔗 Related Issue

  Closes: #712 
