### PR TITLE
fix(frontend): resolve AI chatbot using localhost in production

### DIFF
--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -2,7 +2,9 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { tokenService } from './token.service';
 import { sanitizeObject } from '../lib/sanitize';
 
-const baseApiUrl = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_URL) || 'http://localhost:3001';
+// const baseApiUrl = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_URL) || 'http://localhost:3001';
+const baseApiUrl =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 export const API_URL = baseApiUrl.endsWith('/api') ? baseApiUrl : `${baseApiUrl.replace(/\/$/, '')}/api`;
 
 interface RetriableRequestConfig extends InternalAxiosRequestConfig {

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -2,7 +2,6 @@ import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
 import { tokenService } from './token.service';
 import { sanitizeObject } from '../lib/sanitize';
 
-// const baseApiUrl = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_API_URL) || 'http://localhost:3001';
 const baseApiUrl =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 export const API_URL = baseApiUrl.endsWith('/api') ? baseApiUrl : `${baseApiUrl.replace(/\/$/, '')}/api`;

--- a/frontend/src/services/socketService.ts
+++ b/frontend/src/services/socketService.ts
@@ -1,7 +1,5 @@
 import { io, Socket } from 'socket.io-client';
 
-// const SOCKET_URL = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_SOCKET_URL) || `http://localhost:3001`;
-
 const SOCKET_URL =
   process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
 

--- a/frontend/src/services/socketService.ts
+++ b/frontend/src/services/socketService.ts
@@ -1,6 +1,9 @@
 import { io, Socket } from 'socket.io-client';
 
-const SOCKET_URL = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_SOCKET_URL) || `http://localhost:3001`;
+// const SOCKET_URL = (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_SOCKET_URL) || `http://localhost:3001`;
+
+const SOCKET_URL =
+  process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
 
 let socketInstance: Socket | null = null;
 let authToken: string | null = null;


### PR DESCRIPTION
## 📌 Overview
Fixes the frontend AI chatbot configuration so that production builds correctly use the configured `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_SOCKET_URL` instead of falling back to `localhost:3001`.

The changes ensure that API and Socket.IO endpoints are resolved using Next.js public environment variables during build time.
---
## 🛠️ Type of Change

- [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ Backend
- [ ] 📄 Documentation
- [ ] 🧪 Testing
- [ ] ⛓️ Smart Contract
---
## 🔗 Related Issue

Closes #785 

---

## 🧪 Testing & Verification

- [ ] Smart Contracts: NA
- [x] Frontend: Verified locally
- [ ] Integration: NA

### Verification

- Before the fix, the frontend attempted to send requests to:
  ```
  http://localhost:3001/api/ai/batch-query
  ```
  resulting in:
  ```
  ERR_CONNECTION_REFUSED
  ```

- After the fix, the frontend correctly sends requests to:
  ```
  https://cropapi.sonusid.in/api/ai/batch-query
  ```

- The remaining HTTP 530 response originates from the deployed backend/Cloudflare infrastructure and is outside the scope of this frontend change.

---

## 📸 Screenshots / Demos

### Before
<img width="1022" height="163" alt="image" src="https://github.com/user-attachments/assets/a29edb08-1c83-4108-ab31-8555827d36ea" />


```
POST http://localhost:3001/api/ai/batch-query
ERR_CONNECTION_REFUSED
```

### After
<img width="1037" height="177" alt="image" src="https://github.com/user-attachments/assets/cd4220d0-899e-4457-bff7-dddb87968c5a" />
<img width="1317" height="522" alt="image" src="https://github.com/user-attachments/assets/3ce5bb37-4649-4255-835c-ac5adf7a9ece" />


```
POST https://cropapi.sonusid.in/api/ai/batch-query
HTTP 530 (Cloudflare)
```

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have commented my code, particularly in complex areas (N/A)
- [ ] I have updated the documentation accordingly. (N/A)
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This PR intentionally contains only the minimal frontend changes required to resolve the incorrect API endpoint resolution.

Modified files:

- `frontend/src/services/apiClient.ts`
- `frontend/src/services/socketService.ts`

No backend, authentication, deployment, or infrastructure changes are included in this PR.