### PR TITLE
fix(backend): make auction settlement atomic and idempotent

### DIFF
--- a/backend/jobs/auctionSettlement.js
+++ b/backend/jobs/auctionSettlement.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const logger = require("../utils/logger");
 const Auction = require("../models/Auction");
 const User = require("../models/User");
@@ -5,119 +6,219 @@ const Batch = require("../models/Batch");
 const socketService = require("../services/socketService");
 const notificationService = require("../services/notificationService");
 
-const settleExpiredAuctions = async () => {
+class AuctionSettlementError extends Error {
+  constructor(message, auctionId, cause) {
+    super(message);
+    this.name = "AuctionSettlementError";
+    this.auctionId = auctionId;
+    this.cause = cause;
+  }
+}
+
+const claimAndSettleNextAuction = async (now, excludedAuctionIds = []) => {
+  const session = await mongoose.startSession();
+  let claimedAuction = null;
+  let settlementResult = null;
+
   try {
-    // Find active auctions that have expired
-    const expiredAuctions = await Auction.find({
-      status: "active",
-      endTime: { $lte: new Date() },
-    });
+    await session.withTransaction(async () => {
+      claimedAuction = null;
+      settlementResult = null;
+      const claimFilter = {
+        status: "active",
+        endTime: { $lte: now },
+        settledAt: null,
+      };
+      if (excludedAuctionIds.length > 0) {
+        claimFilter._id = { $nin: excludedAuctionIds };
+      }
 
-    if (expiredAuctions.length === 0) return;
+      claimedAuction = await Auction.findOneAndUpdate(
+        claimFilter,
+        {
+          $set: {
+            status: "ended",
+            settledAt: now,
+          },
+        },
+        {
+          new: true,
+          session,
+          sort: { endTime: 1 },
+        },
+      );
 
-    logger.info(`Found ${expiredAuctions.length} expired auctions to settle`);
+      if (!claimedAuction) return null;
 
-    for (const auction of expiredAuctions) {
-      auction.status = "ended";
-      await auction.save();
+      let buyer = null;
+      let farmer = null;
+      let batch = null;
 
-      const io = socketService.getIO();
+      if (claimedAuction.highestBidder) {
+        buyer = await User.findById(claimedAuction.highestBidder, null, { session });
+        farmer = await User.findOneAndUpdate(
+          { _id: claimedAuction.farmerId },
+          { $inc: { balance: claimedAuction.currentHighestBid } },
+          { new: true, session },
+        );
+        if (!farmer) {
+          throw new Error("Auction farmer not found");
+        }
 
-      // If there's a highest bidder, finalize the deal
-      if (auction.highestBidder) {
-        // 1. Credit the farmer's account
-        await User.findByIdAndUpdate(auction.farmerId, {
-          $inc: { balance: auction.currentHighestBid },
-        });
-
-        // 2. Fetch buyer details
-        const buyer = await User.findById(auction.highestBidder);
         const buyerName = buyer ? buyer.name : "Buyer";
-        const farmer = await User.findById(auction.farmerId);
-
-        // 3. Update the batch stage to 'mandi' and record history entry
-        const batch = await Batch.findById(auction.cropId);
-        if (batch) {
-          batch.currentStage = "mandi";
-          batch.updates.push({
-            stage: "mandi",
-            actor: buyerName,
-            location: "Auction Market",
-            notes: `Purchased at live auction for ${auction.currentHighestBid} credits`,
-          });
-          await batch.save();
-
-          logger.info(
-            `Auction settled: Batch ${batch.batchId} sold to ${buyerName} for ${auction.currentHighestBid} credits`,
-          );
-
-          // Trigger Socket.io real-time update events for batch stage change
-          if (io) {
-            io.to(`batch:${batch.batchId}`).emit("batch-updated", batch);
-            io.emit("batch-stage-changed", {
-              batchId: batch.batchId,
-              stage: "mandi",
-            });
-          }
-        }
-
-        // 4. Notify the winner and the farmer about the sale outcome
-        const buyerId = auction.highestBidder.toString();
-        const farmerId = auction.farmerId.toString();
-        const finalPrice = auction.currentHighestBid;
-
-        await notificationService.createInAppNotification(
-          buyerId,
-          "Auction Won",
-          `You won the auction for batch ${auction.batchId} for ${finalPrice} credits.`,
-          "auction",
+        batch = await Batch.findOneAndUpdate(
+          { _id: claimedAuction.cropId },
           {
-            auctionId: auction._id.toString(),
-            batchId: auction.batchId,
-            finalPrice,
+            $set: { currentStage: "mandi" },
+            $push: {
+              updates: {
+                stage: "mandi",
+                actor: buyerName,
+                location: "Auction Market",
+                notes: `Purchased at live auction for ${claimedAuction.currentHighestBid} credits`,
+              },
+            },
           },
+          { new: true, session },
         );
-
-        await notificationService.createInAppNotification(
-          farmerId,
-          "Auction Sold",
-          `Your auction for batch ${auction.batchId} sold for ${finalPrice} credits.`,
-          "auction",
-          {
-            auctionId: auction._id.toString(),
-            batchId: auction.batchId,
-            finalPrice,
-          },
-        );
-
-        if (buyer && buyer.email) {
-          await notificationService.sendEmail(
-            buyer.email,
-            `You won auction ${auction.batchId}`,
-            `<h2>Auction Won</h2><p>Congratulations! You won the auction for batch <strong>${auction.batchId}</strong> for <strong>${finalPrice}</strong> credits.</p><p>CropChain Team</p>`,
-          );
+        if (!batch) {
+          throw new Error("Auction batch not found");
         }
-
-        if (farmer && farmer.email) {
-          await notificationService.sendEmail(
-            farmer.email,
-            `Auction sold: ${auction.batchId}`,
-            `<h2>Auction Sold</h2><p>Your auction for batch <strong>${auction.batchId}</strong> has completed successfully for <strong>${finalPrice}</strong> credits.</p><p>CropChain Team</p>`,
-          );
-        }
-      } else {
-        logger.info(
-          `Auction ended without any bids for batch ${auction.batchId}`,
-        );
       }
 
-      // Emit socket notifications to the room
-      if (io) {
-        io.to(`auction:${auction._id}`).emit("auction_ended", auction);
-      }
-    }
+      settlementResult = { auction: claimedAuction, buyer, farmer, batch };
+    });
+    return settlementResult;
   } catch (error) {
-    logger.error("Error settling expired auctions:", { error: error.message });
+    throw new AuctionSettlementError(
+      error.message,
+      claimedAuction ? claimedAuction._id.toString() : null,
+      error,
+    );
+  } finally {
+    await session.endSession();
+  }
+};
+const runSideEffect = async (description, action) => {
+  try {
+    await action();
+  } catch (error) {
+    logger.error(`Auction settlement side effect failed (${description}):`, {
+      error: error.message,
+    });
+  }
+};
+
+const emitSettlementSideEffects = async ({ auction, buyer, farmer, batch }) => {
+  let io = null;
+  try {
+    io = socketService.getIO();
+  } catch (error) {
+    logger.error("Auction settlement side effect failed (socket lookup):", {
+      error: error.message,
+    });
+  }
+
+  if (!auction.highestBidder) {
+    logger.info(`Auction ended without any bids for batch ${auction.batchId}`);
+  } else {
+    const buyerId = auction.highestBidder.toString();
+    const farmerId = auction.farmerId.toString();
+    const finalPrice = auction.currentHighestBid;
+    const buyerName = buyer ? buyer.name : "Buyer";
+
+    logger.info(
+      `Auction settled: Batch ${batch.batchId} sold to ${buyerName} for ${finalPrice} credits`,
+    );
+
+    if (io) {
+      await runSideEffect("batch socket events", async () => {
+        io.to(`batch:${batch.batchId}`).emit("batch-updated", batch);
+        io.emit("batch-stage-changed", {
+          batchId: batch.batchId,
+          stage: "mandi",
+        });
+      });
+    }
+
+    await runSideEffect("winner notification", () =>
+      notificationService.createInAppNotification(
+        buyerId,
+        "Auction Won",
+        `You won the auction for batch ${auction.batchId} for ${finalPrice} credits.`,
+        "auction",
+        {
+          auctionId: auction._id.toString(),
+          batchId: auction.batchId,
+          finalPrice,
+        },
+      ),
+    );
+
+    await runSideEffect("farmer notification", () =>
+      notificationService.createInAppNotification(
+        farmerId,
+        "Auction Sold",
+        `Your auction for batch ${auction.batchId} sold for ${finalPrice} credits.`,
+        "auction",
+        {
+          auctionId: auction._id.toString(),
+          batchId: auction.batchId,
+          finalPrice,
+        },
+      ),
+    );
+
+    if (buyer && buyer.email) {
+      await runSideEffect("winner email", () =>
+        notificationService.sendEmail(
+          buyer.email,
+          `You won auction ${auction.batchId}`,
+          `<h2>Auction Won</h2><p>Congratulations! You won the auction for batch <strong>${auction.batchId}</strong> for <strong>${finalPrice}</strong> credits.</p><p>CropChain Team</p>`,
+        ),
+      );
+    }
+
+    if (farmer && farmer.email) {
+      await runSideEffect("farmer email", () =>
+        notificationService.sendEmail(
+          farmer.email,
+          `Auction sold: ${auction.batchId}`,
+          `<h2>Auction Sold</h2><p>Your auction for batch <strong>${auction.batchId}</strong> has completed successfully for <strong>${finalPrice}</strong> credits.</p><p>CropChain Team</p>`,
+        ),
+      );
+    }
+  }
+
+  if (io) {
+    await runSideEffect("auction ended socket event", async () => {
+      io.to(`auction:${auction._id}`).emit("auction_ended", auction);
+    });
+  }
+};
+
+const settleExpiredAuctions = async () => {
+  const attemptedAuctionIds = [];
+
+  while (true) {
+    try {
+      const result = await claimAndSettleNextAuction(
+        new Date(),
+        attemptedAuctionIds,
+      );
+      if (!result) return;
+
+      attemptedAuctionIds.push(result.auction._id.toString());
+      await emitSettlementSideEffects(result);
+    } catch (error) {
+      logger.error("Error settling expired auction:", {
+        auctionId: error.auctionId,
+        error: error.message,
+      });
+
+      if (!error.auctionId) return;
+      attemptedAuctionIds.push(error.auctionId);
+    }
   }
 };
 
@@ -126,4 +227,9 @@ const startAuctionSettlementJob = () => {
   setInterval(settleExpiredAuctions, 10000);
 };
 
-module.exports = { startAuctionSettlementJob, settleExpiredAuctions };
+module.exports = {
+  startAuctionSettlementJob,
+  settleExpiredAuctions,
+  claimAndSettleNextAuction,
+  emitSettlementSideEffects,
+};

--- a/backend/models/Auction.js
+++ b/backend/models/Auction.js
@@ -44,6 +44,10 @@ const auctionSchema = new mongoose.Schema({
     enum: ['active', 'ended', 'cancelled'],
     default: 'active',
     index: true
+  },
+  settledAt: {
+    type: Date,
+    default: null
   }
 }, { timestamps: true });
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "jest": "^29.7.0",
+        "mongodb-memory-server": "^10.4.1",
         "nodemon": "^3.1.14",
         "supertest": "^6.3.4"
       },
@@ -1118,11 +1119,11 @@
       "license": "MIT"
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.6.tgz",
-      "integrity": "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==",
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.12.tgz",
+      "integrity": "sha512-QAfAMwNgnYxZ2C6D1HgeP7Gc4i/uvJRim415PCIL9ptRxWMNbWeLBYb2/9R4pGKny/s1FVu2JA2cxCUBUOggrA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -1718,6 +1719,16 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1765,6 +1776,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
       }
     },
     "node_modules/babel-jest": {
@@ -1888,6 +1914,91 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
+      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base-x": {
       "version": "3.0.11",
@@ -2521,6 +2632,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -3203,6 +3321,16 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3323,6 +3451,13 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3382,6 +3517,40 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/find-up": {
@@ -5476,8 +5645,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -5623,6 +5792,239 @@
         "@types/whatwg-url": "^8.2.1",
         "whatwg-url": "^11.0.0"
       }
