### PR TITLE
fix: remove unused internal function _canUpdate in CropChain.sol

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -620,13 +620,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         emit RoleUpdated(account, roles[account]);
     }
 
-    function _canUpdate(Stage stage, ActorRole role) internal pure returns (bool) {
-        if (stage == Stage.Farmer && role == ActorRole.Farmer) return true;
-        if (stage == Stage.Mandi && role == ActorRole.Mandi) return true;
-        if (stage == Stage.Transport && role == ActorRole.Transporter) return true;
-        if (stage == Stage.Retailer && role == ActorRole.Retailer) return true;
-        return false;
-    }
+
 
     function _getCurrentCustodian(bytes32 batchId) internal view returns (address) {
         SupplyChainUpdate[] storage updates = _batchUpdates[batchId];


### PR DESCRIPTION
## 📌 Overview
Removed the unused internal function `_canUpdate` from `CropChain.sol`. This function was defined but never invoked anywhere in the contract (the contract utilizes `_canUpdateStage` instead). Removing this dead code helps keep the codebase clean, reduces clutter, and marginally decreases deployment footprint.

## 🛠️ Type of Change

- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #905

---

## 🧪 Testing & Verification

- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos
N/A (Backend/Smart Contract dead code removal only)

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic). *(N/A - code removed)*
- [x] I have updated the documentation accordingly. *(N/A)*
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
This was purely a cleanup task to remove dead code.
