### PR TITLE
Fix: dynamic block explorer url

### DIFF
--- a/backend/services/blockchainWorker.js
+++ b/backend/services/blockchainWorker.js
@@ -21,6 +21,47 @@ const User = require('../models/User');
 const { getStageNumber } = require('../constants/stages');
 const { addEmailJob } = require('../jobs/queue');
 
+// Block explorer URL cache and resolvers
+let _explorerBaseUrl = null;
+
+/**
+ * Resolve block explorer base URL from provider chain ID
+ * @returns {Promise<string>} Base URL for the block explorer
+ */
+async function getExplorerBaseUrl() {
+    if (_explorerBaseUrl) return _explorerBaseUrl;
+
+    try {
+        const network = await provider.getNetwork();
+        const chainId = Number(network.chainId);
+        const explorers = {
+            1: 'https://etherscan.io',
+            5: 'https://goerli.etherscan.io',
+            11155111: 'https://sepolia.etherscan.io',
+            137: 'https://polygonscan.com',
+            80001: 'https://mumbai.polygonscan.com',
+            42161: 'https://arbiscan.io',
+            421614: 'https://sepolia.arbiscan.io',
+            1101: 'https://zkevm.polygonscan.com',
+            2442: 'https://cardona-zkevm.polygonscan.com',
+        };
+        _explorerBaseUrl = explorers[chainId] || 'https://sepolia.etherscan.io';
+    } catch {
+        _explorerBaseUrl = 'https://sepolia.etherscan.io';
+    }
+    return _explorerBaseUrl;
+}
+
+/**
+ * Build a block explorer URL for a transaction
+ * @param {string} txHash - Transaction hash
+ * @returns {Promise<string>} Full explorer URL
+ */
+async function getBlockExplorerTxUrl(txHash) {
+    const baseUrl = await getExplorerBaseUrl();
+    return `${baseUrl}/tx/${txHash}`;
+}
+
 // Gas configuration
 const GAS_CONFIG = {
     maxFeePerGas: ethers.parseUnits('100', 'gwei'), // Max 100 gwei
@@ -319,13 +360,14 @@ async function processCreateBatch(job) {
             if (batchDoc) {
                 const farmer = await User.findById(batchDoc.farmerId).lean();
                 if (farmer && farmer.email) {
+                    const explorerUrl = await getBlockExplorerTxUrl(tx.hash);
                     await addEmailJob(
                         farmer.email,
                         `Blockchain Confirmation: Batch ${batchId} Created`,
                         `<h2>Batch Creation Confirmed</h2>
                         <p>Hello ${farmer.name},</p>
                         <p>Your batch <strong>${batchId}</strong> has been successfully recorded on the blockchain.</p>
-                        <p>Transaction Hash: <a href="https://sepolia.etherscan.io/tx/${tx.hash}">${tx.hash}</a></p>
+                        <p>Transaction Hash: <a href="${explorerUrl}">${tx.hash}</a></p>
                         <p>Block Number: ${receipt.blockNumber}</p>
                         <p>CropChain Team</p>`
                     );
@@ -512,13 +554,14 @@ async function processUpdateBatch(job) {
             if (batchDoc) {
                 const farmer = await User.findById(batchDoc.farmerId).lean();
                 if (farmer && farmer.email) {
+                    const explorerUrl = await getBlockExplorerTxUrl(tx.hash);
                     await addEmailJob(
                         farmer.email,
                         `Blockchain Confirmation: Batch ${batchId} Updated`,
                         `<h2>Batch Update Confirmed</h2>
                         <p>Hello ${farmer.name},</p>
                         <p>The update to your batch <strong>${batchId}</strong> has been successfully recorded on the blockchain.</p>
-                        <p>Transaction Hash: <a href="https://sepolia.etherscan.io/tx/${tx.hash}">${tx.hash}</a></p>
+                        <p>Transaction Hash: <a href="${explorerUrl}">${tx.hash}</a></p>
                         <p>Block Number: ${receipt.blockNumber}</p>
                         <p>CropChain Team</p>`
                     );

--- a/prdescription.md
+++ b/prdescription.md
@@ -1,0 +1,63 @@
+## 📌 Overview
+
+This PR fixes the hardcoded block explorer URL in blockchain worker email notifications. Both email templates in `blockchainWorker.js` pointed to `sepolia.etherscan.io` regardless of which network the contract was actually deployed on (Polygon Mumbai, Arbitrum Sepolia, Polygon zkEVM, Ethereum mainnet, etc.), producing dead links for non-Sepolia deployments.
+
+## 🛠️ Type of Change
+- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
+- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
+- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
+- [ ] 📄 **Documentation** (README, Roadmap updates)
+- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)
+
+---
+
+## 🔗 Related Issue
+Closes #<issue-number>
+
+---
+
+## 🧪 Testing & Verification
+- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
+- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
+- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)
+
+---
+
+## 📸 Screenshots / Demos
+
+N/A
+
+---
+
+## ✅ PR Checklist
+- [x] My code follows the project's style guidelines.
+- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
+- [ ] I have updated the documentation accordingly.
+- [x] My changes generate no new warnings.
+
+---
+
+## 💬 Additional Notes
+
+### Root cause
+Two inline HTML email templates in `blockchainWorker.js` hardcoded `https://sepolia.etherscan.io/tx/${tx.hash}` as the transaction link. The worker uses `process.env.INFURA_URL` to connect to the provider, but the explorer URL never reflected the actual network.
+
+### Fix
+Added a cached chain-ID-to-explorer resolver (`getExplorerBaseUrl`) that calls `provider.getNetwork()` to detect the chain ID and maps it to the correct block explorer. Supported networks:
+
+| Chain ID | Network | Explorer URL |
+|---|---|---|
+| 1 | Ethereum Mainnet | etherscan.io |
+| 5 | Goerli | goerli.etherscan.io |
+| 11155111 | Sepolia | sepolia.etherscan.io |
+| 137 | Polygon Mainnet | polygonscan.com |
+| 80001 | Mumbai | mumbai.polygonscan.com |
+| 42161 | Arbitrum One | arbiscan.io |
+| 421614 | Arbitrum Sepolia | sepolia.arbiscan.io |
+| 1101 | Polygon zkEVM | zkevm.polygonscan.com |
+| 2442 | Polygon zkEVM Cardona | cardona-zkevm.polygonscan.com |
+
+If the chain ID is unrecognized or the network call fails, the resolver falls back to `sepolia.etherscan.io` (preserving backward compatibility).
+
+### Files changed
+- `backend/services/blockchainWorker.js` — added `getExplorerBaseUrl()` and `getBlockExplorerTxUrl()` helpers; replaced both hardcoded Sepolia Etherscan links in `processCreateBatch` and `processUpdateBatch` email templates with dynamic URLs


### PR DESCRIPTION
## 📌 Overview

This PR fixes the hardcoded block explorer URL in blockchain worker email notifications. Both email templates in `blockchainWorker.js` pointed to `sepolia.etherscan.io` regardless of which network the contract was actually deployed on (Polygon Mumbai, Arbitrum Sepolia, Polygon zkEVM, Ethereum mainnet, etc.), producing dead links for non-Sepolia deployments.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #778

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

### Root cause
Two inline HTML email templates in `blockchainWorker.js` hardcoded `https://sepolia.etherscan.io/tx/${tx.hash}` as the transaction link. The worker uses `process.env.INFURA_URL` to connect to the provider, but the explorer URL never reflected the actual network.

### Fix
Added a cached chain-ID-to-explorer resolver (`getExplorerBaseUrl`) that calls `provider.getNetwork()` to detect the chain ID and maps it to the correct block explorer. Supported networks:

| Chain ID | Network | Explorer URL |
|---|---|---|
| 1 | Ethereum Mainnet | etherscan.io |
| 5 | Goerli | goerli.etherscan.io |
| 11155111 | Sepolia | sepolia.etherscan.io |
| 137 | Polygon Mainnet | polygonscan.com |
| 80001 | Mumbai | mumbai.polygonscan.com |
| 42161 | Arbitrum One | arbiscan.io |
| 421614 | Arbitrum Sepolia | sepolia.arbiscan.io |
| 1101 | Polygon zkEVM | zkevm.polygonscan.com |
| 2442 | Polygon zkEVM Cardona | cardona-zkevm.polygonscan.com |

If the chain ID is unrecognized or the network call fails, the resolver falls back to `sepolia.etherscan.io` (preserving backward compatibility).

### Files changed
- `backend/services/blockchainWorker.js` — added `getExplorerBaseUrl()` and `getBlockExplorerTxUrl()` helpers; replaced both hardcoded Sepolia Etherscan links in `processCreateBatch` and `processUpdateBatch` email templates with dynamic URLs
