### PR TITLE
ci: automate Docker image publishing to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,58 @@ jobs:
       - name: Run Frontend Tests
         working-directory: frontend/
         run: npm run test:ci
+
+  # Job 6: Publish Docker Images
+  docker-publish:
+    name: Publish Docker Images to GHCR
+    runs-on: ubuntu-latest
+    needs: [backend-tests, frontend-tests, smart-contract-tests, smart-contract-security-audit]
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: read
+      packages: write
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: backend
+            context: backend/
+            dockerfile: backend/Dockerfile.dev
+          - name: frontend
+            context: frontend/
+            dockerfile: frontend/Dockerfile.dev
+          - name: ml-service
+            context: ml-service/
+            dockerfile: ml-service/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.service.name }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch
+            type=sha,prefix=sha-
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.service.context }}
+          file: ${{ matrix.service.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ The system is live and deployed across production services:
 ````md
 ## Docker Setup
 
+### Published Images (GHCR)
+
+Validated Docker images are automatically published to the GitHub Container Registry (GHCR) upon merging to the `main` branch or creating a release tag.
+
+Available images include:
+- `ghcr.io/<repository-owner>/backend:latest` (or `:main`, `:sha-<commit>`)
+- `ghcr.io/<repository-owner>/frontend:latest`
+- `ghcr.io/<repository-owner>/ml-service:latest`
+
 ### Prerequisites
 
 Make sure the following are installed on your system:


### PR DESCRIPTION
📌 Overview
Automated the publishing of our Docker images to the GitHub Container Registry (GHCR). This workflow securely authenticates with GHCR using the built-in `GITHUB_TOKEN`, builds the images, and automatically tags and publishes them upon successful completion of our CI and security tests on `main`. I also added documentation for these pre-built images in the `README.md`.

🛠️ Type of Change
 [ ] ⛓️ Smart Contract (Solidity changes, Gas optimization)
 [ ] 💻 Frontend (UI/UX, React components, Tailwind)
 [ ] ⚙️ Backend (API routes, MongoDB schemas, Middleware)
 [x] 📄 Documentation (README, Roadmap updates)
 [x] 🧪 Testing (CI/CD Pipeline, Deployment Automation)

🔗 Related Issue
Closes #840 

🧪 Testing & Verification
 Smart Contracts: npx hardhat test passed? (NA)
 Frontend: Verified on Mobile/Desktop responsiveness? (NA)
 Integration: Verified ethers.js connectivity with local/testnet node? (NA)

📸 Screenshots / Demos
*(N/A - CI configuration updates only)*

✅ PR Checklist
 [x] My code follows the project's style guidelines.
 [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
 [x] I have updated the documentation accordingly.
 [x] My changes generate no new warnings.
