### PR TITLE
fix: remove duplicate const mongoose declarations in User.js and Auction

### DIFF
--- a/backend/models/Auction.js
+++ b/backend/models/Auction.js
@@ -51,61 +51,6 @@ const auctionSchema = new mongoose.Schema({
     default: null
   }
 }, { timestamps: true, toJSON: { getters: false, virtuals: false } });
-const mongoose = require("mongoose");
-
-const auctionSchema = new mongoose.Schema(
-  {
-    cropId: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "Batch",
-      required: true,
-    },
-    batchId: {
-      type: String,
-      required: true,
-      index: true,
-    },
-    farmerId: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User",
-      required: true,
-    },
-    startPrice: {
-      type: Number,
-      required: true,
-      min: [0, "Start price cannot be negative"],
-    },
-    currentHighestBid: {
-      type: Number,
-      required: true,
-      min: [0, "Current bid cannot be negative"],
-    },
-    highestBidder: {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "User",
-      default: null,
-    },
-    startTime: {
-      type: Date,
-      default: Date.now,
-    },
-    endTime: {
-      type: Date,
-      required: true,
-    },
-    status: {
-      type: String,
-      enum: ["active", "ended", "cancelled"],
-      default: "active",
-      index: true,
-    },
-    settledAt: {
-      type: Date,
-      default: null,
-    },
-  },
-  { timestamps: true },
-);
 
 auctionSchema.index({ status: 1, endTime: 1 });
 
@@ -122,4 +67,3 @@ auctionSchema.set('toJSON', {
 });
 
 module.exports = mongoose.model('Auction', auctionSchema);
-module.exports = mongoose.model("Auction", auctionSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,8 +1,6 @@
 const mongoose = require('mongoose');
 const { ROLES, VALID_ROLES } = require('../constants/permissions');
 const { fromString } = require('../utils/decimalHelpers');
-const mongoose = require("mongoose");
-const { ROLES, VALID_ROLES } = require("../constants/permissions");
 
 const userSchema = new mongoose.Schema(
   {
@@ -97,10 +95,8 @@ const userSchema = new mongoose.Schema(
       default: 0,
     },
     balance: {
-        type: mongoose.Schema.Types.Decimal128,
-        default: () => fromString('100000')
-      type: Number,
-      default: 100000,
+      type: mongoose.Schema.Types.Decimal128,
+      default: () => fromString('100000')
     },
     lastLogin: { type: Date },
     resetPasswordToken: { type: String },


### PR DESCRIPTION
## 📌 Overview

This PR fixes the duplicate `const mongoose = require('mongoose')` declarations in `backend/models/User.js` and `backend/models/Auction.js`. In Node.js strict mode, redeclaring a `const` variable in the same scope throws `SyntaxError: Identifier 'mongoose' has already been declared`, preventing the server from starting. The fix removes the duplicate imports so that each file imports mongoose once at the top.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #830

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified `node -e "require('./backend/app.js')"` runs without SyntaxError? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have not added any redundant comments.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- `User.js` had duplicate `const mongoose` at line 4 and duplicate role imports.
- `Auction.js` had a duplicate `const mongoose` at line 54 along with a full duplicate schema block and duplicate `module.exports`.
- All duplicate blocks and redundant imports have been removed, leaving a single clean import per file.
