### PR TITLE
ci: add automated SBOM generation with anchore/sbom-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,19 @@ jobs:
       - name: Run Frontend Tests
         working-directory: frontend/
         run: npm run test:ci
+
+  # Job 6: SBOM Generation
+  sbom-generation:
+    name: Generate Software Bill of Materials (SBOM)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM (SPDX)
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          artifact-name: cropchain-sbom.spdx.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,14 @@ mumbai: {
 - **Fail-Safe**: Empty accounts array prevents accidental transactions
 - **Hardhat Compliant**: Follows Hardhat best practices
 
+## Supply Chain Security (SBOM)
+
+To maintain visibility into our software supply chain and third-party dependencies, CropChain automatically generates a Software Bill of Materials (SBOM) during the CI pipeline.
+
+- **Standard**: We use the SPDX format for our generated SBOMs.
+- **Access**: The SBOM is automatically uploaded as a GitHub Actions artifact (`cropchain-sbom.spdx.json`) upon every build. It can be downloaded from the "Artifacts" section of any successful workflow run.
+- **Tooling**: We utilize the official `anchore/sbom-action` to ensure reproducible and accurate SBOM generation.
+
 ## Setup Instructions
 
 ### For Local Development


### PR DESCRIPTION
📌 Overview
Integrated automated Software Bill of Materials (SBOM) generation into our CI pipeline using the `anchore/sbom-action`. This ensures we maintain full visibility into our software supply chain and third-party dependencies. The generated SPDX-formatted SBOM is automatically uploaded as a GitHub Actions artifact on every build. I have also added documentation for this process in `SECURITY.md`.

🛠️ Type of Change
 [ ] ⛓️ Smart Contract (Solidity changes, Gas optimization)
 [ ] 💻 Frontend (UI/UX, React components, Tailwind)
 [ ] ⚙️ Backend (API routes, MongoDB schemas, Middleware)
 [x] 📄 Documentation (README, Roadmap updates, SECURITY.md)
 [x] 🧪 Testing (Hardhat tests, Jest/Vitest, CI/CD Pipeline & Supply Chain Security)

🔗 Related Issue
Closes #838 

🧪 Testing & Verification
 Smart Contracts: npx hardhat test passed? (NA)
 Frontend: Verified on Mobile/Desktop responsiveness? (NA)
 Integration: Verified ethers.js connectivity with local/testnet node? (NA)

📸 Screenshots / Demos
*(N/A - CI configuration updates only)*

✅ PR Checklist
 [x] My code follows the project's style guidelines.
 [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
 [x] I have updated the documentation accordingly.
 [x] My changes generate no new warnings.
