### PR TITLE
fix: replace predictable Date.now() nonce with crypto.randomBytes

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -373,7 +373,7 @@ const getNonce = async (req, res) => {
     }
 
     // Generate a unique nonce
-    const nonce = `CropChain Authentication ${Date.now()}`;
+    const nonce = crypto.randomBytes(32).toString('hex');
 
     // Store nonce with expiration (5 minutes)
     await redis.set(`nonce:${address.toLowerCase()}`, nonce, "EX", 300);


### PR DESCRIPTION
## 📌 Overview

This PR fixes the predictable wallet authentication nonce generation in `backend/controllers/authController.js`. The nonce was generated using `` `CropChain Authentication ${Date.now()}` ``, where `Date.now()` increments predictably by ~1000ms per second. An attacker observing a valid nonce could predict future nonces within the 5-minute Redis TTL window, enabling replay attacks. The fix replaces timestamp-based nonces with cryptographically random values using `crypto.randomBytes(32).toString('hex')`.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #831

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified nonces are now 64-char hex strings instead of predictable timestamps? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have not added any redundant comments.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- `crypto` was already imported at the top of the file, so no new dependency was needed.
- The Redis TTL (300s / 5 minutes) remains unchanged — the fix only addresses the predictability of the nonce value itself.
- Nonces are now 64-character hex strings (32 random bytes), providing 256 bits of entropy.