+    },
+    "node_modules/mongodb-memory-server": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-10.4.1.tgz",
+      "integrity": "sha512-XpCyV1e7QQ1lW28rgtXP4ZlX8ZfD/8z1ZGNxz2y3JrosLgDrNnYWvPjlgFj3JjboYUtlh1jF2Ez/rwsQA6cl0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "mongodb-memory-server-core": "10.4.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-10.4.1.tgz",
+      "integrity": "sha512-YJdrEyF9hk64nfeoVDMP6IfTzK+gLZhrQqYyP6JJMsqo2LK5eF7JRZ4YPQDmt1re/JhItpiU+ypiZbIG1OsW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-mutex": "^0.5.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.4.3",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.11",
+        "https-proxy-agent": "^7.0.6",
+        "mongodb": "^6.9.0",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.7.3",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.8.1",
+        "yauzl": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mongodb-memory-server/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/mongoose": {
       "version": "7.8.9",
@@ -5900,6 +6302,44 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/new-find-package-json/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -6365,6 +6805,13 @@
         "linebreak": "^1.0.2",
         "png-js": "^1.0.0"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7311,8 +7758,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -7380,6 +7827,18 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
+      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -7679,6 +8138,29 @@
         "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7692,6 +8174,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-hex": {
@@ -8220,6 +8712,19 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.4.1",
     "nodemon": "^3.1.14",
     "supertest": "^6.3.4"
   },

