### PR TITLE
feat(smart-contracts): mint sub-batches during purchases to preserve blockchain traceability

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -94,6 +94,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
     event ListingCreated(uint256 indexed listingId, bytes32 indexed batchId, address indexed seller, uint256 quantity, uint256 unitPriceWei);
     event ListingPurchased(uint256 indexed listingId, address indexed buyer, uint256 quantity, uint256 totalPaidWei);
+    event SubBatchCreated(bytes32 indexed parentBatchId, bytes32 indexed subBatchId, address indexed owner, uint256 quantity);
     event ListingCancelled(uint256 indexed listingId, address indexed cancelledBy);
     event ProceedsWithdrawn(address indexed account, uint256 amountWei);
     event SpotPriceRecorded(bytes32 indexed cropTypeHash, uint256 priceWei, uint256 timestamp);
@@ -413,6 +414,38 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
             listing.active = false;
         }
 
+        // Mint a sub-batch for the buyer to preserve traceability
+        bytes32 subBatchId = keccak256(abi.encodePacked(listing.batchId, msg.sender, block.timestamp, listingId));
+        
+        cropBatches[subBatchId] = CropBatch({
+            batchId: subBatchId,
+            cropTypeHash: batch.cropTypeHash,
+            ipfsCID: batch.ipfsCID,
+            quantity: quantity,
+            createdAt: block.timestamp,
+            creator: msg.sender,
+            exists: true,
+            isRecalled: false,
+            currentTemperature: batch.currentTemperature,
+            currentHumidity: batch.currentHumidity,
+            isSpoiled: false
+        });
+
+        _batchUpdates[subBatchId].push(
+            SupplyChainUpdate({
+                // Inherit the stage from the parent's latest update, or default to Transport/Retailer?
+                // For simplicity, we assign it to the buyer as the new custodian at the current stage
+                stage: _batchUpdates[listing.batchId].length > 0 ? _batchUpdates[listing.batchId][_batchUpdates[listing.batchId].length - 1].stage : Stage.Farmer,
+                actorName: "Buyer",
+                location: "Marketplace",
+                timestamp: block.timestamp,
+                notes: "Purchased and split from parent batch",
+                updatedBy: msg.sender
+            })
+        );
+
+        allBatchIds.push(subBatchId);
+
         pendingWithdrawals[listing.seller] += totalCost;
 
         uint256 refund = msg.value - totalCost;
@@ -421,6 +454,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         }
 
         emit ListingPurchased(listingId, msg.sender, quantity, totalCost);
+        emit SubBatchCreated(listing.batchId, subBatchId, msg.sender, quantity);
     }
 
     function cancelListing(uint256 listingId) external whenNotPaused nonReentrant {


### PR DESCRIPTION
# Description

## Summary

The current implementation of `buyFromListing()` in `smart-contracts/contracts/CropChain.sol` reduces the quantity of the seller's batch after a purchase but does not create an on-chain representation of the purchased crop.

As a result, while payment and inventory deduction occur successfully, the purchased quantity is never reassigned to the buyer, causing a break in the blockchain's supply-chain traceability.

This feature proposes introducing **sub-batch creation** during purchases so that every transferred quantity continues to exist as a traceable blockchain asset.

---

## Current Behavior

Suppose Farmer A owns:

```
Batch #15
Quantity: 1000 kg
```

A listing is created for **500 kg**.

Buyer B purchases all 500 kg.

Current outcome:

```
Batch #15
Quantity: 500 kg
```

The purchased **500 kg** no longer exists on-chain.

The buyer receives:

* ❌ No batch ownership
* ❌ No provenance record
* ❌ No lifecycle history
* ❌ No transferable asset
* ❌ No blockchain proof of custody

Although payment succeeds, half of the physical crop effectively disappears from the blockchain ledger.

---

## Proposed Solution

Implement automatic **sub-batch minting** whenever a purchase is made.

During `buyFromListing()`:

* Generate a unique sub-batch ID.
* Create a new `CropBatch`.
* Copy immutable metadata from the parent batch:

  * crop type
  * IPFS CID
  * certifications
  * harvest details
  * IoT metadata
  * origin information
* Assign ownership to the buyer.
* Store the purchased quantity in the new batch.
* Preserve the relationship with the parent batch.
* Emit an event linking both batches.

Example:

```
Before Purchase

Batch #15
Owner: Farmer A
Quantity: 1000 kg

↓

Buyer purchases 500 kg

↓

Batch #15
Owner: Farmer A
Quantity: 500 kg

Batch #42
Parent Batch: #15
Owner: Buyer B
Quantity: 500 kg
```

Every kilogram remains accounted for throughout the supply chain.

---

## Suggested Implementation

Possible additions include:

* Add a `parentBatchId` field to `CropBatch`.
* Generate deterministic sub-batch identifiers.
* Copy immutable metadata from the parent.
* Initialize lifecycle history for the child batch.
* Emit:

```solidity
event SubBatchCreated(
    uint256 indexed parentBatchId,
    uint256 indexed subBatchId,
    address indexed owner,
    uint256 quantity
);
```

Alternative implementations such as ERC-1155 receipt tokens or NFT-backed ownership receipts may also be considered, but a child-batch architecture aligns well with the existing traceability model.

---

## Benefits

* Preserves complete blockchain traceability.
* Prevents loss of purchased quantities from the ledger.
* Provides buyers with verifiable ownership records.
* Enables downstream resale and lifecycle updates.
* Improves provenance and auditability.
* Maintains supply-chain mass conservation.
* Better supports future analytics and compliance features.

---

## Acceptance Criteria

* [ ] Partial purchases automatically create a new sub-batch.
* [ ] Buyer becomes the owner of the new batch.
* [ ] Parent batch quantity is reduced correctly.
* [ ] Parent-child relationship is stored.
* [ ] Metadata is inherited from the parent batch.
* [ ] Lifecycle history starts for the child batch.
* [ ] `SubBatchCreated` event is emitted.
* [ ] Existing functionality remains backward compatible.
* [ ] Unit tests cover partial and full purchase scenarios.

---

## Files Likely Affected

```
smart-contracts/contracts/CropChain.sol
```

Potentially:

```
smart-contracts/test/
backend/
frontend/
```

if batch ownership or event indexing is exposed through the application.

---

## Why This Feature Matters

The primary objective of CropChain is end-to-end supply chain traceability. Without representing purchased quantities on-chain, ownership history becomes incomplete, undermining provenance, auditing, and future transfers.

Introducing sub-batching ensures that every physical quantity remains represented on the blockchain throughout its lifecycle.

---

## Labels

* `GSSoC'26`
* `feature`
* `enhancement`
* `smart-contracts`
* `architecture`

---

### Related Issue

  Closes #714 
