### PR TITLE
fix: extract verifyWalletSignature helper to deduplicate wallet auth logic

### DIFF
--- a/backend/config/blockchain.js
+++ b/backend/config/blockchain.js
@@ -1,98 +1,25 @@
-'use strict';
 const { ethers } = require("ethers");
 const { loadWallet } = require("../utils/keystore");
 
-const { ethers } = require('ethers');
-const {
-  SecretsManagerClient,
-  GetSecretValueCommand,
-} = require('@aws-sdk/client-secrets-manager');
-
-// ─── Provider / Contract config ───────────────────────────────────────────────
 const PROVIDER_URL =
   process.env.INFURA_URL ||
   process.env.SEPOLIA_URL ||
-  'https://ethereum-sepolia-rpc.publicnode.com';
-
+  "https://ethereum-sepolia-rpc.publicnode.com";
 const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
 
 // Contract ABI - aligned with CropChain.sol
 const contractABI = [
-  'event BatchCreated(bytes32 indexed batchId, string ipfsCID, uint256 quantity, address indexed creator)',
-  'event BatchUpdated(bytes32 indexed batchId, uint8 stage, string actorName, string location, address indexed updatedBy)',
-  'function getBatch(bytes32 batchId) view returns (tuple(bytes32 batchId, bytes32 cropTypeHash, string ipfsCID, uint256 quantity, uint256 createdAt, address creator, bool exists, bool isRecalled))',
-  'function getTotalBatches() view returns (uint256)',
-  'function getBatchIdByIndex(uint256 index) view returns (bytes32)',
-  'function createBatch(bytes32 batchId, bytes32 cropTypeHash, string calldata ipfsCID, uint256 quantity, string calldata actorName, string calldata location, string calldata notes) returns (bool)',
-  'function updateBatch(bytes32 batchId, uint8 stage, string calldata actorName, string calldata location, string calldata notes) returns (bool)',
-  'function setRole(address user, uint8 role)',
-  'function roles(address user) view returns (uint8)',
+  "event BatchCreated(bytes32 indexed batchId, string ipfsCID, uint256 quantity, address indexed creator)",
+  "event BatchUpdated(bytes32 indexed batchId, uint8 stage, string actorName, string location, address indexed updatedBy)",
+  "function getBatch(bytes32 batchId) view returns (tuple(bytes32 batchId, bytes32 cropTypeHash, string ipfsCID, uint256 quantity, uint256 createdAt, address creator, bool exists, bool isRecalled))",
+  "function getTotalBatches() view returns (uint256)",
+  "function getBatchIdByIndex(uint256 index) view returns (bytes32)",
+  "function createBatch(bytes32 batchId, bytes32 cropTypeHash, string calldata ipfsCID, uint256 quantity, string calldata actorName, string calldata location, string calldata notes) returns (bool)",
+  "function updateBatch(bytes32 batchId, uint8 stage, string calldata actorName, string calldata location, string calldata notes) returns (bool)",
+  "function setRole(address user, uint8 role)",
+  "function roles(address user) view returns (uint8)",
 ];
 
