### PR TITLE
fix(chat): make AI chat messages scrollable

### DIFF
--- a/frontend/src/components/AIChatbot.tsx
+++ b/frontend/src/components/AIChatbot.tsx
@@ -428,11 +428,11 @@ const AIChatbot: React.FC = () => {
               <AnimatePresence>
                 {!isMinimized && (
                   <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
                     transition={{ duration: 0.3 }}
-                    className="flex flex-col flex-1"
+                    className="flex flex-col flex-1 min-h-0"
                   >
                     {/* Messages Area */}
                     <div className="flex-1 overflow-y-auto p-4 space-y-4 scrollbar-thin scrollbar-thumb-green-200 dark:scrollbar-thumb-gray-600">


### PR DESCRIPTION
## 📌 Overview

This PR fixes the AI chat interface where the conversation was not scrollable after the number of messages exceeded the visible chat area. The message container now supports vertical scrolling while keeping the chat header and input section fixed, improving usability during long conversations.

---

## 🛠️ Type of Change

- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #786 

---

## 🧪 Testing & Verification

- [ ] **Smart Contracts:** `npx hardhat test` passed? (NA)
- [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos

**Before:**
<img width="475" height="637" alt="image" src="https://github.com/user-attachments/assets/19e83893-06ad-4099-9557-cc9359dc2fc3" />

- Chat messages overflowed the visible area without a scrollbar, making older messages inaccessible.

**After:**
<img width="481" height="640" alt="image" src="https://github.com/user-attachments/assets/88732492-53e3-4fe6-a325-697e10346e38" />

- Chat message container scrolls correctly when the conversation exceeds the available height.
- Header and input remain fixed while browsing previous messages.

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic). *(Not applicable)*
- [ ] I have updated the documentation accordingly. *(Not applicable)*
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- Applied a minimal frontend-only fix.
- No backend logic or API functionality was modified.
- Existing UI behavior and responsiveness have been preserved.