### PR TITLE
fix(backend): handle ethers v6 bigint gas values in oracle IoT fulfillment

### DIFF
--- a/backend/services/oracleService.js
+++ b/backend/services/oracleService.js
@@ -242,14 +242,26 @@ class OracleService {
 
       logger.info(`⛽ Gas estimate: ${gasEstimate.toString()}`);
 
+      // ethers v6 estimateGas returns a bigint, so apply the 20% buffer with
+      // bigint arithmetic instead of Math.floor(number * 1.2).
+      const gasLimit = (gasEstimate * 120n) / 100n;
+
+      // Resolve fee fields from the provider's FeeData (ethers v6 requires
+      // individual bigint fee values, not the whole FeeData object).
+      const feeData = await this.provider.getFeeData();
+      const overrides = { gasLimit };
+      if (feeData.maxFeePerGas != null && feeData.maxPriorityFeePerGas != null) {
+        overrides.maxFeePerGas = feeData.maxFeePerGas;
+        overrides.maxPriorityFeePerGas = feeData.maxPriorityFeePerGas;
+      } else if (feeData.gasPrice != null) {
+        overrides.gasPrice = feeData.gasPrice;
+      }
+
       const tx = await this.contract.fulfillIoTData(
         batchId,
         temperatureRaw,
         iotData.humidity,
-        {
-          gasLimit: Math.floor(gasEstimate * 1.2), // 20% buffer
-          gasPrice: await this.provider.getFeeData(),
-        },
+        overrides,
       );
 
       logger.info(`📤 Transaction sent: ${tx.hash}`);

--- a/backend/tests/oracleService.test.js
+++ b/backend/tests/oracleService.test.js
@@ -1,0 +1,58 @@
+jest.mock("../utils/logger", () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const oracleService = require("../services/oracleService");
+
+const makeContract = () => {
+  const call = jest.fn().mockResolvedValue({
+    hash: "0xabc",
+    wait: jest.fn().mockResolvedValue({ blockNumber: 1, gasUsed: 90000n }),
+  });
+  call.estimateGas = jest.fn().mockResolvedValue(100000n);
+  return { fulfillIoTData: call };
+};
+
+describe("OracleService.fulfillIoTData (ethers v6 bigint handling)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("uses a bigint gasLimit with 20% buffer and EIP-1559 fee bigints", async () => {
+    const contract = makeContract();
+    oracleService.contract = contract;
+    oracleService.provider = {
+      getFeeData: jest.fn().mockResolvedValue({
+        maxFeePerGas: 25000000000n,
+        maxPriorityFeePerGas: 2000000000n,
+        gasPrice: 25000000000n,
+      }),
+    };
+
+    const receipt = await oracleService.fulfillIoTData("0x1234", {
+      temperature: 24.5,
+      humidity: 60,
+    });
+
+    const overrides = contract.fulfillIoTData.mock.calls[0][3];
+    expect(overrides.gasLimit).toBe(120000n);
+    expect(overrides.maxFeePerGas).toBe(25000000000n);
+    expect(overrides.maxPriorityFeePerGas).toBe(2000000000n);
+    expect(overrides.gasPrice).toBeUndefined();
+    expect(receipt.blockNumber).toBe(1);
+  });
+
+  it("falls back to legacy gasPrice when no EIP-1559 fields are present", async () => {
+    const contract = makeContract();
+    oracleService.contract = contract;
+    oracleService.provider = {
+      getFeeData: jest.fn().mockResolvedValue({ gasPrice: 15000000000n }),
+    };
+
+    await oracleService.fulfillIoTData("0x1234", {
+      temperature: 24.5,
+      humidity: 60,
+    });
+
+    const overrides = contract.fulfillIoTData.mock.calls[0][3];
+    expect(overrides.gasLimit).toBe(120000n);
+    expect(overrides.gasPrice).toBe(15000000000n);
+    expect(overrides.maxFeePerGas).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 📌 Overview

This PR fixes the ethers v6 incompatibility in `backend/services/oracleService.js` (`fulfillIoTData`, lines 237–253) that made every IoT data-fulfillment transaction fail before submission. In ethers v6 `estimateGas` returns a `bigint`, so `Math.floor(gasEstimate * 1.2)` threw `TypeError: Cannot mix BigInt and other types`. Additionally, the whole `FeeData` object from `provider.getFeeData()` was passed as `gasPrice`, where ethers v6 requires individual bigint fee fields. The gas limit is now buffered with bigint arithmetic (`(gasEstimate * 120n) / 100n`) and transaction overrides resolve EIP-1559 `maxFeePerGas`/`maxPriorityFeePerGas` with a legacy `gasPrice` fallback.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #920

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified with Jest — bigint gasLimit (20% buffer) + EIP-1559 fee bigints and legacy `gasPrice` fallback both submit without the BigInt TypeError? (Yes)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change adds regression coverage in `backend/tests/oracleService.test.js` that stubs the contract/provider with ethers v6 `bigint` semantics and asserts the exact overrides passed to `fulfillIoTData`: `gasLimit: 120000n` (20% buffer over a `100000n` estimate), EIP-1559 `maxFeePerGas`/`maxPriorityFeePerGas` when available, and a `gasPrice` fallback for legacy chains. The fix mirrors the existing ethers v6 bigint pattern already used in `backend/services/blockchainWorker.js`.