--- a/backend/tests/auctionSettlement.integration.test.js
+++ b/backend/tests/auctionSettlement.integration.test.js
@@ -1,0 +1,127 @@
+const mongoose = require("mongoose");
+const { MongoMemoryReplSet } = require("mongodb-memory-server");
+
+const mockCreateInAppNotification = jest.fn();
+const mockSendEmail = jest.fn();
+const mockSocketEmit = jest.fn();
+const mockGlobalEmit = jest.fn();
+const mockGetIO = jest.fn();
+const mockLoggerError = jest.fn();
+
+jest.mock("../services/notificationService", () => ({
+  createInAppNotification: mockCreateInAppNotification,
+  sendEmail: mockSendEmail,
+}));
+
+jest.mock("../services/socketService", () => ({
+  getIO: mockGetIO,
+}));
+
+jest.mock("../utils/logger", () => ({
+  info: jest.fn(),
+  error: mockLoggerError,
+  warn: jest.fn(),
+}));
+
+const Auction = require("../models/Auction");
+const { settleExpiredAuctions } = require("../jobs/auctionSettlement");
+
+jest.setTimeout(180000);
+
+describe("auction settlement transaction integration", () => {
+  let replSet;
+
+  beforeAll(async () => {
+    replSet = await MongoMemoryReplSet.create({
+      instanceOpts: [{ launchTimeout: 60000 }],
+      replSet: { count: 1, storageEngine: "wiredTiger" },
+    });
+    await mongoose.connect(replSet.getUri(), { dbName: "auction-settlement-test" });
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (replSet) await replSet.stop();
+  });
+
+  beforeEach(async () => {
+    await mongoose.connection.db.dropDatabase();
+    jest.clearAllMocks();
+    mockCreateInAppNotification.mockResolvedValue({});
+    mockSendEmail.mockResolvedValue({ success: true });
+    mockGetIO.mockReturnValue({
+      to: jest.fn(() => ({ emit: mockSocketEmit })),
+      emit: mockGlobalEmit,
+    });
+  });
+
+  it("settles one real auction exactly once across concurrent workers", async () => {
+    const farmerId = new mongoose.Types.ObjectId();
+    const buyerId = new mongoose.Types.ObjectId();
+    const batchObjectId = new mongoose.Types.ObjectId();
+
+    await mongoose.connection.collection("users").insertMany([
+      {
+        _id: farmerId,
+        name: "Farmer One",
+        email: "farmer@example.com",
+        balance: 100,
+      },
+      {
+        _id: buyerId,
+        name: "Buyer One",
+        email: "buyer@example.com",
+        balance: 500,
+      },
+    ]);
+
+    await mongoose.connection.collection("batches").insertOne({
+      _id: batchObjectId,
+      batchId: "BATCH-REAL-100",
+      currentStage: "farmer",
+      updates: [],
+    });
+
+    const auction = await Auction.create({
+      cropId: batchObjectId,
+      batchId: "BATCH-REAL-100",
+      farmerId,
+      startPrice: 100,
+      currentHighestBid: 125,
+      highestBidder: buyerId,
+      startTime: new Date(Date.now() - 60000),
+      endTime: new Date(Date.now() - 1000),
+      status: "active",
+    });
+
+    await Promise.all([settleExpiredAuctions(), settleExpiredAuctions()]);
+
+    const [settledAuction, farmer, batch] = await Promise.all([
+      Auction.findById(auction._id).lean(),
+      mongoose.connection.collection("users").findOne({ _id: farmerId }),
+      mongoose.connection.collection("batches").findOne({ _id: batchObjectId }),
+    ]);
+
+    expect(settledAuction.status).toBe("ended");
+    expect(settledAuction.settledAt).toBeInstanceOf(Date);
+    expect(farmer.balance).toBe(225);
+    expect(batch.currentStage).toBe("mandi");
+    expect(batch.updates).toHaveLength(1);
+    expect(batch.updates[0]).toEqual(expect.objectContaining({
+      stage: "mandi",
+      actor: "Buyer One",
+    }));
+
+    expect(mockCreateInAppNotification).toHaveBeenCalledTimes(2);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+    expect(
+      mockSocketEmit.mock.calls.filter(([event]) => event === "auction_ended"),
+    ).toHaveLength(1);
+    expect(
+      mockSocketEmit.mock.calls.filter(([event]) => event === "batch-updated"),
+    ).toHaveLength(1);
+    expect(
+      mockGlobalEmit.mock.calls.filter(([event]) => event === "batch-stage-changed"),
+    ).toHaveLength(1);
+  });
+});

