### PR TITLE
fix: restrict IoT telemetry submission to batch owner/authorized roles

### DIFF
--- a/backend/constants/permissions.js
+++ b/backend/constants/permissions.js
@@ -61,6 +61,9 @@ const PERMISSIONS = {
   // Cross-chain permissions
   CROSSCHAIN_DISPATCH: "crosschain:dispatch",
   CROSSCHAIN_VIEW: "crosschain:view",
+
+  // IoT permissions
+  IOT_SUBMIT: "iot:submit",
 };
 
 // ==================== ROLES ====================
@@ -93,6 +96,7 @@ const ROLE_PERMISSIONS = {
     PERMISSIONS.BATCH_UPDATE,
     PERMISSIONS.STAGE_FARMER,
     PERMISSIONS.BLOCKCHAIN_TRANSACTION,
+    PERMISSIONS.IOT_SUBMIT,
   ],
 
   [ROLES.MANDI]: [
@@ -107,6 +111,7 @@ const ROLE_PERMISSIONS = {
     PERMISSIONS.BATCH_UPDATE,
     PERMISSIONS.STAGE_TRANSPORT,
     PERMISSIONS.BLOCKCHAIN_TRANSACTION,
+    PERMISSIONS.IOT_SUBMIT,
   ],
 
   [ROLES.RETAILER]: [
@@ -162,6 +167,9 @@ const ROLE_PERMISSIONS = {
     // Cross-chain permissions
     PERMISSIONS.CROSSCHAIN_DISPATCH,
     PERMISSIONS.CROSSCHAIN_VIEW,
+
+    // IoT permissions
+    PERMISSIONS.IOT_SUBMIT,
   ],
 
   [ROLES.SUPER_ADMIN]: [

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -437,6 +437,99 @@ const checkBatchSafetyStatus = async (req, res, next) => {
   }
 };
 
+/**
+ * Authorize IoT telemetry submission for a specific batch.
+ *
+ * Rules (applied in order):
+ *  1. No authenticated user  → 401
+ *  2. Role lacks iot:submit  → 403 (short-circuit, no DB hit)
+ *  3. Batch not found        → 404
+ *  4. User is admin/super_admin → pass (bypass ownership check)
+ *  5. User is batch owner    → pass
+ *  6. Otherwise              → 403
+ *
+ * On success, attaches the batch document to `req.batch`.
+ *
+ * @route  POST /api/batches/:batchId/iot
+ * @access farmer (own batch) | transporter (own batch) | admin | super_admin
+ */
+const authorizeIoTSubmission = async (req, res, next) => {
+  try {
+    if (!req.user) {
+      return res
+        .status(401)
+        .json({ error: "Not authorized", message: "Authentication required" });
+    }
+
+    const userId = req.user.id || req.user._id;
+    const { batchId } = req.params;
+
+    // Step 1: role-permission gate — no DB query needed for this check
+    const rolePermissions = PERMISSIONS.IOT_SUBMIT;
+    const userRolePermissions =
+      require("../constants/permissions").getRolePermissions(req.user.role);
+
+    if (!userRolePermissions.includes(rolePermissions)) {
+      logger.warn("IoT submit blocked: insufficient permission", {
+        userId,
+        role: req.user.role,
+        batchId,
+        reason: "insufficient permission",
+      });
+      return res
+        .status(403)
+        .json({ error: "Access denied", message: "Insufficient permissions to submit IoT data" });
+    }
+
+    // Step 2: fetch the batch
+    const batch = await Batch.findOne({ batchId });
+    if (!batch) {
+      return res
+        .status(404)
+        .json({ error: "Not Found", message: "Batch not found" });
+    }
+
+    // Step 3: admins bypass ownership check
+    if (isAdminRole(req.user.role)) {
+      req.batch = batch;
+      return next();
+    }
+
+    // Step 4: ownership check
+    const userFarmerId = req.user.farmerId || userId;
+    const batchOwnerStr = batch.farmerId?.toString().trim().toLowerCase() || "";
+    const userFarmerIdStr = userFarmerId?.toString().trim().toLowerCase() || "";
+    const userIdStr = userId?.toString().trim().toLowerCase() || "";
+
+    const isOwner =
+      batchOwnerStr === userFarmerIdStr || batchOwnerStr === userIdStr;
+
+    if (!isOwner) {
+      logger.warn("IoT submit blocked: ownership check failed", {
+        userId,
+        role: req.user.role,
+        batchId,
+        batchOwner: batch.farmerId?.toString(),
+        reason: "ownership check failed",
+      });
+      return res
+        .status(403)
+        .json({ error: "Access denied", message: "Unauthorized access to batch" });
+    }
+
+    req.batch = batch;
+    return next();
+  } catch (error) {
+    logger.error("IoT authorization error", {
+      error: error.message,
+      stack: error.stack,
+    });
+    return res
+      .status(500)
+      .json({ error: "Server Error", message: "Authorization check failed" });
+  }
+};
+
 module.exports = {
   protect,
   adminOnly,
@@ -450,4 +543,5 @@ module.exports = {
   inspectorOnly,
   requireMultisigOrAdmin,
   checkBatchSafetyStatus,
+  authorizeIoTSubmission,
 };

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -8,7 +8,7 @@ const {
   recordIoTData,
   getIoTData,
 } = require("../controllers/batchController");
-const { protect, adminOnly } = require("../middleware/auth");
+const { protect, adminOnly, authorizeIoTSubmission } = require("../middleware/auth");
 const { batchLimiter, iotLimiter } = require("../middleware/rateLimiters");
 
 router.get("/status", (req, res) => {
@@ -40,8 +40,8 @@ router.patch(
   updateBatchStatus,
 );
 
-// IoT sensor data
-router.post("/batches/:batchId/iot", iotLimiter, protect, recordIoTData);
+// IoT sensor data — POST requires ownership/role check (fix for issue #809)
+router.post("/batches/:batchId/iot", iotLimiter, protect, authorizeIoTSubmission, recordIoTData);
 router.get("/batches/:batchId/iot", iotLimiter, protect, getIoTData);
 router.get("/batches/:batchId/iot/history", iotLimiter, protect, getIoTData);
 


### PR DESCRIPTION
## Summary

Fixes #809 
`POST /api/batches/:batchId/iot` was protected only by authentication, allowing any logged-in user to submit spoofed temperature/humidity readings for batches they don't own. This could corrupt spoilage status and supply-chain activity history.

## Changes

### `backend/constants/permissions.js`
- Added `IOT_SUBMIT: "iot:submit"` permission
- Granted to: `farmer`, `transporter`, `admin`, `super_admin`
- Excluded: `mandi`, `retailer`, `quality_inspector`

### `backend/middleware/auth.js`
- Added `authorizeIoTSubmission` middleware with the following logic:
  - No authenticated user → 401
  - Role lacks `iot:submit` → 403 (short-circuits before any DB query)
  - Batch not found → 404
  - `admin` / `super_admin` → allowed regardless of ownership
  - Batch owner (`farmerId` match) → allowed
  - Any other authenticated user → 403 + audit log

### `backend/routes/index.js`
- `POST /api/batches/:batchId/iot` middleware chain updated:
  `iotLimiter → protect → authorizeIoTSubmission → recordIoTData`
- `GET` IoT routes unchanged — no regression

## Security Impact

Before this fix, any authenticated user could POST fabricated sensor readings to any batch. After this fix, only the batch owner (farmer/transporter) or an admin can submit telemetry. Every rejected attempt is logged with `userId`, `role`, `batchId`, and rejection reason for audit purposes.

## Testing

- Unauthenticated request → 401
- Authenticated user with no `iot:submit` role (e.g. `mandi`) → 403
- Authenticated farmer posting to a batch they don't own → 403
- Authenticated farmer posting to their own batch → 200
- Admin posting to any batch → 200
- GET IoT endpoints still accessible to all authenticated users → 200
