### PR TITLE
fix: clear notification loading state for guests

### DIFF
--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -81,8 +81,13 @@ export const NotificationProvider = ({ children }: { children: ReactNode }) => {
                 cleanupSocket();
             };
         } else {
+            // Logged-out (or not-yet-authenticated) users have no notifications
+            // to load, so loading must be cleared here too — otherwise it stays
+            // stuck at its initial `true` value forever for anyone who never
+            // logs in.
             setNotifications([]);
             setUnreadCount(0);
+            setLoading(false);
         }
     }, [isAuthenticated, user]);
 

--- a/frontend/src/context/__tests__/NotificationContext.test.tsx
+++ b/frontend/src/context/__tests__/NotificationContext.test.tsx
@@ -1,0 +1,258 @@
+/** @jest-environment jsdom */
+
+import "@testing-library/jest-dom";
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { NotificationProvider, useNotifications } from "../NotificationContext";
+import { notificationService } from "../../services/notificationService";
+import { onNewNotification } from "../../services/socketService";
+import { useAuth } from "../AuthContext";
+import toast from "react-hot-toast";
+
+jest.mock("../AuthContext", () => ({
+    useAuth: jest.fn(),
+}));
+
+jest.mock("../../services/notificationService", () => ({
+    notificationService: {
+        getNotifications: jest.fn(),
+        getUnreadCount: jest.fn(),
+        markAsRead: jest.fn(),
+        markAllAsRead: jest.fn(),
+    },
+}));
+
+jest.mock("../../services/socketService", () => ({
+    onNewNotification: jest.fn(),
+}));
+
+jest.mock("react-hot-toast", () => ({
+    __esModule: true,
+    default: {
+        success: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+const mockedUseAuth = useAuth as jest.Mock;
+const mockedGetNotifications = notificationService.getNotifications as jest.Mock;
+const mockedGetUnreadCount = notificationService.getUnreadCount as jest.Mock;
+const mockedMarkAsRead = notificationService.markAsRead as jest.Mock;
+const mockedMarkAllAsRead = notificationService.markAllAsRead as jest.Mock;
+const mockedOnNewNotification = onNewNotification as jest.Mock;
+
+const sampleNotifications = [
+    { _id: "n1", title: "First alert", read: false },
+    { _id: "n2", title: "Second alert", read: false },
+];
+
+// Simple consumer used to exercise the context from tests.
+function NotificationConsumer() {
+    const { notifications, unreadCount, loading, markAsRead, markAllAsRead, fetchNotifications } =
+        useNotifications();
+
+    return (
+        <div>
+            <div data-testid="loading">{String(loading)}</div>
+            <div data-testid="unread-count">{unreadCount}</div>
+            <div data-testid="notification-count">{notifications.length}</div>
+            <button onClick={() => fetchNotifications()}>Refetch</button>
+            <button onClick={() => markAsRead("n1")}>Mark n1 read</button>
+            <button onClick={() => markAllAsRead()}>Mark all read</button>
+        </div>
+    );
+}
+
+const renderWithProvider = () =>
+    render(
+        <NotificationProvider>
+            <NotificationConsumer />
+        </NotificationProvider>
+    );
+
+describe("NotificationContext", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedGetNotifications.mockResolvedValue([...sampleNotifications]);
+        mockedGetUnreadCount.mockResolvedValue(2);
+        mockedMarkAsRead.mockResolvedValue(undefined);
+        mockedMarkAllAsRead.mockResolvedValue(undefined);
+        mockedOnNewNotification.mockReturnValue(() => {});
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it("never gets stuck loading for a logged-out user", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
+
+        renderWithProvider();
+
+        // Regression check for the bug: loading must resolve to false, not
+        // stay stuck at its initial `true` value forever.
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+        expect(screen.getByTestId("notification-count")).toHaveTextContent("0");
+        expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+        expect(mockedGetNotifications).not.toHaveBeenCalled();
+    });
+
+    it("clears notifications and stops loading when a user logs out", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        const { rerender } = render(
+            <NotificationProvider>
+                <NotificationConsumer />
+            </NotificationProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("notification-count")).toHaveTextContent("2");
+        });
+        expect(screen.getByTestId("loading")).toHaveTextContent("false");
+
+        // User logs out.
+        mockedUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
+        rerender(
+            <NotificationProvider>
+                <NotificationConsumer />
+            </NotificationProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+        expect(screen.getByTestId("notification-count")).toHaveTextContent("0");
+        expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+    });
+
+    it("fetches notifications and turns off loading for an authenticated user", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        renderWithProvider();
+
+        expect(screen.getByTestId("loading")).toHaveTextContent("true");
+
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+        expect(screen.getByTestId("notification-count")).toHaveTextContent("2");
+        expect(screen.getByTestId("unread-count")).toHaveTextContent("2");
+        expect(mockedGetNotifications).toHaveBeenCalledTimes(1);
+        expect(mockedGetUnreadCount).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fetch notifications when logged out, even if fetchNotifications is called directly", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
+
+        renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+
+        act(() => {
+            screen.getByRole("button", { name: "Refetch" }).click();
+        });
+
+        expect(mockedGetNotifications).not.toHaveBeenCalled();
+    });
+
+    it("marks a single notification as read and decrements the unread count", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("notification-count")).toHaveTextContent("2");
+        });
+
+        await act(async () => {
+            screen.getByRole("button", { name: "Mark n1 read" }).click();
+        });
+
+        expect(mockedMarkAsRead).toHaveBeenCalledWith("n1");
+        await waitFor(() => {
+            expect(screen.getByTestId("unread-count")).toHaveTextContent("1");
+        });
+    });
+
+    it("shows an error toast when marking a notification as read fails", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+        mockedMarkAsRead.mockRejectedValue(new Error("network error"));
+
+        renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("notification-count")).toHaveTextContent("2");
+        });
+
+        await act(async () => {
+            screen.getByRole("button", { name: "Mark n1 read" }).click();
+        });
+
+        expect(toast.error).toHaveBeenCalledWith("Failed to mark notification as read");
+    });
+
+    it("marks all notifications as read and zeroes the unread count", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("notification-count")).toHaveTextContent("2");
+        });
+
+        await act(async () => {
+            screen.getByRole("button", { name: "Mark all read" }).click();
+        });
+
+        expect(mockedMarkAllAsRead).toHaveBeenCalled();
+        await waitFor(() => {
+            expect(screen.getByTestId("unread-count")).toHaveTextContent("0");
+        });
+    });
+
+    it("subscribes to real-time notifications and cleans up on unmount when authenticated", async () => {
+        const cleanup = jest.fn();
+        mockedOnNewNotification.mockReturnValue(cleanup);
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        const { unmount } = renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+
+        expect(mockedOnNewNotification).toHaveBeenCalledTimes(1);
+        unmount();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not subscribe to real-time notifications when logged out", async () => {
+        mockedUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
+
+        renderWithProvider();
+        await waitFor(() => {
+            expect(screen.getByTestId("loading")).toHaveTextContent("false");
+        });
+
+        expect(mockedOnNewNotification).not.toHaveBeenCalled();
+    });
+
+    it("polls for notifications every 60 seconds while authenticated", async () => {
+        jest.useFakeTimers({ legacyFakeTimers: false });
+        mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
+
+        renderWithProvider();
+
+        await waitFor(() => {
+            expect(mockedGetNotifications).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            jest.advanceTimersByTime(60000);
+        });
+        await waitFor(() => {
+            expect(mockedGetNotifications).toHaveBeenCalledTimes(2);
+        });
+    });
+});

