### PR TITLE
fix(backend): make approval statistics route reachable

### DIFF
--- a/backend/routes/approvalRoutes.js
+++ b/backend/routes/approvalRoutes.js
@@ -82,6 +82,17 @@ router.get('/pending', protect, inspectorOnly, async (req, res) => {
     }
 });
 
+// Get statistics
+router.get('/stats', protect, adminOnly, async (req, res) => {
+    try {
+        const stats = await MultisigService.getStatistics();
+        res.json({ success: true, data: stats });
+    } catch (error) {
+        logger.error('[APPROVAL] Stats error:', error);
+        res.status(500).json({ error: 'Failed to fetch statistics', message: error.message });
+    }
+});
+
 // Get approval request details
 router.get('/:requestId', protect, async (req, res) => {
     try {
@@ -158,17 +169,6 @@ router.get('/batch/:batchId', protect, async (req, res) => {
     } catch (error) {
         logger.error('[APPROVAL] History error:', error);
         res.status(500).json({ error: 'Failed to fetch approval history', message: error.message });
-    }
-});
-
-// Get statistics
-router.get('/stats', protect, adminOnly, async (req, res) => {
-    try {
-        const stats = await MultisigService.getStatistics();
-        res.json({ success: true, data: stats });
-    } catch (error) {
-        logger.error('[APPROVAL] Stats error:', error);
-        res.status(500).json({ error: 'Failed to fetch statistics', message: error.message });
     }
 });
 

--- a/backend/tests/approvalRoutes.test.js
+++ b/backend/tests/approvalRoutes.test.js
@@ -1,0 +1,98 @@
+process.env.NODE_ENV = 'test';
+
+const express = require('express');
+const request = require('supertest');
+
+const mockMultisigService = {
+    getStatistics: jest.fn(),
+    getRequestDetails: jest.fn()
+};
+
+jest.mock('../services/multisigService', () => mockMultisigService);
+jest.mock('../services/activityService', () => ({ logActivity: jest.fn() }));
+jest.mock('../utils/logger', () => ({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+}));
+
+jest.mock('../middleware/auth', () => ({
+    protect: jest.fn((req, res, next) => {
+        const role = req.get('x-test-role');
+        if (!role) {
+            return res.status(401).json({ error: 'Not authorized' });
+        }
+        req.user = { _id: 'user-1', role };
+        next();
+    }),
+    adminOnly: jest.fn((req, res, next) => {
+        if (req.user && ['admin', 'super_admin'].includes(req.user.role)) {
+            return next();
+        }
+        return res.status(403).json({ error: 'Access denied', message: 'Admin access required' });
+    }),
+    inspectorOnly: jest.fn((req, res, next) => next()),
+    requirePermissions: jest.fn(() => (req, res, next) => next())
+}));
+
+const approvalRoutes = require('../routes/approvalRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/approvals', approvalRoutes);
+
+describe('Approval routes', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('GET /api/approvals/stats', () => {
+        it.each(['admin', 'super_admin'])('returns statistics for an authenticated %s', async (role) => {
+            const statistics = { pending: 3, approved: 8, rejected: 2 };
+            mockMultisigService.getStatistics.mockResolvedValue(statistics);
+
+            const response = await request(app)
+                .get('/api/approvals/stats')
+                .set('x-test-role', role)
+                .expect(200);
+
+            expect(mockMultisigService.getStatistics).toHaveBeenCalledTimes(1);
+            expect(mockMultisigService.getRequestDetails).not.toHaveBeenCalled();
+            expect(response.body).toEqual({ success: true, data: statistics });
+        });
+
+        it('rejects an unauthenticated request', async () => {
+            await request(app).get('/api/approvals/stats').expect(401);
+
+            expect(mockMultisigService.getStatistics).not.toHaveBeenCalled();
+            expect(mockMultisigService.getRequestDetails).not.toHaveBeenCalled();
+        });
+
+        it('rejects an authenticated non-admin request', async () => {
+            await request(app)
+                .get('/api/approvals/stats')
+                .set('x-test-role', 'farmer')
+                .expect(403);
+
+            expect(mockMultisigService.getStatistics).not.toHaveBeenCalled();
+            expect(mockMultisigService.getRequestDetails).not.toHaveBeenCalled();
+        });
+    });
+
+    it('GET /api/approvals/:requestId still returns request details', async () => {
+        const approval = {
+            requestId: 'request-123',
+            initiatedBy: { _id: 'user-1' }
+        };
+        mockMultisigService.getRequestDetails.mockResolvedValue(approval);
+
+        const response = await request(app)
+            .get('/api/approvals/request-123')
+            .set('x-test-role', 'farmer')
+            .expect(200);
+
+        expect(mockMultisigService.getRequestDetails).toHaveBeenCalledWith('request-123');
+        expect(mockMultisigService.getStatistics).not.toHaveBeenCalled();
+        expect(response.body).toEqual({ success: true, data: approval });
+    });
+});


### PR DESCRIPTION
## 📌 Overview

This PR fixes an Express route-ordering bug that made the approval statistics endpoint unreachable.

The static route:

`GET /api/approvals/stats`

was registered after the parameterized route:

`GET /api/approvals/:requestId`

As a result, requests to `/stats` were incorrectly handled as approval-detail requests with `requestId = "stats"`.

This change moves the statistics route above the parameterized route and adds regression tests to ensure statistics requests are routed correctly while preserving normal request-detail behavior.

## 🛠️ Type of Change

* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)
* [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
* [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [ ] 📄 **Documentation** (README, Roadmap updates)

---

## 🔗 Related Issue

Closes #697

---

## 🧪 Testing & Verification

### Targeted Verification

* Added regression tests covering:

  * Admin access to `/api/approvals/stats`
  * Super Admin access to `/api/approvals/stats`
  * `MultisigService.getStatistics()` invocation
  * Ensuring `"stats"` never reaches `getRequestDetails()`
  * Normal `/api/approvals/:requestId` behavior
  * Unauthorized and non-admin access rejection

### Results

* Targeted Jest tests: ✅ **5/5 Passed**
* Syntax validation: ✅ Passed
* `git diff --check`: ✅ Passed

### Repository-wide Status

A full backend Jest run was also executed. Some unrelated pre-existing failures remain in the repository (including missing `services/notificationQueue` and an existing `logger.warn` mock issue). These failures are unrelated to this PR.

* [ ] **Smart Contracts:** `npx hardhat test` passed? **NA**
* [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? **NA**
* [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? **NA**

---

## 📸 Screenshots / Demos

N/A (Backend-only route fix)

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly. *(Not required for this change)*
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

### Files Changed

* `backend/routes/approvalRoutes.js`
* `backend/tests/approvalRoutes.test.js`

### Implementation Summary

* Moved `GET /stats` above `GET /:requestId`.
* Added regression coverage to prevent future route-shadowing regressions.
* Kept the fix narrowly scoped to issue #697.
* No API contract, authorization logic, or service-layer behavior was modified.