### PR TITLE
fix(socket): authorize verification room membership

### DIFF
--- a/backend/services/socketService.js
+++ b/backend/services/socketService.js
@@ -229,9 +229,23 @@ function initializeSocketIO(httpServer) {
       socket.on(
         "join-verification-room",
         withGuard("join-verification-room", (userId) => {
-          socket.join(`verification:user:${userId}`);
+          const authenticatedUserId = socket.user?.id;
+          if (
+            !authenticatedUserId ||
+            authenticatedUserId.toString() !== userId
+          ) {
+            socket.emit("error", {
+              message: "Access denied: you can only join your own verification room",
+            });
+            logger.warn(
+              `[SOCKET] Unauthorized attempt by ${socket.id} to join verification room`,
+            );
+            return;
+          }
+
+          socket.join(`verification:user:${authenticatedUserId}`);
           logger.info(
-            `[SOCKET] Client ${socket.id} joined verification room: ${userId}`,
+            `[SOCKET] Client ${socket.id} joined verification room: ${authenticatedUserId}`,
           );
         }),
       );

--- a/backend/tests/socket.test.js
+++ b/backend/tests/socket.test.js
@@ -181,6 +181,55 @@ describe("Socket.IO Service", () => {
 
       expect(mockIo.to).toHaveBeenCalledWith("batch:BATCH001");
     });
+
+    test("emitToVerificationRoom should emit to the correct user room", () => {
+      const eventData = { status: "verified" };
+
+      socketService.emitToVerificationRoom(
+        "user-a",
+        "verification:updated",
+        eventData,
+      );
+
+      expect(mockIo.to).toHaveBeenCalledWith("verification:user:user-a");
+    });
+  });
+
+  describe("Verification Room Authorization", () => {
+    let joinVerificationRoomHandler;
+
+    beforeEach(() => {
+      const { Server } = require("socket.io");
+      socketService.initializeSocketIO({});
+
+      const connectionHandler = Server.onCallback.mock.calls.find(
+        ([eventName]) => eventName === "connection",
+      )[1];
+      mockSocket.user = { id: "user-a", role: "farmer" };
+      connectionHandler(mockSocket);
+      joinVerificationRoomHandler = mockSocket.on.mock.calls.find(
+        ([eventName]) => eventName === "join-verification-room",
+      )[1];
+    });
+
+    test("allows a user to join their own verification room", async () => {
+      await joinVerificationRoomHandler("user-a");
+
+      expect(mockSocket.join).toHaveBeenCalledWith("verification:user:user-a");
+      expect(mockSocket.emit).not.toHaveBeenCalledWith(
+        "error",
+        expect.any(Object),
+      );
+    });
+
+    test("denies a user from joining another user's verification room", async () => {
+      await joinVerificationRoomHandler("user-b");
+
+      expect(mockSocket.join).not.toHaveBeenCalledWith("verification:user:user-b");
+      expect(mockSocket.emit).toHaveBeenCalledWith("error", {
+        message: "Access denied: you can only join your own verification room",
+      });
+    });
   });
 
   describe("Auction Bidding", () => {


### PR DESCRIPTION
## 📌 Overview

This PR fixes an authorization vulnerability in the Socket.IO verification room handler.

Previously, the `join-verification-room` event trusted a client-supplied `userId` and allowed any authenticated socket to join `verification:user:<userId>` without verifying ownership. This change authorizes room membership using the authenticated socket identity and prevents unauthorized subscriptions to another user's verification events.

The PR also adds tests covering authorized and unauthorized room joins.

---

## 🛠️ Type of Change

- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #772

---

## 🧪 Testing & Verification

- [ ] **Smart Contracts:** `npx hardhat test` passed? **NA**
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? **NA**
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? **NA**

### Verification performed

- Added tests covering:
  - Authorized user joining their own verification room.
  - Unauthorized attempts to join another user's verification room.
  - Verification events continuing to reach the correct recipient.
- Verified `node --check backend/tests/socket.test.js` passes.
- Verified `git diff --check` passes.

> Note: Full Jest execution is currently blocked by pre-existing upstream issues (missing `cross-env` dependency and an existing syntax error tracked separately). These are unrelated to the changes in this PR.

---

## 📸 Screenshots / Demos

N/A (Backend-only change)

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic), where necessary.
- [ ] I have updated the documentation accordingly. *(Not required for this change.)*
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- Authorization now follows the existing socket authentication convention (`socket.user.id`).
- Verification rooms are joined using the authenticated user ID rather than a client-supplied ID.
- The fix is intentionally scoped to the verification room authorization logic and its corresponding tests.