### PR TITLE
fix: remove maximum-scale to restore pinch-to-zoom accessibility

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -21,7 +21,6 @@ export const viewport: Viewport = {
   themeColor: "#0ea5e9",
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
 };
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## 📌 Overview

This PR fixes the WCAG 2.1 AA violation (SC 1.4.4 Resize Text) caused by `maximumScale: 1` in the Next.js viewport export. This setting rendered `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">`, which completely disabled pinch-to-zoom on mobile browsers. The fix removes the `maximumScale` constraint so users can zoom and resize text up to at least 200%.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #891

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

Removing `maximumScale` from the `viewport` export in `frontend/src/app/layout.tsx` restores native pinch-to-zoom on mobile browsers, satisfying WCAG 2.1 AA Success Criterion 1.4.4 (Resize Text) without restricting text scaling to a fixed upper bound. No runtime dependencies or styling were affected.