### PR TITLE
fix: allow role-authorized non-owners to update batch lifecycle

### DIFF
--- a/backend/controllers/lifecycleController.js
+++ b/backend/controllers/lifecycleController.js
@@ -146,11 +146,12 @@ exports.updateLifecycle = async (req, res) => {
       const batchFarmerId = batch.farmerId?.toString().trim().toLowerCase();
       const isOwner = userId === batchFarmerId;
 
-      if (!isOwner) {
-        logger.warn("Lifecycle update rejected: user does not own this batch", {
+      if (!isOwner && !isAuthorizedForStage(req.user.role, stage)) {
+        logger.warn("Lifecycle update rejected: user does not own this batch and role is not authorized for target stage", {
           userId,
           role: req.user.role,
           batchId: batch.batchId,
+          targetStage: stage,
           batchOwner: batch.farmerId
         });
         return res.status(403).json(apiResponse.errorResponse(


### PR DESCRIPTION
## 📌 Overview

This PR fixes the lifecycle ownership check in `backend/controllers/lifecycleController.js` that blocked ALL non-owner, non-admin users from updating a batch's lifecycle stage. Legitimate supply chain actors (transporters, mandi officers, retailers) who do not own the batch were unable to advance it through the supply chain (e.g., "Planted" → "Harvested", "In Transit" → "Delivered"). The role-based authorization check at lines 192-200 was unreachable for non-owners because the ownership check short-circuited first.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #833

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified transporter can set "Transported", retailer can set "Delivered" on batches they don't own? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have not added any redundant comments.
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

- The ownership check now uses `isAuthorizedForStage()` to allow role-authorized non-owners (transporters, mandi, retailers, quality inspectors) to pass through.
- The role-based authorization check at line 193 remains as a secondary safeguard.
- Ownership flow: admin → always allowed; owner → always allowed; non-owner + authorized role → allowed; non-owner + unauthorized role → blocked.
