### PR TITLE
fix: return 400 for invalid ObjectId in auction routes

### DIFF
--- a/backend/controllers/auctionController.js
+++ b/backend/controllers/auctionController.js
@@ -154,6 +154,13 @@ const getAllAuctions = async (req, res) => {
 const getAuctionDetails = async (req, res) => {
     try {
         const { id } = req.params;
+
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            return res.status(400).json(
+                apiResponse.errorResponse('Invalid auction ID format', 'INVALID_AUCTION_ID', 400)
+            );
+        }
+
         const auction = await Auction.findById(id).lean();
         convertDecimal128(auction);
 
@@ -190,6 +197,13 @@ const getAuctionDetails = async (req, res) => {
 const getAuctionBids = async (req, res) => {
     try {
         const { id } = req.params;
+
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            return res.status(400).json(
+                apiResponse.errorResponse('Invalid auction ID format', 'INVALID_AUCTION_ID', 400)
+            );
+        }
+
         const bids = await Bid.find({ auctionId: id })
             .sort({ timestamp: -1 })
             .lean();
@@ -213,6 +227,14 @@ const placeBid = async (req, res) => {
     try {
         const { id } = req.params;
         const { bidAmount } = req.body;
+
+        if (!mongoose.Types.ObjectId.isValid(id)) {
+            await session.abortTransaction();
+            session.endSession();
+            return res.status(400).json(
+                apiResponse.errorResponse('Invalid auction ID format', 'INVALID_AUCTION_ID', 400)
+            );
+        }
 
         if (!bidAmount || bidAmount <= 0) {
             await session.abortTransaction();


### PR DESCRIPTION
## Summary

Fixes #872  

passing a malformed ID (e.g. `abc`, `123`) to any auction 
route that calls `Auction.findById(id)` caused Mongoose to throw a 
`CastError`, which was caught by the generic error handler and returned 
as a 500. It should be a 400.

## Changes

`backend/controllers/auctionController.js`

Added `mongoose.Types.ObjectId.isValid(id)` guard at the top of:
- `getAuctionDetails` → `GET /api/auctions/:id`
- `getAuctionBids`    → `GET /api/auctions/:id/bids`
- `placeBid`          → `POST /api/auctions/:id/bid`

Invalid IDs now return `400 INVALID_AUCTION_ID` immediately, before 
any database query is attempted.

## Before / After

| Request | Before | After |
|---------|--------|-------|
| `GET /api/auctions/not-an-id` | 500 Server Error | 400 Invalid auction ID format |
| `GET /api/auctions/123` | 500 Server Error | 400 Invalid auction ID format |
| `POST /api/auctions/bad-id/bid` | 500 Server Error | 400 Invalid auction ID format |
| `GET /api/auctions/<valid-id>` | unchanged | unchanged |
