### PR TITLE
fix: deny CORS requests without Origin header when credentials are allowed

### DIFF
--- a/backend/startup/middleware.js
+++ b/backend/startup/middleware.js
@@ -6,6 +6,30 @@ const createNoSqlSanitizer = require("../middleware/nosqlSanitizer");
 const { generalLimiter } = require("../middleware/rateLimiters");
 const notificationService = require("../services/notificationService");
 
+/**
+ * Build the CORS options for the express `cors` middleware.
+ *
+ * @param {string[]} uniqueAllowedOrigins - whitelisted origins
+ */
+function createCorsOptions(uniqueAllowedOrigins) {
+  return {
+    origin: function (origin, callback) {
+      // Deny requests that send no Origin header when credentials are enabled.
+      // Browsers always send an Origin header on cross-origin/credentialed
+      // requests; allowing no-Origin would reflect
+      // `Access-Control-Allow-Credentials: true` to non-browser clients.
+      if (!origin) return callback(null, false);
+      if (uniqueAllowedOrigins.includes(origin)) {
+        callback(null, true);
+      } else {
+        logger.warn("CORS blocked", { origin });
+        callback(new Error("Not allowed by CORS"));
+      }
+    },
+    credentials: true,
+  };
+}
+
 module.exports = (app) => {
   // Security logging middleware
   const securityLogger = (req, res, next) => {
@@ -100,19 +124,7 @@ module.exports = (app) => {
     allowedOrigins.push("http://localhost:3000", "http://localhost:5173");
   const uniqueAllowedOrigins = [...new Set(allowedOrigins)];
 
-  const corsOptions = {
-    origin: function (origin, callback) {
-      if (!origin) return callback(null, true);
-      if (uniqueAllowedOrigins.includes(origin)) {
-        callback(null, true);
-      } else {
-        logger.warn("CORS blocked", { origin });
-        callback(new Error("Not allowed by CORS"));
-      }
-    },
-    credentials: true,
-  };
-  app.use(cors(corsOptions));
+  app.use(cors(createCorsOptions(uniqueAllowedOrigins)));
 
   const maxFileSize = parseInt(process.env.MAX_FILE_SIZE) || 10 * 1024 * 1024;
   app.use(express.json({ limit: maxFileSize }));
@@ -157,3 +169,5 @@ module.exports = (app) => {
     next();
   });
 };
+
+module.exports.createCorsOptions = createCorsOptions;

--- a/backend/tests/cors.test.js
+++ b/backend/tests/cors.test.js
@@ -1,78 +1,41 @@
+const express = require("express");
+const cors = require("cors");
 const request = require("supertest");
+const { createCorsOptions } = require("../startup/middleware");
+
+const ALLOWED_ORIGINS = ["http://trusted.com", "http://frontend.com"];
+
+function buildTestApp() {
+  const app = express();
+  app.use(cors(createCorsOptions(ALLOWED_ORIGINS)));
+  app.get("/api/status", (_req, res) => {
+    res.status(200).json({ status: "ok" });
+  });
+  return app;
+}
 
 describe("CORS Configuration", () => {
   let app;
 
   beforeEach(() => {
-    jest.resetModules();
-
-    process.env.NODE_ENV = "test";
-    process.env.ALLOWED_ORIGINS = "http://trusted.com";
-    process.env.FRONTEND_URL = "http://frontend.com";
-
     jest.spyOn(console, "log").mockImplementation(() => {});
     jest.spyOn(console, "error").mockImplementation(() => {});
     jest.spyOn(console, "warn").mockImplementation(() => {});
-
-    jest.mock("mongoose", () => {
-      const mSchema = function () {
-        return {
-          index: jest.fn(),
-          pre: jest.fn(),
-          post: jest.fn(),
-          virtual: jest.fn().mockReturnValue({
-            get: jest.fn().mockReturnThis(),
-            set: jest.fn().mockReturnThis(),
-          }),
-          methods: {},
-          statics: {},
-        };
-      };
-
-      // Mock Schema.Types
-      mSchema.Types = {
-        ObjectId: "ObjectId",
-        String: String,
-        Number: Number,
-        Boolean: Boolean,
-        Date: Date,
-      };
-
-      const mMongoose = {
-        connect: jest.fn(),
-        connection: { readyState: 1 },
-        startSession: jest.fn(),
-        Schema: mSchema,
-        model: jest.fn().mockImplementation(() => ({
-          find: jest.fn().mockReturnThis(),
-          findOne: jest.fn().mockReturnThis(),
-          create: jest.fn(),
-          findOneAndUpdate: jest.fn(),
-          sort: jest.fn().mockReturnThis(),
-          limit: jest.fn().mockReturnThis(),
-          skip: jest.fn().mockReturnThis(),
-        })),
-        Query: jest.fn(),
-      };
-      return mMongoose;
-    });
-
-    app = require("../server");
+    app = buildTestApp();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
 
-  test("should allow requests from ALLOWED_ORIGINS", async () => {
+  test("should allow requests from ALLOWED_ORIGINS with credentials", async () => {
     const res = await request(app)
       .get("/api/status")
       .set("Origin", "http://trusted.com");
 
     expect(res.status).toBe(200);
-    // Default cors() returns * so this will fail if it expects http://trusted.com
-    // But for allowed origins, * is also technically allowed, but we want explicit allow.
-    // Let's check what it returns.
+    expect(res.headers["access-control-allow-origin"]).toBe("http://trusted.com");
+    expect(res.headers["access-control-allow-credentials"]).toBe("true");
   });
 
   test("should allow requests from FRONTEND_URL", async () => {
@@ -81,12 +44,8 @@ describe("CORS Configuration", () => {
       .set("Origin", "http://frontend.com");
 
     expect(res.status).toBe(200);
-  });
-
-  test("should allow requests with no origin", async () => {
-    const res = await request(app).get("/api/status");
-
-    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe("http://frontend.com");
+    expect(res.headers["access-control-allow-credentials"]).toBe("true");
   });
 
   test("should block requests from disallowed origins", async () => {
@@ -94,8 +53,19 @@ describe("CORS Configuration", () => {
       .get("/api/status")
       .set("Origin", "http://evil.com");
 
-    // Current: 200 (FAIL)
-    // Expected after fix: 500/403
     expect(res.status).not.toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  test("should deny requests with no origin when credentials are enabled", async () => {
+    const res = await request(app).get("/api/status");
+
+    // The request still executes (CORS is browser-enforced), but no origin or
+    // credential headers are reflected, so no-Origin clients cannot gain
+    // credentialed access.
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(res.headers["access-control-allow-credentials"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## 📌 Overview

Closes a CORS misconfiguration in `backend/startup/middleware.js` where requests **without an `Origin` header were allowed** even though `credentials: true` is set. Because browsers always send an `Origin` header on cross-origin/credentialed requests, any no-Origin client could bypass the allowlist while still being reflected `Access-Control-Allow-Credentials: true`.

- Extracted CORS options into a standalone, unit-testable `createCorsOptions(uniqueAllowedOrigins)` helper (exported from `startup/middleware.js`).
- The `origin` callback now **denies requests with no `Origin` header** (`callback(null, false)`), so no origin or credential headers are reflected to no-Origin clients.
- Allowed origins are still reflected explicitly (`Access-Control-Allow-Origin: <origin>`), disallowed origins remain blocked with a `CORS blocked` warning.

## 🛠️ Type of Change

- [x] 🐛 **Bug Fix**
- [x] 🔧 **Refactoring**
- [x] ⚙️ **Backend**
- [x] 🧪 **Testing**
- [ ] 🚀 **New Feature**
- [ ] 📚 **Documentation**

## 🔗 Related Issue

- Closes #887

## 🧪 Testing & Verification

- Added/updated unit tests in `backend/tests/cors.test.js` (4/4 passing):
  - Requests from `ALLOWED_ORIGINS` → `200`, `Access-Control-Allow-Origin` + `Access-Control-Allow-Credentials: true` reflected.
  - Requests from `FRONTEND_URL` → allowed with credential headers.
  - Requests from disallowed origins → rejected, no origin/credential headers reflected.
  - **Requests with no `Origin` header → request executes but no `Access-Control-Allow-Origin`/`Access-Control-Allow-Credentials` headers are reflected (credentialed access denied).**
- Tests now exercise `createCorsOptions` in isolation (no full server boot), which is more focused and no longer blocked by the pre-existing `config/blockchain.js` parse corruption on `main`.
- Full suite run: **21/37 suites pass, 153 tests pass; all 16 failing suites are pre-existing on `main`** (unrelated: `config/blockchain.js` parse corruption from PR #883's bad merge affects 3 suites; plus known `auctionSettlement`, `batch`, `socket`, `verificationEvents`, etc. failures). `cors.test.js` itself now passes 4/4 (previously 0/4).

```bash
cd backend
npm install          # installs pre-existing missing `handlebars` dep (declared in package.json)
npx jest tests/cors.test.js --ci --forceExit   # 4 passed
```

## 📸 Screenshots / Demos

N/A — logic change verified via automated tests above.

## ✅ PR Checklist

- [x] Code follows project style and conventions
- [x] No secrets, credentials, or sensitive data introduced
- [x] Tests added/updated and passing
- [x] `description.md` provided
- [x] Branch pushed to origin

## 💬 Additional Notes

- **Test harness fix included**: `tests/cors.test.js` previously failed to load because `handlebars` (`services/emailService.js`) was declared in `backend/package.json` but missing from `node_modules`, and the mongoose mock lacked `Schema.set()`. The rewritten test file no longer needs either workaround since it tests `createCorsOptions` in isolation.
- **Not in scope**: the pre-existing `config/blockchain.js` / `scripts/reconcile.js` corruption from the PR #883 merge (fixed on the unmerged `fix/wallet-auth-helper` branch) causes 3 suites to fail parsing on this branch's base `main`; unrelated to this change.
