### PR TITLE
fix(ci): fail pipeline on Slither security findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,9 @@ jobs:
       # Step 4: Run Slither Security Analysis
       - name: Run Slither Security Analysis
         uses: crytic/slither-action@v0.4.0
-        continue-on-error: true
         with:
           target: "smart-contracts/contracts/"
-          fail-on: none
+          fail-on: all
           slither-args: '--filter-paths "smart-contracts/contracts/lib/openzeppelin/**" --exclude naming-convention,external-function,low-level-calls,assembly,constable-states'
 
   # Job 3: Backend Tests


### PR DESCRIPTION
Remove `continue-on-error: true` and restore the default `fail-on: all` behavior so GitHub Actions correctly fails when Slither reports security findings.

Closes #852

## 📌 Overview

This PR fixes the GitHub Actions security audit workflow so that smart contract security findings correctly fail the CI pipeline.

### Changes
- Removed `continue-on-error: true` from the Slither analysis step.
- Changed `fail-on: none` to `fail-on: all` to restore the action's default behavior.
- Ensures that any Slither finding that is not already excluded by the project's detector configuration causes the CI job to fail.
- Preserves the existing detector exclusions defined through `slither-args`.

---

## 🛠️ Type of Change

- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #852

---

## 🧪 Testing & Verification

- [x] **Smart Contracts:** **NA** (Workflow configuration change only; no Solidity contracts modified.)
- [x] **Frontend:** **NA**
- [x] **Integration:** **NA**

### Validation
- Verified GitHub Actions workflow YAML syntax.
- Verified `crytic/slither-action@v0.4.0` supports `fail-on: all`.
- Confirmed downstream workflow behavior remains correct:
  - Security audit failure blocks Docker publishing through `needs`.
  - Failed CI prevents the deployment workflow from running.

---

## 📸 Screenshots / Demos

Not applicable (CI workflow configuration change).

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

The project already excludes selected low-value Slither detectors using `slither-args` (such as `naming-convention` and `external-function`). This PR does not change those exclusions—it only ensures that any remaining reported findings correctly fail the CI pipeline, restoring the intended behavior of the security audit.