### PR TITLE
fix: prune rate limiter buckets and remove listeners on socket disconnect

### DIFF
--- a/backend/services/socketService.js
+++ b/backend/services/socketService.js
@@ -21,7 +21,8 @@ const EVENT_RATE_LIMITS = {
 
 function createRateLimiter() {
   const buckets = new Map();
-  return function checkRate(event, socketId) {
+
+  function checkRate(event, socketId) {
     const config = EVENT_RATE_LIMITS[event];
     if (!config) return true;
     const key = `${socketId}:${event}`;
@@ -40,7 +41,23 @@ function createRateLimiter() {
     }
     timestamps.push(now);
     return true;
-  };
+  }
+
+  /**
+   * Remove every rate-limit bucket recorded for a socket.
+   * Called on disconnect so entries for disconnected sockets never accumulate.
+   * @param {string} socketId
+   */
+  function clearSocket(socketId) {
+    const prefix = `${socketId}:`;
+    for (const key of buckets.keys()) {
+      if (key.startsWith(prefix)) {
+        buckets.delete(key);
+      }
+    }
+  }
+
+  return { checkRate, clearSocket };
 }
 
 function validatePayload(event, data) {
@@ -90,7 +107,7 @@ function initializeSocketIO(httpServer) {
       maxHttpBufferSize: MAX_HTTP_BUFFER_SIZE,
     });
 
-    const checkRate = createRateLimiter();
+    const { checkRate, clearSocket } = createRateLimiter();
 
     io.use((socket, next) => {
       const token =
@@ -120,13 +137,23 @@ function initializeSocketIO(httpServer) {
         );
       }
 
+      // Only emit to a socket that is still connected. Async handlers can
+      // finish after the client has disconnected, so every emit is guarded.
+      function safeEmit(event, payload) {
+        if (!socket.connected) return;
+        socket.emit(event, payload);
+      }
+
       function withGuard(event, handler) {
         return async (data) => {
+          if (!socket.connected) {
+            return;
+          }
           if (!checkRate(event, socket.id)) {
             logger.warn(
               `[SOCKET] Rate limit exceeded for ${socket.id} on ${event}`,
             );
-            socket.emit("error", {
+            safeEmit("error", {
               message: "Too many requests. Please slow down.",
             });
             return;
@@ -135,7 +162,7 @@ function initializeSocketIO(httpServer) {
             logger.warn(
               `[SOCKET] Invalid payload from ${socket.id} on ${event}`,
             );
-            socket.emit("error", { message: "Invalid payload." });
+            safeEmit("error", { message: "Invalid payload." });
             return;
           }
           return await handler(data);
@@ -149,7 +176,7 @@ function initializeSocketIO(httpServer) {
           try {
             const user = socket.user;
             if (!user) {
-              socket.emit("error", {
+              safeEmit("error", {
                 message: "Authentication required to join batch room",
               });
               return;
@@ -160,7 +187,7 @@ function initializeSocketIO(httpServer) {
 
             const batch = await Batch.findOne({ batchId }).lean();
             if (!batch) {
-              socket.emit("error", { message: "Batch not found" });
+              safeEmit("error", { message: "Batch not found" });
               return;
             }
 
@@ -184,7 +211,7 @@ function initializeSocketIO(httpServer) {
             const canRead = hasPermission(user.role, PERMISSIONS.BATCH_READ);
 
             if (!isOwner && !canViewAll && !canRead) {
-              socket.emit("error", {
+              safeEmit("error", {
                 message:
                   "Access denied: you do not have permission to view this batch",
               });
@@ -203,7 +230,7 @@ function initializeSocketIO(httpServer) {
               `[SOCKET ERROR] Error authorizing batch room join for ${socket.id}:`,
               err,
             );
-            socket.emit("error", { message: "Failed to verify batch access" });
+            safeEmit("error", { message: "Failed to verify batch access" });
           }
         }),
       );
@@ -228,7 +255,7 @@ function initializeSocketIO(httpServer) {
             !authenticatedUserId ||
             authenticatedUserId.toString() !== userId
           ) {
-            socket.emit("error", {
+            safeEmit("error", {
               message: "Access denied: you can only join your own verification room",
             });
             logger.warn(
@@ -305,7 +332,7 @@ function initializeSocketIO(httpServer) {
             const User = require("../models/User");
 
             if (!socket.user) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message: "Authentication required",
               });
             }
@@ -317,29 +344,29 @@ function initializeSocketIO(httpServer) {
             //    the authoritative deduction happens atomically below).
             const user = await User.findById(bidderId);
             if (!user) {
-              return socket.emit("bid_error", { message: "User not found" });
+              return safeEmit("bid_error", { message: "User not found" });
             }
 
             // 2. Fetch auction and validate state
             const auction = await Auction.findById(auctionId);
             if (!auction) {
-              return socket.emit("bid_error", { message: "Auction not found" });
+              return safeEmit("bid_error", { message: "Auction not found" });
             }
 
             if (auction.status !== "active" || new Date() > auction.endTime) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message: "Auction is not active or has already ended.",
               });
             }
 
             if (auction.farmerId.toString() === bidderId) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message: "Farmers cannot bid on their own auctions.",
               });
             }
 
             if (bidAmount <= auction.currentHighestBid) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message: `Bid must be strictly higher than the current highest bid of ${auction.currentHighestBid} credits.`,
               });
             }
@@ -358,7 +385,7 @@ function initializeSocketIO(httpServer) {
             // Pre-flight balance check (best-effort; the atomic $inc below is
             // the authoritative guard against overdraft).
             if (user.balance < amountToDeduct) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message: `Insufficient funds. Your balance is ${user.balance} credits.`,
               });
             }
@@ -383,7 +410,7 @@ function initializeSocketIO(httpServer) {
             );
 
             if (!updatedAuction) {
-              return socket.emit("bid_error", {
+              return safeEmit("bid_error", {
                 message:
                   "Bid failed. Someone else may have placed a higher bid first.",
               });
@@ -433,7 +460,7 @@ function initializeSocketIO(httpServer) {
             );
           } catch (error) {
             logger.error("[SOCKET ERROR] error placing bid:", error);
-            socket.emit("bid_error", {
+            safeEmit("bid_error", {
               message: "An internal error occurred while placing your bid.",
             });
           }
@@ -443,6 +470,10 @@ function initializeSocketIO(httpServer) {
       // Handle disconnection
       socket.on("disconnect", () => {
         logger.info(`[SOCKET] Client disconnected: ${socket.id}`);
+        // Release rate-limit buckets and all registered handlers so neither the
+        // socket object nor its closures are retained (prevents memory leaks).
+        clearSocket(socket.id);
+        socket.removeAllListeners();
       });
 
       // Handle errors
@@ -542,6 +573,7 @@ function emitToUser(userId, eventName, data) {
 module.exports = {
   initializeSocketIO,
   getIO,
+  createRateLimiter,
   emitToBatchRoom,
   emitGlobal,
   emitToVerificationRoom,

--- a/backend/tests/socket.test.js
+++ b/backend/tests/socket.test.js
@@ -62,10 +62,13 @@ describe("Socket.IO Service", () => {
         headers: {},
       },
       user: undefined,
+      connected: true,
+      id: "socket-1",
       join: jest.fn(),
       leave: jest.fn(),
       on: jest.fn(),
       emit: jest.fn(),
+      removeAllListeners: jest.fn(),
     };
     mockNext = jest.fn();
   });
@@ -405,6 +408,142 @@ describe("Socket.IO Service", () => {
         "bid_error",
         expect.any(Object),
       );
+    });
+  });
+
+  describe("Rate Limiter Cleanup", () => {
+    test("checkRate allows up to maxPerSecond then rejects", () => {
+      const { createRateLimiter } = require("../services/socketService");
+      const limiter = createRateLimiter();
+
+      for (let i = 0; i < 10; i++) {
+        expect(limiter.checkRate("place_bid", "socket-1")).toBe(true);
+      }
+      expect(limiter.checkRate("place_bid", "socket-1")).toBe(false);
+      expect(limiter.checkRate("join-batch-room", "socket-1")).toBe(true);
+    });
+
+    test("clearSocket removes buckets for that socket only", () => {
+      const { createRateLimiter } = require("../services/socketService");
+      const limiter = createRateLimiter();
+
+      for (let i = 0; i < 10; i++) {
+        limiter.checkRate("place_bid", "socket-1");
+        limiter.checkRate("place_bid", "socket-2");
+      }
+      expect(limiter.checkRate("place_bid", "socket-1")).toBe(false);
+      expect(limiter.checkRate("place_bid", "socket-2")).toBe(false);
+
+      limiter.clearSocket("socket-1");
+
+      for (let i = 0; i < 10; i++) {
+        expect(limiter.checkRate("place_bid", "socket-1")).toBe(true);
+      }
+      expect(limiter.checkRate("place_bid", "socket-2")).toBe(false);
+    });
+  });
+
+  describe("Disconnect Cleanup", () => {
+    test("disconnect prunes rate limiter buckets and removes all listeners", () => {
+      const { Server } = require("socket.io");
+      socketService.initializeSocketIO({});
+
+      const connectionHandler = Server.onCallback.mock.calls.find(
+        ([eventName]) => eventName === "connection",
+      )[1];
+      mockSocket.user = { id: "user-a", role: "farmer" };
+      connectionHandler(mockSocket);
+
+      const joinBatchRoomHandler = mockSocket.on.mock.calls.find(
+        ([eventName]) => eventName === "join-batch-room",
+      )[1];
+
+      for (let i = 0; i < 10; i++) {
+        joinBatchRoomHandler("batch-1");
+      }
+      joinBatchRoomHandler("batch-1");
+      expect(mockSocket.emit).toHaveBeenCalledWith("error", {
+        message: "Too many requests. Please slow down.",
+      });
+      mockSocket.emit.mockClear();
+
+      const disconnectHandler = mockSocket.on.mock.calls.find(
+        ([eventName]) => eventName === "disconnect",
+      )[1];
+      disconnectHandler();
+
+      expect(mockSocket.removeAllListeners).toHaveBeenCalled();
+    });
+  });
+
+  describe("Disconnected Socket Guards", () => {
+    test("withGuard skips the handler when the socket is disconnected", async () => {
+      const { Server } = require("socket.io");
+      socketService.initializeSocketIO({});
+
+      const connectionHandler = Server.onCallback.mock.calls.find(
+        ([eventName]) => eventName === "connection",
+      )[1];
+      mockSocket.user = { id: "user-a", role: "farmer" };
+      mockSocket.connected = false;
+      connectionHandler(mockSocket);
+      mockSocket.join.mockClear();
+      mockSocket.emit.mockClear();
+
+      const joinBatchRoomHandler = mockSocket.on.mock.calls.find(
+        ([eventName]) => eventName === "join-batch-room",
+      )[1];
+      await joinBatchRoomHandler("batch-1");
+
+      expect(mockSocket.join).not.toHaveBeenCalled();
+      expect(mockSocket.emit).not.toHaveBeenCalled();
+    });
+
+    test("safeEmit does not emit after the socket disconnects mid-handler", async () => {
+      const { Server } = require("socket.io");
+      socketService.initializeSocketIO({});
+
+      const connectionHandler = Server.onCallback.mock.calls.find(
+        ([eventName]) => eventName === "connection",
+      )[1];
+      mockSocket.user = { id: "user-a", name: "User A" };
+      connectionHandler(mockSocket);
+
+      const placeBidHandler = mockSocket.on.mock.calls.find(
+        ([eventName]) => eventName === "place_bid",
+      )[1];
+
+      mockAuction.findById.mockReset();
+      mockAuction.findOneAndUpdate.mockReset();
+      mockUser.findById.mockReset();
+      mockUser.findByIdAndUpdate.mockReset();
+      mockBid.mockClear();
+      mockBidSave.mockReset();
+      mockBidSave.mockResolvedValue({});
+
+      mockAuction.findById.mockImplementation(() => {
+        mockSocket.connected = false;
+        return Promise.resolve({
+          _id: "auction-1",
+          farmerId: { toString: () => "farmer-1" },
+          batchId: "BATCH001",
+          status: "active",
+          endTime: new Date(Date.now() + 60000),
+          currentHighestBid: 0,
+          highestBidder: null,
+        });
+      });
+      mockUser.findById.mockResolvedValue({ _id: "user-a", balance: 1000 });
+      mockAuction.findOneAndUpdate.mockResolvedValue({
+        _id: "auction-1",
+        currentHighestBid: 50,
+        highestBidder: "user-a",
+        toObject: () => ({}),
+      });
+
+      await placeBidHandler({ auctionId: "auction-1", bidAmount: 50 });
+
+      expect(mockSocket.emit).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION


## 📌 Overview

Fixes the Socket.IO rate-limiter memory leak and stale-socket emissions in `backend/services/socketService.js`.

- **Rate limiter buckets never pruned on disconnect.** `createRateLimiter()` keeps a `buckets` Map keyed by `${socketId}:${event}` (e.g. `socketId:place_bid`) that grew forever. The limiter now returns `{ checkRate, clearSocket }`, and the disconnect handler calls `clearSocket(socket.id)` to delete every bucket owned by that socket.
- **Disconnect handler only logged.** It now also calls `socket.removeAllListeners()` so the socket object and its handler closures (each holding references to `socket`, `withGuard`, the rate limiter, and model imports) can be garbage collected.
- **Async handlers emit to stale references.** The `withGuard` wrapper now short-circuits when `!socket.connected`, and every `socket.emit(...)` inside the wrapped handlers is routed through a `safeEmit(event, payload)` helper that checks `socket.connected` before emitting — so a handler that finishes after the client disconnects no longer emits into the void.
- `createRateLimiter` is exported so the cleanup behavior is unit-testable.

## 🛠️ Type of Change

- [x] ✨ New Feature
- [x] 🐛 Bug Fix
- [x] 🔧 Refactor
- [x] ⚙️ Backend
- [ ] 🖥️ Frontend
- [x] 🧪 Testing
- [ ] 🏗️ Infrastructure / Tooling
- [ ] 📄 Documentation
- [ ] 💻 Other (please specify)

## 🔗 Related Issue

Closes #888

## 🧪 Testing & Verification

- `node --check` passes on the modified service and test files.
- Extended `tests/socket.test.js` with 5 new tests (all passing):
  - `checkRate` allows up to `maxPerSecond` then rejects.
  - `clearSocket` removes buckets for one socket while leaving another socket's buckets intact.
  - Disconnect handler calls `removeAllListeners()` after rate-limit entries were populated.
  - `withGuard` skips the handler entirely when the socket is disconnected.
  - `safeEmit` does not emit `bid_error` when the socket disconnects mid-`place_bid`.
- Full Jest run on this branch: **10 failed / 154 passed / 164 total**. The 10 failures are the identical pre-existing failures that reproduce on `main` (e.g. `batch.test.js`, `verificationEvents.test.js`, `socket.test.js` "refunds previous highest bidder" assertion — a pre-existing wrong assertion about `findByIdAndUpdate` call order). **No new failures introduced.** The `socket.test.js` suite improved from 10/11 passing to 15/16.
- Note: 3 suites (`rbac`, `passwordReset`, `batchSearchRegex`) fail to parse on this branch's base `main` due to a pre-existing `config/blockchain.js` duplicate-`ethers` import from a bad merge of PR #883 — addressed in the separate `fix/wallet-auth-helper` PR and intentionally not duplicated here.

## 📸 Screenshots / Demos

No UI changes.

## ✅ PR Checklist

- [x] I have followed the contribution guidelines.
- [x] My code compiles and passes linting/type checks (where applicable).
- [x] I have tested my changes thoroughly (unit, integration, and/or manual testing as applicable).
- [x] I have added/updated documentation as needed.
- [x] I have reviewed my code for security best practices.
- [x] My changes are backward-compatible and do not break existing functionality.
- [x] I have kept the PR focused and reduced risk of unintended changes.

## 💬 Additional Notes

- Behavior preserved: the `io.to(...).emit("auction_update", ...)` room broadcast is intentionally **not** gated on the bidding socket's connection — a bid is still persisted even if that bidder disconnects, and the rest of the auction room must still receive the update.
- The `description.md` file in the repo root is intentionally **not** included in this PR.
- PR: https://github.com/Kirtan-pc/CropChain/pull/new/fix/socket-rate-limiter-cleanup