--- a/backend/tests/auctionSettlement.test.js
+++ b/backend/tests/auctionSettlement.test.js
@@ -1,32 +1,41 @@
-const mockAuctionFind = jest.fn();
+const mockStartSession = jest.fn();
+const mockAuctionFindOneAndUpdate = jest.fn();
 const mockUserFindById = jest.fn();
-const mockUserFindByIdAndUpdate = jest.fn();
-const mockBatchFindById = jest.fn();
+const mockUserFindOneAndUpdate = jest.fn();
+const mockBatchFindOneAndUpdate = jest.fn();
 const mockCreateInAppNotification = jest.fn();
 const mockSendEmail = jest.fn();
 const mockGetIO = jest.fn();
+const mockSocketEmit = jest.fn();
+const mockGlobalEmit = jest.fn();
+
+jest.mock("mongoose", () => ({
+  startSession: mockStartSession,
+}));
 
 jest.mock("../models/Auction", () => ({
-  find: mockAuctionFind,
+  findOneAndUpdate: mockAuctionFindOneAndUpdate,
 }));
 
 jest.mock("../models/User", () => ({
   findById: mockUserFindById,
-  findByIdAndUpdate: mockUserFindByIdAndUpdate,
+  findOneAndUpdate: mockUserFindOneAndUpdate,
 }));
 
 jest.mock("../models/Batch", () => ({
-  findById: mockBatchFindById,
+  findOneAndUpdate: mockBatchFindOneAndUpdate,
 }));
 
 jest.mock("../services/socketService", () => ({
   getIO: mockGetIO,
 }));