-// ─── Cached instances ─────────────────────────────────────────────────────────
-// These are populated lazily on first call to getContract() / getWallet()
-let _provider = null;
-let _wallet = null;
-let _contractInstance = null;
-
-// ─── Key retrieval ────────────────────────────────────────────────────────────
-
-/**
- * Retrieves the blockchain signing private key securely.
- *
- * PRODUCTION  → fetches from AWS Secrets Manager using AWS_SECRET_ARN.
- *               The secret must be stored as JSON: { "private_key": "0x..." }
- *               PRIVATE_KEY must NOT be set in production.
- *
- * DEVELOPMENT → reads PRIVATE_KEY (or ETH_PRIVATE_KEY) from .env.
- *               Never use this path in production.
- *
- * @returns {Promise<string>} The private key as a 0x-prefixed hex string.
- */
-async function getSigningKey() {
-  if (process.env.NODE_ENV === 'production') {
-    if (!process.env.AWS_SECRET_ARN) {
-      throw new Error(
-        '[blockchain] Production requires AWS_SECRET_ARN to be set. ' +
-        'Store your private key in AWS Secrets Manager and point ' +
-        'AWS_SECRET_ARN at that secret. Never use PRIVATE_KEY in production.'
-      );
-    }
-
-    const client = new SecretsManagerClient({
-      region: process.env.AWS_REGION || 'us-east-1',
-    });
-
-    const response = await client.send(
-      new GetSecretValueCommand({
-        SecretId: process.env.AWS_SECRET_ARN,
-      })
-    );
-
-    const secret = JSON.parse(response.SecretString);
-
-    if (!secret.private_key) {
-      throw new Error(
-        '[blockchain] AWS Secrets Manager secret must contain a "private_key" field. ' +
-        'Expected format: { "private_key": "0x..." }'
-      );
-    }
-
-    return secret.private_key;
-  }
-
-  // ── Development / test fallback ──────────────────────────────────────────
-  const devKey = process.env.PRIVATE_KEY || process.env.ETH_PRIVATE_KEY;
-
-  if (!devKey) {
-    throw new Error(
-      '[blockchain] No signing key found. ' +
-      'For local development set PRIVATE_KEY in your .env file. ' +
-      'For production set AWS_SECRET_ARN instead.'
-    );
-  }
-
-  return devKey;
 let contractInstance = null;
 let provider = null;
 let wallet = null;
@@ -159,80 +86,18 @@ function getContract() {
   return contractInstance;
 }
 
-// ─── Public API ───────────────────────────────────────────────────────────────
-
 /**
- * Returns the ethers.js provider, creating it once and caching it.
+ * Get provider instance
  * @returns {ethers.JsonRpcProvider|null}
  */
 function getProvider() {
-  if (_provider) return _provider;
-
-  if (!PROVIDER_URL) {
-    console.warn('[blockchain] No provider URL configured (INFURA_URL / SEPOLIA_URL).');
-    return null;
+  if (!provider && PROVIDER_URL) {
+    provider = new ethers.JsonRpcProvider(PROVIDER_URL);
   }
-
-  _provider = new ethers.JsonRpcProvider(PROVIDER_URL);
-  return _provider;
+  return provider;
 }
 
 /**
- * Returns the signing wallet, fetching the key securely on first call.
- * Caches the wallet after the first successful creation.
- *
- * @returns {Promise<ethers.Wallet|null>}
- */
-async function getWallet() {
-  if (_wallet) return _wallet;
-
-  const provider = getProvider();
-  if (!provider) return null;
-
-  try {
-    const privateKey = await getSigningKey();
-    _wallet = new ethers.Wallet(privateKey, provider);
-    return _wallet;
-  } catch (err) {
-    console.error('[blockchain] Failed to create wallet:', err.message);
-    return null;
-  }
-}
-
-/**
- * Returns the CropChain contract instance, creating it once and caching it.
- * Returns null (with a console warning) if configuration is incomplete.
- *
- * @returns {Promise<ethers.Contract|null>}
- */
-async function getContract() {
-  if (_contractInstance) return _contractInstance;
-
-  if (!CONTRACT_ADDRESS) {
-    console.warn('[blockchain] CONTRACT_ADDRESS is not set — blockchain features disabled.');
-    return null;
-  }
-
-  const wallet = await getWallet();
-  if (!wallet) {
-    console.warn('[blockchain] Wallet unavailable — cannot create contract instance.');
-    return null;
-  }
-
-  try {
-    _contractInstance = new ethers.Contract(CONTRACT_ADDRESS, contractABI, wallet);
-    console.log('✓ Blockchain contract initialised');
-    return _contractInstance;
-  } catch (err) {
-    console.error('[blockchain] Failed to initialise contract:', err.message);
-    return null;
-  }
-}
-
-module.exports = {
-  getContract,   // async — await it
-  getWallet,     // async — await it
-  getProvider,   // sync  — no await needed
  * Get wallet instance
  * @returns {ethers.Wallet|null} Wallet instance or null if not ready/configured
  */

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -393,6 +393,56 @@ const getNonce = async (req, res) => {
 };
 
 /**
+ * Verify a wallet signature against the nonce stored for the given address.
+ *
+ * Shared by walletLogin and walletRegister:
+ * - Fetches the stored nonce (never falls back to a constant string)
+ * - Recovers the signing address from the signature
+ * - Confirms it matches the claimed address
+ * - Deletes the used nonce to prevent replay attacks
+ *
+ * @param {{ address: string, signature: string }} params
+ * @returns {Promise<string>} the verified, normalized address
+ * @throws {Error} with `status` and `message` when verification fails
+ */
+const verifyWalletSignature = async ({ address, signature }) => {
+  const normalizedAddress = address.toLowerCase();
+
+  // Get stored nonce
+  const storedNonce = await redis.get(`nonce:${normalizedAddress}`);
+  // ALWAYS require stored nonce - never fall back to constant string
+  if (!storedNonce) {
+    const error = new Error(
+      "No authentication nonce found. Please request a new one.",
+    );
+    error.status = 401;
+    throw error;
+  }
+
+  // Verify the signature against the stored nonce
+  let recoveredAddress;
+  try {
+    recoveredAddress = verifyMessage(storedNonce, signature);
+  } catch (error) {
+    const verificationError = new Error("Invalid signature");
+    verificationError.status = 401;
+    throw verificationError;
+  }
+
+  // Verify recovered address matches claimed address
+  if (recoveredAddress.toLowerCase() !== normalizedAddress) {
+    const error = new Error("Signature verification failed - address mismatch");
+    error.status = 401;
+    throw error;
+  }
+
+  // Delete used nonce to prevent replay attacks
+  await redis.del(`nonce:${normalizedAddress}`);
+
+  return normalizedAddress;
+};
+
+/**
  * Verify wallet signature and authenticate user
  */
 const walletLogin = async (req, res) => {
@@ -412,44 +462,18 @@ const walletLogin = async (req, res) => {
     }
 
     const { address, signature, nonce: providedNonce } = validationResult.data;
-    const normalizedAddress = address.toLowerCase();
 
-    // Get stored nonce
-    const storedNonce = await redis.get(`nonce:${normalizedAddress}`);
-    // ALWAYS require stored nonce - never fall back to constant string
-    if (!storedNonce) {
-      return res
-        .status(401)
-        .json(
-          apiResponse.unauthorizedResponse(
-            "No authentication nonce found. Please request a new one.",
-          ),
-        );
-    }
-
-    // Use stored nonce (provided nonce is for backwards compatibility only)
-    const nonce = storedNonce;
-    // Clean up expired nonces
-
-    // Verify the signature
-    let recoveredAddress;
+    // Verify the wallet signature against the stored nonce
+    let normalizedAddress;
     try {
-      recoveredAddress = verifyMessage(nonce, signature);
+      normalizedAddress = await verifyWalletSignature({ address, signature });
     } catch (error) {
-      return res
-        .status(401)
-        .json(apiResponse.unauthorizedResponse("Invalid signature"));
-    }
-
-    // Verify recovered address matches claimed address
-    if (recoveredAddress.toLowerCase() !== normalizedAddress) {
-      return res
-        .status(401)
-        .json(
-          apiResponse.unauthorizedResponse(
-            "Signature verification failed - address mismatch",
-          ),
-        );
+      if (error.status) {
+        return res
+          .status(error.status)
+          .json(apiResponse.unauthorizedResponse(error.message));
+      }
+      throw error;
     }
 
     // Find user by wallet address
@@ -467,8 +491,6 @@ const walletLogin = async (req, res) => {
         );
     }
 
-    // Delete used nonce to prevent replay attacks
-    await redis.del(`nonce:${normalizedAddress}`);
     // Generate JWT with user's role from database
     attachRefreshCookie(res, user);
     const response = apiResponse.successResponse(
@@ -542,41 +564,21 @@ const walletRegister = async (req, res) => {
       nonce: providedNonce,
       role,
     } = validationResult.data;
-    const normalizedAddress = walletAddress.toLowerCase();
 
-    // Get stored nonce
-    const storedNonce = await redis.get(`nonce:${normalizedAddress}`);
-
-    // ALWAYS require stored nonce - never fall back to constant string
-    if (!storedNonce) {
-      return res
-        .status(401)
-        .json(
-          apiResponse.unauthorizedResponse(
-            "No authentication nonce found. Please request a new one.",
-          ),
-        );
-    }
-
-    // Use stored nonce — storedNonce is a plain string returned from Redis
-    const nonce = storedNonce;
-
-    // Verify signature
-    let recoveredAddress;
+    // Verify the wallet signature against the stored nonce
+    let normalizedAddress;
     try {
-      recoveredAddress = verifyMessage(nonce, signature);
+      normalizedAddress = await verifyWalletSignature({
+        address: walletAddress,
+        signature,
+      });
     } catch (error) {
-      return res
-        .status(401)
-        .json(apiResponse.unauthorizedResponse("Invalid signature"));
-    }
-
-    if (recoveredAddress.toLowerCase() !== normalizedAddress) {
-      return res
-        .status(401)
-        .json(
-          apiResponse.unauthorizedResponse("Signature verification failed"),
-        );
+      if (error.status) {
+        return res
+          .status(error.status)
+          .json(apiResponse.unauthorizedResponse(error.message));
+      }
+      throw error;
     }
 
     // Check if user exists
@@ -604,9 +606,6 @@ const walletRegister = async (req, res) => {
       role,
       password: await bcrypt.hash(randomPassword, 12), // Secure random password for wallet users
     });
-
-    // Delete used nonce
-    await redis.del(`nonce:${normalizedAddress}`);
 
     attachRefreshCookie(res, user);
     const response = apiResponse.successResponse(
@@ -660,3 +659,329 @@ const refreshSession = async (req, res) => {
           apiResponse.errorResponse(
             "Refresh token secret is not configured",
             "SERVER_CONFIGURATION_ERROR",
+            500,
+          ),
+        );
+    }
+
+    const decoded = jwt.verify(refreshToken, refreshSecret);
+
+    if (decoded.type !== "refresh") {
+      return res
+        .status(401)
+        .json(apiResponse.unauthorizedResponse("Invalid refresh token"));
+    }
+
+    const user = await User.findById(decoded.id).select("-password");
+
+    if (!user) {
+      clearRefreshCookie(res);
+
+      return res
+        .status(401)
+        .json(apiResponse.unauthorizedResponse("User not found"));
+    }
+
+    if (
+      decoded.tokenVersion !== undefined &&
+      decoded.tokenVersion !== user.tokenVersion
+    ) {
+      clearRefreshCookie(res);
+      return res
+        .status(401)
+        .json(
+          apiResponse.unauthorizedResponse(
+            "Token has been invalidated. Please log in again.",
+          ),
+        );
+    }
+
+    attachRefreshCookie(res, user);
+
+    return res.json(
+      apiResponse.successResponse(buildAuthPayload(user), "Session refreshed"),
+    );
+  } catch (error) {
+    clearRefreshCookie(res);
+
+    return res
+      .status(401)
+      .json(
+        apiResponse.unauthorizedResponse("Invalid or expired refresh token"),
+      );
+  }
+};
+
+const logoutUser = (req, res) => {
+  clearRefreshCookie(res);
+  return res.json(apiResponse.successResponse(null, "Logout successful"));
+};
+
+const forgotPassword = async (req, res) => {
+  try {
+    const { email } = req.body;
+    if (!email) {
+      return res
+        .status(400)
+        .json(
+          apiResponse.errorResponse("Email is required", "EMAIL_REQUIRED", 400),
+        );
+    }
+
+    const user = await User.findOne({ email: email.toLowerCase() });
+    if (!user) {
+      return res.json(
+        apiResponse.successResponse(
+          null,
+          "If an account exists with this email, a password reset link has been sent.",
+        ),
+      );
+    }
+
+    // Generate reset token
+    const resetToken = crypto.randomBytes(20).toString("hex");
+
+    // Hash token and set expire (15 minutes)
+    user.resetPasswordToken = crypto
+      .createHash("sha256")
+      .update(resetToken)
+      .digest("hex");
+    user.resetPasswordExpire = Date.now() + 15 * 60 * 1000;
+
+    await user.save();
+
+    // Send email
+    const resetUrl = `${process.env.FRONTEND_URL || "http://localhost:3000"}/reset-password?token=${resetToken}`;
+    const message = `
+            <h2>Password Reset Request</h2>
+            <p>You requested a password reset. Please click on the link below or paste it into your browser to reset your password:</p>
+            <a href="${resetUrl}" target="_blank">${resetUrl}</a>
+            <p>This link is valid for 15 minutes.</p>
+            <p>If you did not request this, please ignore this email.</p>
+            <p>CropChain Team</p>
+        `;
+
+    try {
+      const notificationService = require("../services/notificationService");
+      await notificationService.sendEmail(
+        user.email,
+        "Password Reset Request",
+        message,
+      );
+      return res.json(
+        apiResponse.successResponse(
+          null,
+          "If an account exists with this email, a password reset link has been sent.",
+        ),
+      );
+    } catch (emailErr) {
+      user.resetPasswordToken = undefined;
+      user.resetPasswordExpire = undefined;
+      await user.save();
+      return res
+        .status(500)
+        .json(
+          apiResponse.errorResponse(
+            "Email could not be sent",
+            "EMAIL_SEND_ERROR",
+            500,
+          ),
+        );
+    }
+  } catch (error) {
+    return res
+      .status(500)
+      .json(
+        apiResponse.errorResponse(
+          "Server error during forgot password",
+          "SERVER_ERROR",
+          500,
+        ),
+      );
+  }
+};
+
+const resetPassword = async (req, res) => {
+    try {
+        const { token } = req.params;
+        const { password } = req.body;
+
+        if (!password) {
+            return res.status(400).json(
+                apiResponse.errorResponse('New password is required', 'PASSWORD_REQUIRED', 400)
+            );
+        }
+
+        const passwordResult = passwordSchema.safeParse(password);
+        if (!passwordResult.success) {
+            return res.status(400).json(
+                apiResponse.errorResponse(
+                    'Password must be 8-128 characters and contain at least one uppercase letter, one lowercase letter, one number, and one special character',
+                    'INVALID_PASSWORD',
+                    400,
+                    extractValidationDetails(passwordResult.error)
+                )
+            );
+        }
+
+        const resetPasswordToken = crypto
+            .createHash('sha256')
+            .update(token)
+            .digest('hex');
+
+        const user = await User.findOne({
+            resetPasswordToken,
+            resetPasswordExpire: { $gt: Date.now() }
+        });
+
+        if (!user) {
+            return res.status(400).json(
+                apiResponse.errorResponse('Invalid or expired password reset token', 'INVALID_TOKEN', 400)
+            );
+        }
+
+        const salt = await bcrypt.genSalt(12);
+        user.password = await bcrypt.hash(passwordResult.data, salt);
+        user.resetPasswordToken = undefined;
+        user.resetPasswordExpire = undefined;
+        user.tokenVersion = (user.tokenVersion || 0) + 1;
+
+        await user.save();
+
+        return res.json(
+            apiResponse.successResponse(null, 'Password reset successful')
+        );
+    } catch (error) {
+        return res
+            .status(500)
+            .json(
+                apiResponse.errorResponse(
+                    'Server error during password reset',
+                    'SERVER_ERROR',
+                    500,
+                ),
+            );
+    }
+};
+
+const addFunds = async (req, res) => {
+  try {
+    const { amount, userId } = req.body;
+
+    if (!userId) {
+      return res
+        .status(400)
+        .json(
+          apiResponse.errorResponse(
+            "Please provide a target userId",
+            "MISSING_USER_ID",
+            400,
+          ),
+        );
+    }
+
+    if (amount === undefined || typeof amount !== "number" || amount <= 0) {
+      return res
+        .status(400)
+        .json(
+          apiResponse.errorResponse(
+            "Please provide a valid positive number for amount",
+            "INVALID_AMOUNT",
+            400,
+          ),
+        );
+    }
+
+    const user = await User.findById(userId);
+    if (!user) {
+      return res.status(404).json(apiResponse.notFoundResponse("User", userId));
+    }
+
+    user.balance = fromDecimal(toDecimal(user.balance || 0).plus(toDecimal(amount)));
+    await user.save();
+
+    logger.info("Funds added successfully", {
+      adminId: req.user.id,
+      targetUserId: user._id,
+      amount,
+      newBalance: toNumber(user.balance),
+    });
+
+    return res.json(
+      apiResponse.successResponse(
+        { user: sanitizeUser(user) },
+        "Funds added successfully",
+      ),
+    );
+  } catch (error) {
+    logger.error("Error adding funds", { error: error.message });
+    return res
+      .status(500)
+      .json(
+        apiResponse.errorResponse(
+          "Server error while adding funds",
+          "SERVER_ERROR",
+          500,
+        ),
+      );
+  }
+};
+
+const setFallbackPassword = async (req, res) => {
+    try {
+        const { password } = req.body;
+
+        const passwordResult = passwordSchema.safeParse(password);
+        if (!passwordResult.success) {
+            return res.status(400).json(
+                apiResponse.errorResponse(
+                    'Password does not meet security requirements',
+                    'INVALID_PASSWORD',
+                    400,
+                    extractValidationDetails(passwordResult.error)
+                )
+            );
+        }
+
+        const user = await User.findById(req.user.id);
+        if (!user) {
+            return res.status(404).json(
+                apiResponse.notFoundResponse('User', req.user.id)
+            );
+        }
+
+        // Hash password with higher cost factor
+        const salt = await bcrypt.genSalt(12);
+        const hashedPassword = await bcrypt.hash(passwordResult.data, salt);
+
+        user.password = hashedPassword;
+        await user.save();
+
+        logger.info('Fallback password set successfully', { userId: user._id });
+
+        return res.json(
+            apiResponse.successResponse({ user: sanitizeUser(user) }, 'Fallback password set successfully')
+        );
+    } catch (error) {
+        logger.error('Error setting fallback password', { error: error.message });
+        return res.status(500).json(
+            apiResponse.errorResponse('Server error while setting fallback password', 'SERVER_ERROR', 500)
+        );
+    }
+};
+
+module.exports = {
+  registerUser,
+  loginUser,
+  walletLogin,
+  walletRegister,
+  verifyWalletSignature,
+  getNonce,
+  updateProfile,
+  refreshSession,
+  logoutUser,
+  forgotPassword,
+  resetPassword,
+  addFunds,
+  setFallbackPassword,
+};

--- a/backend/scripts/reconcile.js
+++ b/backend/scripts/reconcile.js
@@ -1,7 +1,7 @@
 require("dotenv").config();
 const { ethers } = require("ethers");
 const Batch = require("../models/Batch");
-const { getContract, initialize } = require("../config/blockchain");
+const { initialize } = require("../config/blockchain");
 
 const STAGE_NAMES = ["farmer", "mandi", "transport", "retailer"];
 
@@ -28,7 +28,6 @@ function normalizeBatchId(batchIdBytes32) {
 async function reconcile() {
   console.log("🔄 Starting reconciliation...");
 
-  const contract = await getContract();
   const contract = await initialize();
   if (!contract) {
     console.error("❌ Blockchain contract not available. Check configuration.");

--- a/backend/tests/authController.test.js
+++ b/backend/tests/authController.test.js
@@ -1,0 +1,90 @@
+const { ethers } = require("ethers");
+
+let mockRedisClient;
+
+jest.mock("ioredis", () => {
+  mockRedisClient = {
+    get: jest.fn(),
+    del: jest.fn(),
+    set: jest.fn(),
+    on: jest.fn(),
+  };
+  return jest.fn(() => mockRedisClient);
+});
+
+const originalNodeEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = "development";
+const { verifyWalletSignature } = require("../controllers/authController");
+process.env.NODE_ENV = originalNodeEnv;
+
+describe("verifyWalletSignature", () => {
+  let wallet;
+  let nonce;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    wallet = ethers.Wallet.createRandom();
+    nonce = "test-nonce-123";
+  });
+
+  it("should resolve the normalized address on a valid signature", async () => {
+    const signature = await wallet.signMessage(nonce);
+    mockRedisClient.get.mockResolvedValue(nonce);
+
+    const result = await verifyWalletSignature({
+      address: wallet.address,
+      signature,
+    });
+
+    expect(result).toBe(wallet.address.toLowerCase());
+    expect(mockRedisClient.get).toHaveBeenCalledWith(
+      `nonce:${wallet.address.toLowerCase()}`,
+    );
+    expect(mockRedisClient.del).toHaveBeenCalledWith(
+      `nonce:${wallet.address.toLowerCase()}`,
+    );
+  });
+
+  it("should reject with status 401 when no nonce is stored", async () => {
+    mockRedisClient.get.mockResolvedValue(null);
+
+    const error = await verifyWalletSignature({
+      address: wallet.address,
+      signature: await wallet.signMessage(nonce),
+    }).catch((err) => err);
+
+    expect(error.status).toBe(401);
+    expect(error.message).toBe(
+      "No authentication nonce found. Please request a new one.",
+    );
+    expect(mockRedisClient.del).not.toHaveBeenCalled();
+  });
+
+  it("should reject with status 401 on an invalid signature", async () => {
+    mockRedisClient.get.mockResolvedValue(nonce);
+
+    const error = await verifyWalletSignature({
+      address: wallet.address,
+      signature: "0xdeadbeef",
+    }).catch((err) => err);
+
+    expect(error.status).toBe(401);
+    expect(error.message).toBe("Invalid signature");
+    expect(mockRedisClient.del).not.toHaveBeenCalled();
+  });
+
+  it("should reject with status 401 when recovered address does not match the claimed address", async () => {
+    mockRedisClient.get.mockResolvedValue(nonce);
+    const signature = await wallet.signMessage(nonce);
+    const attackerAddress = ethers.Wallet.createRandom().address;
+
+    const error = await verifyWalletSignature({
+      address: attackerAddress,
+      signature,
+    }).catch((err) => err);
+
+    expect(error.status).toBe(401);
+    expect(error.message).toBe("Signature verification failed - address mismatch");
+    expect(mockRedisClient.del).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION


## 📌 Overview

Extracts the duplicated wallet-authentication logic shared by `walletLogin` and `walletRegister` in `backend/controllers/authController.js` into a single `verifyWalletSignature` helper, and unifies the divergent error messages.

- `walletLogin` and `walletRegister` both performed the exact same sequence — nonce retrieval, signature verification, address recovery, and nonce deletion — with copy-pasted code that had **already drifted** (`"Signature verification failed - address mismatch"` vs `"Signature verification failed"`).
- New `verifyWalletSignature({ address, signature })` helper centralizes that logic: fetches the stored nonce, verifies the signature via `ethers.verifyMessage`, confirms the recovered address matches the claimed one, and deletes the used nonce to prevent replay attacks. It returns the verified, normalized address or throws a structured `Error` with `status: 401`.
- Both controllers now call the helper; error responses are produced from the helper's error (`status` + `message`), guaranteeing **consistent messages** for nonce-missing / invalid-signature / address-mismatch.
- Nonce deletion now happens immediately after successful verification (rather than after user lookup/creation), which is strictly better for replay protection.
- The helper is exported and covered by 4 new unit tests in `tests/authController.test.js` (valid signature, missing nonce, invalid signature, address mismatch).

### Pre-existing corruption fixed (blocks startup + test suites)

While verifying, this branch also repairs two files that were left **unparsable on `main`** by a bad merge resolution of PR #883:

- `backend/controllers/authController.js` was truncated mid-expression (the tail incl. `refreshSession`, `setFallbackPassword` and `module.exports` was deleted by commit `f1cff49`). Restored the complete file, then applied the refactor.
- `backend/config/blockchain.js` had a duplicate `const { ethers } = require(...)` plus a mangled merge (unclosed `getSigningKey`, two `module.exports` blocks). Restored the clean pre-merge version (loadWallet/keystore based).
- `backend/scripts/reconcile.js` had a duplicate `const contract` declaration (`await getContract()` + `await initialize()`). Removed the stale `getContract()` call and its unused import.

These were the only 2 files with syntax errors across the backend (verified via `node --check` on every file).

## 🛠️ Type of Change

- [x] ✨ New Feature
- [x] 🐛 Bug Fix
- [x] 🔧 Refactor
- [ ] ⚙️ Backend
- [ ] 🖥️ Frontend
- [x] 🧪 Testing
- [ ] 🏗️ Infrastructure / Tooling
- [ ] 📄 Documentation
- [ ] 💻 Other (please specify)

## 🔗 Related Issue

Closes #889

## 🧪 Testing & Verification

- `node --check` passes on every modified file (`authController.js`, `config/blockchain.js`, `scripts/reconcile.js`).
- New unit suite `tests/authController.test.js`: **4/4 pass** — valid signature (returns normalized address + deletes nonce), missing nonce (401), invalid signature (401), address mismatch (401).
- Full Jest run: **10 failed / 176 passed / 186 total** — the 10 failures are the identical pre-existing failures that also reproduce on `main` (e.g. `batch.test.js`, `verificationEvents.test.js`, `socket.test.js`). **No new failures introduced.** (The 3 suites previously failing to parse — `passwordReset`, `rbac`, `batchSearchRegex` — now pass after the `blockchain.js` repair.)
- Verified byte-identical `config/blockchain.js` restore: `git diff 74983a3 fix/secure-private-key-storage -- backend/config/blockchain.js` is empty.

## 📸 Screenshots / Demos

No UI changes.

## ✅ PR Checklist

- [x] I have followed the contribution guidelines.
- [x] My code compiles and passes linting/type checks (where applicable).
- [x] I have tested my changes thoroughly (unit, integration, and/or manual testing as applicable).
- [x] I have added/updated documentation as needed.
- [x] I have reviewed my code for security best practices.
- [x] My changes are backward-compatible and do not break existing functionality.
- [x] I have kept the PR focused and reduced risk of unintended changes.

## 💬 Additional Notes

- Behavior note: because the helper deletes the nonce immediately after a valid signature verification, a `walletLogin` that hits "wallet not registered" (or a `walletRegister` that hits "already exists") now consumes the nonce; the client should fetch a fresh nonce via `getNonce` before retrying. This is a deliberate replay-protection improvement.
- The `description.md` file in the repo root is intentionally **not** included in this PR.
- PR: https://github.com/Kirtan-pc/CropChain/pull/new/fix/wallet-auth-helper
