### PR TITLE
fix(backend): resolve duplicate variable declarations in notification worker

### DIFF
--- a/backend/jobs/worker.js
+++ b/backend/jobs/worker.js
@@ -15,8 +15,6 @@ let worker = null;
 async function processSendEmail(job) {
   const { to, subject, templateData } = job.data;
   console.log(`[NotificationWorker] Sending email to ${to}`);
-  
-  const { to, subject, html } = job.data;
   logger.info(`[NotificationWorker] Sending email to ${to}`);
 
   await job.updateProgress(10);


### PR DESCRIPTION
## 📌 Overview

This PR fixes the notification worker `backend/jobs/worker.js` which declared the same block-scoped variables twice inside `processSendEmail`. `to` and `subject` were destructured from `job.data` on line 16 and again on line 19, and `html` was declared twice (line 19 as `const` and line 25 as `let`). This caused a parse-time `SyntaxError: Identifier 'to' has already been declared`. Because `server.js:12` requires `./jobs/worker` at module top level, the whole backend process failed to boot — no Express server, no API, no Socket.IO — and the `try/catch` around `notificationWorker.initializeWorker()` never ran since the `require` already crashed the module.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #917

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified `node --check backend/jobs/worker.js` passes with no SyntaxError? (Yes)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change removes the duplicate destructuring of `to`, `subject`, and `html` in `processSendEmail`, keeping a single `const { to, subject, templateData } = job.data` and a single `let html = job.data.html` for the backward-compatible raw-HTML path. The module now loads cleanly, so `server.js` boots and the Express API and Socket.IO listeners bind as expected.
