### PR TITLE
fix(backend): decode on-chain batchId and drop upsert in blockchain listener

### DIFF
--- a/backend/services/blockchainListener.js
+++ b/backend/services/blockchainListener.js
@@ -1,22 +1,33 @@
-﻿const Batch = require("../models/Batch");
+﻿const { ethers } = require("ethers");
+const Batch = require("../models/Batch");
 const socketService = require("./socketService");
 const logger = require("../utils/logger");
+const { STAGE_ORDER } = require("../constants/stages");
 
 function startListener(contract) {
   // ✅ matches your ABI
   contract.on("BatchUpdated", async (batchId, stage, actor) => {
     try {
-      const id = batchId.toString();
-      const stageMap = ["farmer", "mandi", "transport", "retailer"];
-      const stageStr = stageMap[Number(stage)] || "unknown";
-      await Batch.updateOne(
+      // The emitted batchId is the on-chain bytes32 (0x…64 hex), but the DB
+      // stores the human-readable business ID (CROP-2026-0001). Decode it back
+      // so the update matches the real batch document.
+      const id = ethers.decodeBytes32String(batchId);
+      const stageStr = STAGE_ORDER[Number(stage)] || "unknown";
+
+      // No upsert: if the batch is unknown to the DB, log and skip instead of
+      // inserting a malformed document with only batchId/currentStage/syncStatus.
+      const result = await Batch.updateOne(
         { batchId: id },
         {
           currentStage: stageStr,
           syncStatus: "synced",
         },
-        { upsert: true },
       );
+
+      if (result.matchedCount === 0) {
+        logger.warn(`[SYNC] Batch ${id} not found in DB; skipping update`);
+        return;
+      }
 
       logger.info(`[SYNC] Batch ${id} → ${stageStr} by ${actor}`);
 

--- a/backend/tests/blockchainListener.test.js
+++ b/backend/tests/blockchainListener.test.js
@@ -1,0 +1,70 @@
+const { ethers } = require("ethers");
+
+const mockBatch = { updateOne: jest.fn(), findOne: jest.fn() };
+
+jest.mock("../models/Batch", () => mockBatch);
+jest.mock("../services/socketService", () => ({
+  emitToBatchRoom: jest.fn(),
+  emitGlobal: jest.fn(),
+}));
+jest.mock("../utils/logger", () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+
+const socketService = require("../services/socketService");
+const startListener = require("../services/blockchainListener");
+
+const captureHandler = () => {
+  const listeners = {};
+  const handler = {
+    on: (event, fn) => {
+      listeners[event] = fn;
+      return handler;
+    },
+  };
+  startListener(handler);
+  return listeners;
+};
+
+describe("Blockchain listener: BatchUpdated sync", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("updates the real batch using the decoded business ID, without upsert", async () => {
+    const businessId = "CROP-2026-0001";
+    const onChainId = ethers.encodeBytes32String(businessId);
+    const listeners = captureHandler();
+
+    mockBatch.updateOne.mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
+    mockBatch.findOne.mockImplementation(() => ({
+      lean: async () => ({ batchId: businessId, currentStage: "mandi" }),
+    }));
+
+    await listeners.BatchUpdated(onChainId, 1, "0xabc");
+
+    expect(mockBatch.updateOne).toHaveBeenCalledWith(
+      { batchId: businessId },
+      { currentStage: "mandi", syncStatus: "synced" },
+    );
+    expect(mockBatch.updateOne.mock.calls[0][2]).toBeUndefined();
+    expect(socketService.emitToBatchRoom).toHaveBeenCalledWith(
+      businessId,
+      "batch-updated",
+      expect.objectContaining({ batchId: businessId, stage: "mandi" }),
+    );
+    expect(socketService.emitGlobal).toHaveBeenCalled();
+  });
+
+  it("does not insert a malformed doc and skips broadcasts when batch is unknown", async () => {
+    const listeners = captureHandler();
+    mockBatch.updateOne.mockResolvedValue({ matchedCount: 0 });
+
+    await listeners.BatchUpdated(
+      ethers.encodeBytes32String("CROP-2026-9999"),
+      2,
+      "0xabc",
+    );
+
+    expect(mockBatch.updateOne.mock.calls[0][2]).toBeUndefined();
+    expect(mockBatch.findOne).not.toHaveBeenCalled();
+    expect(socketService.emitToBatchRoom).not.toHaveBeenCalled();
+    expect(socketService.emitGlobal).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 📌 Overview

This PR fixes the broken chain→DB reconciliation in `backend/services/blockchainListener.js`. The `BatchUpdated` event emits the on-chain `bytes32` batch ID (`0x…64` hex) while MongoDB stores human-readable business IDs (`CROP-2026-0001`), so `Batch.updateOne({ batchId: id })` never matched a real batch. Worse, `upsert: true` silently inserted malformed documents containing only `batchId`/`currentStage`/`syncStatus`, leaving the real batch record untouched. The listener now decodes the `bytes32` back to the business ID with `ethers.decodeBytes32String` (the inverse of the `ethers.encodeBytes32String` used when submitting transactions), removes `upsert: true`, and skips (with a warning) when no matching batch exists — re-enabling the reconciliation update and the socket broadcasts in the handler.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #922

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [x] **Integration:** Verified with Jest — event with on-chain bytes32 updates the real batch by its decoded business ID, and an unknown batch is skipped without inserting a malformed document? (Yes)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change adds regression coverage in `backend/tests/blockchainListener.test.js`: encoding a business ID to `bytes32` (mirroring `blockchainWorker.js`), firing the captured `BatchUpdated` handler, and asserting the `updateOne` query uses the decoded business ID with no upsert option, socket broadcasts fire with the decoded ID, and unmatched batches produce no write and no broadcast. The stage mapping now uses the centralized `constants/stages` `STAGE_ORDER` instead of a locally duplicated array.
