### PR TITLE
fix(backend): enforce farmer ownership for lifecycle stage updates

### DIFF
--- a/backend/controllers/lifecycleController.js
+++ b/backend/controllers/lifecycleController.js
@@ -145,8 +145,14 @@ exports.updateLifecycle = async (req, res) => {
       const userId = (req.user.id || req.user._id)?.toString().trim().toLowerCase();
       const batchFarmerId = batch.farmerId?.toString().trim().toLowerCase();
       const isOwner = userId === batchFarmerId;
+      const isFarmer = req.user.role === "farmer";
+      const stageAuthorized = isAuthorizedForStage(req.user.role, stage);
+      // Farmers must own the batch they advance to Growing/Harvested.
+      // Other roles (transporter/mandi/retailer/quality_inspector) only
+      // need stage authorization and never own the batch.
+      const allowed = isFarmer ? isOwner && stageAuthorized : stageAuthorized;
 
-      if (!isOwner && !isAuthorizedForStage(req.user.role, stage)) {
+      if (!allowed) {
         logger.warn("Lifecycle update rejected: user does not own this batch and role is not authorized for target stage", {
           userId,
           role: req.user.role,

--- a/backend/tests/lifecycle.test.js
+++ b/backend/tests/lifecycle.test.js
@@ -131,6 +131,79 @@ describe("Crop Lifecycle API Endpoints", () => {
     expect(res.body.data.completionPercentage).toEqual(33);
   });
 
+  it("should reject a non-owner farmer advancing another farmer's batch to Growing", async () => {
+    const testBatch = {
+      batchId: "BATCH123",
+      farmerId: "FARM123",
+      lifecycle: {
+        currentStage: "Registered",
+        stageHistory: [
+          { stage: "Registered", timestamp: new Date(), updatedBy: "System" },
+        ],
+      },
+      save: jest.fn().mockResolvedValue(true),
+    };
+    mockBatch.findOne.mockResolvedValue(testBatch);
+    mockCurrentUser = { id: "FARM999", name: "Other Farmer", role: "farmer" };
+
+    const res = await request(app)
+      .patch("/api/batches/BATCH123/lifecycle")
+      .send({ stage: "Growing" });
+
+    expect(res.statusCode).toEqual(403);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toContain("not authorized");
+  });
+
+  it("should reject a non-owner farmer advancing another farmer's batch to Harvested", async () => {
+    const testBatch = {
+      batchId: "BATCH123",
+      farmerId: "FARM123",
+      lifecycle: {
+        currentStage: "Growing",
+        stageHistory: [
+          { stage: "Registered", timestamp: new Date(), updatedBy: "System" },
+          { stage: "Growing", timestamp: new Date(), updatedBy: "System" },
+        ],
+      },
+      save: jest.fn().mockResolvedValue(true),
+    };
+    mockBatch.findOne.mockResolvedValue(testBatch);
+    mockCurrentUser = { id: "FARM999", name: "Other Farmer", role: "farmer" };
+
+    const res = await request(app)
+      .patch("/api/batches/BATCH123/lifecycle")
+      .send({ stage: "Harvested" });
+
+    expect(res.statusCode).toEqual(403);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("should allow the owner farmer to advance the batch to Harvested", async () => {
+    const testBatch = {
+      batchId: "BATCH123",
+      farmerId: "FARM123",
+      lifecycle: {
+        currentStage: "Growing",
+        stageHistory: [
+          { stage: "Registered", timestamp: new Date(), updatedBy: "System" },
+          { stage: "Growing", timestamp: new Date(), updatedBy: "System" },
+        ],
+      },
+      save: jest.fn().mockResolvedValue(true),
+    };
+    mockBatch.findOne.mockResolvedValue(testBatch);
+    mockCurrentUser = { id: "FARM123", name: "Test Farmer", role: "farmer" };
+
+    const res = await request(app)
+      .patch("/api/batches/BATCH123/lifecycle")
+      .send({ stage: "Harvested" });
+
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.currentStage).toEqual("Harvested");
+  });
+
   it("should prevent duplicate transitions to the current stage", async () => {
     const testBatch = {
       batchId: "BATCH123",


### PR DESCRIPTION
## 📌 Overview

This PR fixes the lifecycle ownership check in `backend/controllers/lifecycleController.js` that was never actually enforced for farmers. `isAuthorizedForStage` returns `true` for a farmer targeting `Growing` or `Harvested`, so a non-owner farmer passed both gates (line 149: `!isOwner && !isAuthorizedForStage(...)` → `true && false` → no 403; line 195: role check passes). A random farmer could set any other farmer's crop to `Growing`/`Harvested`, corrupting the supply-chain record and the `updatedAt`/completion metadata. The ownership check is now enforced: farmers must own the batch they advance, while transporter/mandi/retailer/quality_inspector roles remain authorized by target stage alone, and admins stay fully exempt.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #918

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified with focused Jest run — non-owner farmer → 403, owner farmer → 200, non-owner transporter → 200, admin → 200? (Yes)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change adds regression coverage in `backend/tests/lifecycle.test.js` around the ownership gate: a non-owner farmer advancing another farmer's batch to `Growing`/`Harvested` now gets `403 FORBIDDEN`, the owner farmer can still advance, and non-owner role-authorized transitions (e.g., transporter → `Transported`) continue to work. Note: the full `server.js`-based test suite currently cannot boot on `main` due to two unrelated pre-existing breakages (`getContract` referenced but never defined in `config/blockchain.js`, and an undefined `authorizeIoTSubmission` middleware in `routes/index.js`); the new tests were verified by exercising `updateLifecycle` directly with its dependencies isolated.
