### PR TITLE
fix(mobile): remove duplicate API_URL declaration

### DIFF
--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -1,7 +1,6 @@
 import { API_URL } from "../utils/constants";
 import * as SecureStore from "expo-secure-store";
 
-const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3001/api";
 const TOKEN_KEY = "auth_token";
 
 export const DEFAULT_TIMEOUT = 15000;


### PR DESCRIPTION
## 📌 Overview

This PR fixes a TypeScript compilation error in the mobile application caused by a duplicate `API_URL` declaration.

`mobile/src/services/api.ts` imported `API_URL` from the shared constants module while also declaring a local constant with the same identifier. The duplicate declaration caused an identifier collision during compilation.

This change removes the redundant local declaration and uses the shared configuration as intended.

---

## 🛠️ Type of Change

- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

> Note: Although the fix is in the React Native mobile app, this repository's template does not include a separate Mobile category.

---

## 🔗 Related Issue

Closes #771

---

## 🧪 Testing & Verification

- [ ] **Smart Contracts:** NA
- [ ] **Frontend:** NA
- [ ] **Integration:** NA

### Verification performed

- Verified `git diff --check` passes.
- Confirmed only one `API_URL` declaration remains.
- Confirmed the service now uses the shared configuration from `mobile/src/utils/constants.ts`.

> Full TypeScript compilation could not be executed because the local environment does not contain `mobile/node_modules` or a global `tsc` installation.

---

## 📸 Screenshots / Demos

N/A (Compilation fix)

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have commented my code, particularly in complex areas (Not applicable).
- [ ] I have updated the documentation accordingly. (Not required.)
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- The fix preserves the existing shared configuration for `API_URL`.
- No API request behavior was modified.
- The change is intentionally minimal and scoped only to resolving the duplicate declaration.