### PR TITLE
feat: add Google Benchmark suite for core graph operations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,33 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libbenchmark-dev
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build benchmark binary
+        run: cmake --build build --target CinderPeak_bench
+
+      - name: Run benchmarks
+        run: ./build/CinderPeak_bench --benchmark_format=json | tee benchmark_results.json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark_results.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+# ─── Benchmarks (optional — requires Google Benchmark installed) ───────────────
+find_package(benchmark QUIET)
+if(benchmark_FOUND)
+    add_executable(CinderPeak_bench benchmarks/bench_core_operations.cpp)
+    target_link_libraries(CinderPeak_bench benchmark::benchmark CinderPeak)
+    message(STATUS "Google Benchmark found — CinderPeak_bench target enabled")
+else()
+    message(STATUS "Google Benchmark not found — skipping benchmark target")
+endif()

--- a/benchmarks/bench_core_operations.cpp
+++ b/benchmarks/bench_core_operations.cpp
@@ -1,0 +1,43 @@
+#include <benchmark/benchmark.h>
+#include "CinderPeak.hpp"
+
+using namespace CinderPeak;
+
+// Benchmark: how long does adding N vertices take?
+static void BM_AddVertex(benchmark::State& state) {
+    for (auto _ : state) {
+        CinderGraph<int, int> g(GraphCreationOptions({GraphCreationOptions::Directed}));
+        for (int i = 0; i < state.range(0); ++i)
+            g.addVertex(i);
+    }
+    state.SetComplexityN(state.range(0));
+}
+BENCHMARK(BM_AddVertex)->Range(1 << 10, 1 << 18)->Complexity();
+
+// Benchmark: how long does adding N edges take?
+static void BM_AddEdge(benchmark::State& state) {
+    CinderGraph<int, int> g(GraphCreationOptions({GraphCreationOptions::Directed}));
+    for (int i = 0; i < state.range(0); ++i)
+        g.addVertex(i);
+    for (auto _ : state) {
+        for (int i = 0; i < state.range(0) - 1; ++i)
+            g.addEdge(i, i + 1, 1);
+    }
+    state.SetComplexityN(state.range(0));
+}
+BENCHMARK(BM_AddEdge)->Range(1 << 10, 1 << 16)->Complexity();
+
+// Benchmark: how long does a neighbor lookup take on a 1000-node graph?
+static void BM_NeighborLookup(benchmark::State& state) {
+    CinderGraph<int, int> g(GraphCreationOptions({GraphCreationOptions::Directed}));
+    for (int i = 0; i < 1000; ++i)
+        g.addVertex(i);
+    for (int i = 0; i < 999; ++i)
+        g.addEdge(i, i + 1, 1);
+    for (auto _ : state) {
+        benchmark::DoNotOptimize(g.neighbors(500));
+    }
+}
+BENCHMARK(BM_NeighborLookup);
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
- Add benchmarks/bench_core_operations.cpp with BM_AddVertex, BM_AddEdge, and BM_NeighborLookup benchmarks
- Update CMakeLists.txt with optional benchmark target (QUIET find, does not break builds without Google Benchmark installed)
- Add .github/workflows/benchmark.yml to run benchmarks on PRs and upload results as a JSON artifact

Closes #375 