--- a/frontend/src/context/__tests__/NotificationContext.test.tsx
+++ b/frontend/src/context/__tests__/NotificationContext.test.tsx
@@ -1,7 +1,6 @@
-/** @jest-environment jsdom */
-
 import "@testing-library/jest-dom";
 import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
 
 import { NotificationProvider, useNotifications } from "../NotificationContext";
@@ -10,37 +9,42 @@ import { onNewNotification } from "../../services/socketService";
 import { useAuth } from "../AuthContext";
 import toast from "react-hot-toast";
 
-jest.mock("../AuthContext", () => ({
-    useAuth: jest.fn(),
+vi.mock("../AuthContext", () => ({
+    useAuth: vi.fn(),
 }));
 
-jest.mock("../../services/notificationService", () => ({
+vi.mock("../../services/notificationService", () => ({
     notificationService: {
-        getNotifications: jest.fn(),
-        getUnreadCount: jest.fn(),
-        markAsRead: jest.fn(),
-        markAllAsRead: jest.fn(),
+        getNotifications: vi.fn(),
+        getUnreadCount: vi.fn(),
+        markAsRead: vi.fn(),
+        markAllAsRead: vi.fn(),
     },
 }));
 
-jest.mock("../../services/socketService", () => ({
-    onNewNotification: jest.fn(),
+vi.mock("../../services/socketService", () => ({
+    onNewNotification: vi.fn(),
 }));
 
-jest.mock("react-hot-toast", () => ({
-    __esModule: true,
+vi.mock("react-hot-toast", () => ({
     default: {
-        success: jest.fn(),
-        error: jest.fn(),
+        success: vi.fn(),
+        error: vi.fn(),
     },
 }));
 
-const mockedUseAuth = useAuth as jest.Mock;
-const mockedGetNotifications = notificationService.getNotifications as jest.Mock;
-const mockedGetUnreadCount = notificationService.getUnreadCount as jest.Mock;
-const mockedMarkAsRead = notificationService.markAsRead as jest.Mock;
-const mockedMarkAllAsRead = notificationService.markAllAsRead as jest.Mock;
-const mockedOnNewNotification = onNewNotification as jest.Mock;
+const mockedUseAuth = useAuth as unknown as ReturnType<typeof vi.fn>;
+const mockedGetNotifications = notificationService.getNotifications as unknown as ReturnType<
+    typeof vi.fn
+>;
+const mockedGetUnreadCount = notificationService.getUnreadCount as unknown as ReturnType<
+    typeof vi.fn
+>;
+const mockedMarkAsRead = notificationService.markAsRead as unknown as ReturnType<typeof vi.fn>;
+const mockedMarkAllAsRead = notificationService.markAllAsRead as unknown as ReturnType<
+    typeof vi.fn
+>;
+const mockedOnNewNotification = onNewNotification as unknown as ReturnType<typeof vi.fn>;
 
 const sampleNotifications = [
     { _id: "n1", title: "First alert", read: false },
@@ -73,7 +77,7 @@ const renderWithProvider = () =>
 
 describe("NotificationContext", () => {
     beforeEach(() => {
-        jest.clearAllMocks();
+        vi.clearAllMocks();
         mockedGetNotifications.mockResolvedValue([...sampleNotifications]);
         mockedGetUnreadCount.mockResolvedValue(2);
         mockedMarkAsRead.mockResolvedValue(undefined);
@@ -82,7 +86,7 @@ describe("NotificationContext", () => {
     });
 
     afterEach(() => {
-        jest.useRealTimers();
+        vi.useRealTimers();
     });
 
     it("never gets stuck loading for a logged-out user", async () => {
@@ -213,7 +217,7 @@ describe("NotificationContext", () => {
     });
 
     it("subscribes to real-time notifications and cleans up on unmount when authenticated", async () => {
-        const cleanup = jest.fn();
+        const cleanup = vi.fn();
         mockedOnNewNotification.mockReturnValue(cleanup);
         mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
 
@@ -239,7 +243,7 @@ describe("NotificationContext", () => {
     });
 
     it("polls for notifications every 60 seconds while authenticated", async () => {
-        jest.useFakeTimers({ legacyFakeTimers: false });
+        vi.useFakeTimers();
         mockedUseAuth.mockReturnValue({ isAuthenticated: true, user: { id: "u1" } });
 
         renderWithProvider();
@@ -249,7 +253,7 @@ describe("NotificationContext", () => {
         });
 
         await act(async () => {
-            jest.advanceTimersByTime(60000);
+            vi.advanceTimersByTime(60000);
         });
         await waitFor(() => {
             expect(mockedGetNotifications).toHaveBeenCalledTimes(2);

--- a/frontend/src/context/__tests__/NotificationContext.test.tsx
+++ b/frontend/src/context/__tests__/NotificationContext.test.tsx
@@ -78,6 +78,7 @@ const renderWithProvider = () =>
 describe("NotificationContext", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.useRealTimers();
         mockedGetNotifications.mockResolvedValue([...sampleNotifications]);
         mockedGetUnreadCount.mockResolvedValue(2);
         mockedMarkAsRead.mockResolvedValue(undefined);
@@ -94,8 +95,6 @@ describe("NotificationContext", () => {
 
         renderWithProvider();
 
-        // Regression check for the bug: loading must resolve to false, not
-        // stay stuck at its initial `true` value forever.
         await waitFor(() => {
             expect(screen.getByTestId("loading")).toHaveTextContent("false");
         });
@@ -118,7 +117,6 @@ describe("NotificationContext", () => {
         });
         expect(screen.getByTestId("loading")).toHaveTextContent("false");
 
-        // User logs out.
         mockedUseAuth.mockReturnValue({ isAuthenticated: false, user: null });
         rerender(
             <NotificationProvider>
@@ -253,8 +251,9 @@ describe("NotificationContext", () => {
         });
 
         await act(async () => {
-            vi.advanceTimersByTime(60000);
+            await vi.advanceTimersByTimeAsync(60000);
         });
+
         await waitFor(() => {
             expect(mockedGetNotifications).toHaveBeenCalledTimes(2);
         });


### PR DESCRIPTION
## Related Issue

Closes #721

---

## Description

Fixed an issue where the `NotificationContext` remained in a loading state for unauthenticated users.

Previously, the context initialized `loading` as `true` and cleared notifications when `isAuthenticated` was `false`, but never updated the loading state. As a result, components using `useNotifications` could display an infinite loading spinner instead of showing an empty state or redirecting appropriately.

This fix updates the context to set `loading` to `false` whenever the user is not authenticated. Test cases have also been added to verify that logged-out users do not remain stuck in the loading state.

---

## Changes Made

- Set `loading` to `false` when `isAuthenticated` is `false`.
- Ensured notification state is reset correctly for logged-out users.
- Added/updated tests covering the unauthenticated loading scenario.
- Preserved existing notification behavior for authenticated users.

---

## Steps to Test

1. Open the application while logged out.
2. Navigate to the Notifications page (or any component using `useNotifications`).
3. Verify the loading spinner does not remain visible indefinitely.
4. Confirm an empty state or expected logged-out behavior is displayed.
5. Log in and verify notifications continue to load correctly.
6. Run the NotificationContext test suite and confirm all tests pass.

---

## Expected Result

- Logged-out users do not remain in a loading state.
- `loading` is set to `false` when authentication is unavailable.
- Notification components display the correct empty or logged-out state.
- Authenticated notification loading behavior remains unchanged.

---

## Files Changed

- `frontend/src/context/NotificationContext.tsx`
- `frontend/src/context/__tests__/NotificationContext.test.tsx`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update