+
 jest.mock("../utils/logger", () => ({
   info: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
 }));
+
 jest.mock("../services/notificationService", () => ({
   createInAppNotification: mockCreateInAppNotification,
   sendEmail: mockSendEmail,
@@ -34,106 +43,223 @@ jest.mock("../services/notificationService", () => ({
 
 const { settleExpiredAuctions } = require("../jobs/auctionSettlement");
 
+const clone = (value) => structuredClone(value);
+
+const replaceContents = (target, source) => {
+  target.splice(0, target.length, ...clone(source));
+};
+
 describe("settleExpiredAuctions", () => {
+  let auctions;
+  let users;
+  let batches;
+  let failBatchIds;
+  let sessions;
+
+  const makeAuction = (overrides = {}) => ({
+    _id: "auction-1",
+    cropId: "batch-1",
+    batchId: "BATCH-100",
+    farmerId: "farmer-1",
+    highestBidder: "buyer-1",
+    currentHighestBid: 125,
+    status: "active",
+    endTime: new Date(Date.now() - 1000),
+    settledAt: null,
+    ...overrides,
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
+    auctions = [makeAuction()];
+    users = [
+      { _id: "farmer-1", name: "Farmer One", email: "farmer@example.com", balance: 100 },
+      { _id: "buyer-1", name: "Buyer One", email: "buyer@example.com", balance: 500 },
+    ];
+    batches = [{ _id: "batch-1", batchId: "BATCH-100", currentStage: "farmer", updates: [] }];
+    failBatchIds = new Set();
+    sessions = [];
+
+    mockStartSession.mockImplementation(async () => {
+      const snapshot = {
+        auctions: clone(auctions),
+        users: clone(users),
+        batches: clone(batches),
+      };
+      const session = {
+        startTransaction: jest.fn(),
+        commitTransaction: jest.fn().mockResolvedValue(undefined),
+        dirty: false,
+        withTransaction: jest.fn().mockImplementation(async (callback) => {
+          try {
+            const result = await callback();
+            await session.commitTransaction();
+            return result;
+          } catch (error) {
+            await session.abortTransaction();
+            throw error;
+          }
+        }),
+        abortTransaction: jest.fn().mockImplementation(async () => {
+          if (session.dirty) {
+            replaceContents(auctions, snapshot.auctions);
+            replaceContents(users, snapshot.users);
+            replaceContents(batches, snapshot.batches);
+          }
+        }),
+        endSession: jest.fn(),
+      };
+      sessions.push(session);
+      return session;
+    });
+
+    mockAuctionFindOneAndUpdate.mockImplementation(async (filter, update, options) => {
+      let auction;
+      if (filter.status === "active") {
+        auction = auctions.find((candidate) =>
+          candidate.status === "active" &&
+          candidate.endTime <= filter.endTime.$lte &&
+          !(filter._id && filter._id.$nin.includes(candidate._id)),
+        );
+      } else {
+        auction = auctions.find((candidate) =>
+          candidate._id === filter._id && candidate.status === filter.status,
+        );
+      }
+      if (!auction) return null;
+
+      options.session.dirty = true;
+      Object.assign(auction, update.$set || {});
+      for (const field of Object.keys(update.$unset || {})) {
+        auction[field] = null;
+      }
+      return clone(auction);
+    });
+
+    mockUserFindById.mockImplementation(async (id) => {
+      const user = users.find((candidate) => candidate._id === id);
+      return user ? clone(user) : null;
+    });
+
+    mockUserFindOneAndUpdate.mockImplementation(async (filter, update, options) => {
+      const user = users.find((candidate) => candidate._id === filter._id);
+      if (!user) return null;
+      options.session.dirty = true;
+      user.balance += update.$inc.balance;
+      return clone(user);
+    });
+
+    mockBatchFindOneAndUpdate.mockImplementation(async (filter, update, options) => {
+      if (failBatchIds.has(filter._id)) {
+        throw new Error("Simulated batch update failure");
+      }
+      const batch = batches.find((candidate) => candidate._id === filter._id);
+      if (!batch) return null;
+      options.session.dirty = true;
+      batch.currentStage = update.$set.currentStage;
+      batch.updates.push(clone(update.$push.updates));
+      return clone(batch);
+    });
+
+    mockCreateInAppNotification.mockResolvedValue({});
+    mockSendEmail.mockResolvedValue({ success: true });
+    mockGetIO.mockReturnValue({
+      to: jest.fn(() => ({ emit: mockSocketEmit })),
+      emit: mockGlobalEmit,
+    });
   });
 
-  it("marks the auction as ended and notifies the winner and farmer when a bid exists", async () => {
-    const auction = {
-      _id: "auction-1",
-      batchId: "BATCH-100",
-      farmerId: "farmer-1",
-      highestBidder: "buyer-1",
-      currentHighestBid: 125,
-      status: "active",
-      endTime: new Date(Date.now() - 1000),
-      save: jest.fn().mockResolvedValue(true),
-    };
+  it("settles an expired auction atomically", async () => {
+    await settleExpiredAuctions();
 
-    mockAuctionFind.mockResolvedValue([auction]);
-    mockUserFindById
-      .mockResolvedValueOnce({
-        _id: "farmer-1",
-        name: "Farmer One",
-        email: "farmer@example.com",
-      })
-      .mockResolvedValueOnce({
-        _id: "buyer-1",
-        name: "Buyer One",
-        email: "buyer@example.com",
-      });
-    mockUserFindByIdAndUpdate.mockResolvedValue({});
-    mockBatchFindById.mockResolvedValue({
-      _id: "batch-1",
-      batchId: "BATCH-100",
-      currentStage: "farmer",
-      updates: [],
-      save: jest.fn().mockResolvedValue(true),
-    });
-    mockGetIO.mockReturnValue({
-      to: jest.fn().mockReturnThis(),
-      emit: jest.fn(),
-    });
+    expect(auctions[0].status).toBe("ended");
+    expect(Number.isNaN(new Date(auctions[0].settledAt).getTime())).toBe(false);
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(225);
+    expect(batches[0].currentStage).toBe("mandi");
+    expect(batches[0].updates).toHaveLength(1);
+    expect(batches[0].updates[0]).toEqual(expect.objectContaining({
+      stage: "mandi",
+      actor: "Buyer One",
+    }));
+    expect(sessions[0].commitTransaction).toHaveBeenCalledTimes(1);
+    expect(mockCreateInAppNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows only one concurrent execution to settle an auction", async () => {
+    await Promise.all([settleExpiredAuctions(), settleExpiredAuctions()]);
+
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(225);
+    expect(batches[0].updates).toHaveLength(1);
+    expect(auctions[0].status).toBe("ended");
+    expect(mockCreateInAppNotification).toHaveBeenCalledTimes(2);
+    expect(mockSocketEmit.mock.calls.filter(([event]) => event === "auction_ended")).toHaveLength(1);
+  });
+
+  it("does not repeat database or external side effects after settlement", async () => {
+    await settleExpiredAuctions();
+    const notificationCount = mockCreateInAppNotification.mock.calls.length;
+    const socketCount = mockSocketEmit.mock.calls.length;
 
     await settleExpiredAuctions();
 
-    expect(auction.status).toBe("ended");
-    expect(auction.save).toHaveBeenCalled();
-    expect(mockUserFindByIdAndUpdate).toHaveBeenCalledWith("farmer-1", {
-      $inc: { balance: 125 },
-    });
-    expect(mockCreateInAppNotification).toHaveBeenCalledWith(
-      "buyer-1",
-      "Auction Won",
-      expect.stringContaining("won the auction"),
-      "auction",
-      expect.objectContaining({ auctionId: "auction-1" }),
-    );
-    expect(mockCreateInAppNotification).toHaveBeenCalledWith(
-      "farmer-1",
-      "Auction Sold",
-      expect.stringContaining("sold for 125 credits"),
-      "auction",
-      expect.objectContaining({ auctionId: "auction-1", finalPrice: 125 }),
-    );
-    expect(mockSendEmail).toHaveBeenCalled();
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(225);
+    expect(batches[0].updates).toHaveLength(1);
+    expect(mockCreateInAppNotification).toHaveBeenCalledTimes(notificationCount);
+    expect(mockSocketEmit).toHaveBeenCalledTimes(socketCount);
   });
 
-  it("does not try to notify when no highest bidder exists", async () => {
-    const auction = {
-      _id: "auction-2",
-      batchId: "BATCH-101",
-      farmerId: "farmer-2",
-      highestBidder: null,
-      currentHighestBid: 100,
-      status: "active",
-      endTime: new Date(Date.now() - 1000),
-      save: jest.fn().mockResolvedValue(true),
-    };
-
-    mockAuctionFind.mockResolvedValue([auction]);
-    mockUserFindById.mockResolvedValue({
-      _id: "farmer-2",
-      name: "Farmer Two",
-      email: "farmer2@example.com",
-    });
-    mockBatchFindById.mockResolvedValue({
-      _id: "batch-2",
-      batchId: "BATCH-101",
-      currentStage: "farmer",
-      updates: [],
-      save: jest.fn().mockResolvedValue(true),
-    });
-    mockGetIO.mockReturnValue({
-      to: jest.fn().mockReturnThis(),
-      emit: jest.fn(),
-    });
+  it("rolls back all database changes and leaves the auction retryable", async () => {
+    failBatchIds.add("batch-1");
 
     await settleExpiredAuctions();
 
-    expect(auction.status).toBe("ended");
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(100);
+    expect(batches[0].currentStage).toBe("farmer");
+    expect(batches[0].updates).toHaveLength(0);
+    expect(auctions[0].status).toBe("active");
+    expect(auctions[0].settledAt).toBeNull();
+    expect(sessions[0].abortTransaction).toHaveBeenCalledTimes(1);
+    expect(mockCreateInAppNotification).not.toHaveBeenCalled();
+    expect(mockSocketEmit).not.toHaveBeenCalled();
+  });
+
+  it("ends an auction without bids without crediting or updating a batch", async () => {
+    auctions[0].highestBidder = null;
+
+    await settleExpiredAuctions();
+
+    expect(auctions[0].status).toBe("ended");
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(100);
+    expect(batches[0].currentStage).toBe("farmer");
+    expect(batches[0].updates).toHaveLength(0);
+    expect(mockUserFindOneAndUpdate).not.toHaveBeenCalled();
     expect(mockCreateInAppNotification).not.toHaveBeenCalled();
     expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockSocketEmit.mock.calls.filter(([event]) => event === "auction_ended")).toHaveLength(1);
+  });
+
+  it("continues with another expired auction after one settlement fails", async () => {
+    auctions.push(makeAuction({
+      _id: "auction-2",
+      cropId: "batch-2",
+      batchId: "BATCH-200",
+      farmerId: "farmer-2",
+      highestBidder: "buyer-2",
+      currentHighestBid: 75,
+    }));
+    users.push(
+      { _id: "farmer-2", name: "Farmer Two", email: "farmer2@example.com", balance: 50 },
+      { _id: "buyer-2", name: "Buyer Two", email: "buyer2@example.com", balance: 300 },
+    );
+    batches.push({ _id: "batch-2", batchId: "BATCH-200", currentStage: "farmer", updates: [] });
+    failBatchIds.add("batch-1");
+
+    await settleExpiredAuctions();
+
+    expect(auctions.find((auction) => auction._id === "auction-1").status).toBe("active");
+    expect(users.find((user) => user._id === "farmer-1").balance).toBe(100);
+    expect(auctions.find((auction) => auction._id === "auction-2").status).toBe("ended");
+    expect(users.find((user) => user._id === "farmer-2").balance).toBe(125);
+    expect(batches.find((batch) => batch._id === "batch-2").updates).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## 📌 Overview

Fixes a race condition in expired-auction settlement that could allow concurrent workers to settle the same auction more than once.

Previously, settlement queried expired active auctions and then performed separate non-transactional updates. Concurrent executions could therefore credit the farmer multiple times, append duplicate batch history entries, and emit duplicate notifications, emails, and socket events.

This PR refactors settlement to use MongoDB transactions and durable settlement metadata, ensuring that auction finalization, farmer credit, and batch updates occur atomically and only once.

---

## 🛠️ Type of Change

* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #699

---

## 🧪 Testing & Verification

### Unit Tests

```text
npm test -- --runInBand --watchAll=false tests/auctionSettlement.test.js
PASS — 6/6 tests
```

### Integration Test (MongoDB Replica Set)

```text
npm test -- --runInBand --watchAll=false tests/auctionSettlement.integration.test.js
PASS — 1/1 test
```

### Combined Execution

```text
npm test -- --runInBand --watchAll=false tests/auctionSettlement.test.js tests/auctionSettlement.integration.test.js
PASS — 7/7 tests
```

### Additional Checks

* `node --check` passed for all modified JavaScript files.
* `git diff --check` passed.
* Real concurrency verified using `MongoMemoryReplSet`.

#### Verification Checklist

* [ ] **Smart Contracts:** NA
* [ ] **Frontend:** NA
* [ ] **Integration:** NA

---

## 📸 Screenshots / Demos

N/A (Backend-only change)

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [x] I have commented my code where necessary.
* [ ] I have updated the documentation accordingly. (No documentation changes required)
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

### Key Changes

* Added transactional auction settlement using `session.withTransaction()`.
* Added durable `settledAt` metadata.
* Prevented already-settled auctions from being reclaimed.
* Ensured farmer credit, batch updates, and auction finalization occur in a single transaction.
* Isolated notification, email, socket, and logging side effects so they execute only after a successful commit.
* Added rollback coverage, idempotency coverage, no-bid coverage, failure-isolation coverage, and real concurrency integration testing.

### Deployment Requirement

This implementation requires MongoDB transaction support (replica set or sharded cluster).

The repository's current `docker-compose.yml` and `docker-compose.prod.yml` use standalone MongoDB deployments and therefore cannot execute `session.withTransaction()`.

A follow-up deployment update is required to configure MongoDB as a replica set for Compose-based environments.