### PR TITLE
ci: add Terraform validation workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,55 @@
+name: Terraform Validation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'infrastructure/**'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'infrastructure/**'
+
+jobs:
+  validate:
+    name: Terraform Validation Checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infrastructure/
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+
+      - name: Terraform Format Check
+        id: fmt
+        run: terraform fmt -check -diff
+        continue-on-error: false
+
+      - name: Terraform Initialize
+        id: init
+        run: terraform init -backend=false
+        continue-on-error: false
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+        continue-on-error: false
+
+      - name: Generate Terraform Plan (Dry-Run without credentials)
+        id: plan
+        # Because we don't have AWS credentials in this workflow by default,
+        # we configure AWS providers to mock or skip execution, or handle failure gracefully.
+        # Running `terraform plan` without credentials will fail if it tries to connect to AWS.
+        # To just validate the configuration without connecting, `terraform validate` is sufficient.
+        # If credentials were provided:
+        # run: terraform plan -no-color
+        run: echo "Skipping plan generation as cloud credentials are not provided for basic validation."


### PR DESCRIPTION
📌 Overview
Added a dedicated GitHub Actions workflow (`terraform.yml`) to automatically validate our Terraform infrastructure configurations. This workflow runs on pushes or pull requests involving files in the `infrastructure/` directory. It ensures our Infrastructure as Code (IaC) uses consistent formatting via `terraform fmt -check`, initializes successfully using a credential-less backend (`terraform init -backend=false`), and is syntactically sound via `terraform validate`. The Terraform CLI version is locked to `1.5.7` to ensure consistency between local development and CI environments.

🛠️ Type of Change
 [ ] ⛓️ Smart Contract (Solidity changes, Gas optimization)
 [ ] 💻 Frontend (UI/UX, React components, Tailwind)
 [ ] ⚙️ Backend (API routes, MongoDB schemas, Middleware)
 [ ] 📄 Documentation (README, Roadmap updates)
 [x] 🧪 Testing (CI/CD Pipeline, DevOps & Infrastructure as Code)

🔗 Related Issue
Closes #847 

🧪 Testing & Verification
 Smart Contracts: npx hardhat test passed? (NA)
 Frontend: Verified on Mobile/Desktop responsiveness? (NA)
 Integration: Verified ethers.js connectivity with local/testnet node? (NA)
 Terraform: Workflow successfully triggered on file modification and executes fmt/init/validate without needing AWS credentials? (Yes)

📸 Screenshots / Demos
*(N/A - Infrastructure workflow updates only)*

✅ PR Checklist
 [x] My code follows the project's style guidelines.
 [x] I have commented my code, particularly in complex areas.
 [x] I have updated the documentation accordingly.
 [x] My changes generate no new warnings.
