### PR TITLE
Fix/issue 2 custody transfer

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -419,7 +419,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         }
 
         // Mint a sub-batch for the buyer to preserve traceability
-        bytes32 subBatchId = keccak256(abi.encodePacked(listing.batchId, msg.sender, block.timestamp, listingId));
+        bytes32 subBatchId = keccak256(abi.encodePacked(listing.batchId, msg.sender, block.timestamp, listingId, allBatchIds.length));
         
         cropBatches[subBatchId] = CropBatch({
             batchId: subBatchId,

--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -298,12 +298,10 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // Clear approval after use
         nextCustodianApproval[batchId] = address(0);
 
-        // batchListedQuantity is intentionally NOT reset here. The tracker accumulates
-        // across custodian transitions so the over-allocation guard in createListing()
-        // always reflects the total quantity ever listed minus what has been sold.
-        // Resetting would let a new custodian re-list the full batch quantity while
-        // prior custodians' listings remain active, allowing total listed quantity
-        // to exceed the physical batch quantity.
+        // Reset batchListedQuantity to 0 on custody transfer because the new custodian
+        // now holds the full physical batch and any prior active listings are invalidated
+        // (they can no longer be bought).
+        batchListedQuantity[batchId] = 0;
 
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");
@@ -466,13 +464,12 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         require(listing.active, "Listing inactive");
         require(msg.sender == listing.seller || hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not allowed");
 
-        // Restore the listing's remaining available quantity back to the batch's tracker.
-        // This must happen regardless of who the current custodian is — if custody
-        // has transferred since the listing was created, the condition
-        // listing.seller == _getCurrentCustodian(listing.batchId) would fail and the
-        // tracker would never be decremented, permanently reducing the batch's
-        // available listing supply until no further listings can be created.
-        batchListedQuantity[listing.batchId] -= listing.quantityAvailable;
+        // Only restore the listed quantity if the seller is still the current custodian.
+        // If custody has transferred, the batchListedQuantity was already reset to 0
+        // during updateBatch, and deducting here would corrupt the new custodian's tracker.
+        if (listing.seller == _getCurrentCustodian(listing.batchId)) {
+            batchListedQuantity[listing.batchId] -= listing.quantityAvailable;
+        }
 
         listing.active = false;
         listing.quantityAvailable = 0;


### PR DESCRIPTION
## 📌 Overview
Resolves a critical logic bug where transferring physical custody of a batch failed to clear `batchListedQuantity`. This flaw allowed defunct listings from previous custodians to permanently lock up the batch's supply allocation. Fixed by explicitly resetting `batchListedQuantity = 0` during `updateBatch` custody transfers, and modifying `cancelListing` to only deduct listed quantities if the seller is still the current active custodian.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #800

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
This fix ensures that older un-buyable "ghost" listings from previous custodians no longer artificially restrict the new, rightful physical custodian's ability to list their exact physical batch quantity on the marketplace.
