### PR TITLE
fix: remove duplicate farmer balance credit on auction settlement 

### DIFF
--- a/backend/jobs/auctionSettlement.js
+++ b/backend/jobs/auctionSettlement.js
@@ -5,7 +5,7 @@ const User = require("../models/User");
 const Batch = require("../models/Batch");
 const socketService = require("../services/socketService");
 const notificationService = require("../services/notificationService");
-const { toDecimal, fromDecimal, toNumber } = require("../utils/decimalHelpers");
+const { toNumber } = require("../utils/decimalHelpers");
 
 class AuctionSettlementError extends Error {
   constructor(message, auctionId, cause) {
@@ -56,8 +56,6 @@ const claimAndSettleNextAuction = async (now, excludedAuctionIds = []) => {
       let batch = null;
 
       if (claimedAuction.highestBidder) {
-        buyer = await User.findById(claimedAuction.highestBidder, null, { session });
-        farmer = await User.findById(claimedAuction.farmerId, null, { session });
         buyer = await User.findById(claimedAuction.highestBidder, null, {
           session,
         });
@@ -69,12 +67,6 @@ const claimAndSettleNextAuction = async (now, excludedAuctionIds = []) => {
         if (!farmer) {
           throw new Error("Auction farmer not found");
         }
-
-        const farmerNewBalance = fromDecimal(
-          toDecimal(farmer.balance).plus(toDecimal(claimedAuction.currentHighestBid))
-        );
-        farmer.balance = farmerNewBalance;
-        await farmer.save({ session });
 
         const buyerName = buyer ? buyer.name : "Buyer";
         batch = await Batch.findOneAndUpdate(


### PR DESCRIPTION
## Summary

Fixes #895  

on every auction settlement with a winner, the farmer was 
receiving double the winning bid amount due to the balance being 
incremented twice in the same transaction.

## Root Cause

`claimAndSettleNextAuction` used `findOneAndUpdate` with `$inc` to 
atomically credit the farmer's balance, which returns the document 
*after* the increment. It then immediately called `.plus(bid).save()` 
on that already-incremented document, adding the bid amount a second time.

Also, `User.findById(buyer)` was called twice - the first result was 
silently overwritten.

## Changes

`backend/jobs/auctionSettlement.js`
- Removed the redundant `farmerNewBalance` read-modify-write block 
  (`farmer.balance = ...; farmer.save()`) - the `$inc` via 
  `findOneAndUpdate` is sufficient and correct on its own
- Removed the duplicate `User.findById(buyer)` call
- Removed now-unused `toDecimal` and `fromDecimal` imports

## Before / After

| Winning bid | Farmer balance change (before) | Farmer balance change (after) |
|-------------|-------------------------------|-------------------------------|
| 500 credits | +1000 credits ❌              | +500 credits ✅               |
| 200 credits | +400 credits ❌               | +200 credits ✅               |
