### PR TITLE
fix: resolve sub-batch ID collision in buyFromListing

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -419,7 +419,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         }
 
         // Mint a sub-batch for the buyer to preserve traceability
-        bytes32 subBatchId = keccak256(abi.encodePacked(listing.batchId, msg.sender, block.timestamp, listingId));
+        bytes32 subBatchId = keccak256(abi.encodePacked(listing.batchId, msg.sender, block.timestamp, listingId, allBatchIds.length));
         
         cropBatches[subBatchId] = CropBatch({
             batchId: subBatchId,


### PR DESCRIPTION
## 📌 Overview
Resolves a critical bug in `CropChain.sol` where multiple purchases from the same listing within the identical block resulted in `subBatchId` hash collisions. This collision caused silent overwrites and permanent asset loss for the buyer. Fixed by appending `allBatchIds.length` as a globally unique, strictly incrementing nonce to the `keccak256` payload during `subBatchId` generation.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #799

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
By injecting `allBatchIds.length` directly into the `abi.encodePacked` hashing payload in `buyFromListing`, the generated hash is now mathematically guaranteed to be unique for every single purchase, completely eliminating same-block time-based collisions.
