### PR TITLE
fix(contracts): enforce oracle price protection for unpriced crops

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -338,6 +338,9 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         require(!batch.isSpoiled, "Batch is spoiled");
         require(quantity > 0, "Quantity must be > 0");
         require(unitPriceWei > 0, "Price=0");
+        // The crop must have been priced by the oracle before it can be listed,
+        // so the TWAP/deviation guard in buyFromListing always has a reference.
+        require(latestOraclePrice[batch.cropTypeHash] > 0, "Crop type not priced");
 
         SupplyChainUpdate[] storage updates = _batchUpdates[batchId];
         SupplyChainUpdate storage latestUpdate = updates[updates.length - 1];
@@ -400,10 +403,15 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         
         require(listing.seller == _getCurrentCustodian(listing.batchId), "Seller is no longer the custodian");
 
-        uint256 twapPrice = getTwapPrice(batch.cropTypeHash, twapWindow);
-        if (twapPrice > 0) {
-            require(_withinDeviation(listing.unitPriceWei, twapPrice, maxPriceDeviationBps), "TWAP deviation too high");
+        uint256 referencePrice = getTwapPrice(batch.cropTypeHash, twapWindow);
+        // Cold-start fallback: if there are no TWAP observations yet, fall back
+        // to the latest oracle spot price so the deviation guard is never
+        // silently skipped. Revert if the crop has never been priced at all.
+        if (referencePrice == 0) {
+            referencePrice = latestOraclePrice[batch.cropTypeHash];
         }
+        require(referencePrice > 0, "No oracle price for crop type");
+        require(_withinDeviation(listing.unitPriceWei, referencePrice, maxPriceDeviationBps), "TWAP deviation too high");
 
         uint256 totalCost = listing.unitPriceWei * quantity;
         require(msg.value >= totalCost, "Insufficient payment");

--- a/smart-contracts/test/security.refactor.test.js
+++ b/smart-contracts/test/security.refactor.test.js
@@ -178,6 +178,102 @@ describe("CropChain Security Refactor", function () {
     ).to.be.revertedWith("TWAP deviation too high");
   });
 
+  it("rejects creating a listing when the crop has no oracle price", async function () {
+    const { cropChain, oracle } = await deployFixture();
+
+    const cropType = ethers.keccak256(ethers.toUtf8Bytes("SORGHUM"));
+    const batchId = ethers.keccak256(ethers.toUtf8Bytes("BATCH-006"));
+
+    await cropChain.setRole(oracle.address, Roles.Farmer);
+
+    await cropChain
+      .connect(oracle)
+      .createBatch(
+        batchId,
+        cropType,
+        "ipfs://bafybeigdyrztqz4xq7x4z7m4xq7x4z7m4xq7x4z7m4",
+        50,
+        "farmer",
+        "origin",
+        "notes",
+      );
+
+    await expect(
+      cropChain
+        .connect(oracle)
+        .createListing(batchId, 10, ethers.parseEther("1000")),
+    ).to.be.revertedWith("Crop type not priced");
+  });
+
+  it("enforces the deviation guard at purchase with a single spot observation", async function () {
+    const { cropChain, buyer, oracle } = await deployFixture();
+
+    const cropType = ethers.keccak256(ethers.toUtf8Bytes("QUINOA"));
+    const batchId = ethers.keccak256(ethers.toUtf8Bytes("BATCH-007"));
+
+    await cropChain.setRole(oracle.address, Roles.Oracle);
+    await cropChain.connect(oracle).recordSpotPrice(cropType, ethers.parseEther("1"));
+    await cropChain.setRole(oracle.address, Roles.Farmer);
+
+    await cropChain
+      .connect(oracle)
+      .createBatch(
+        batchId,
+        cropType,
+        "ipfs://bafybeigdyrztqz4xq7x4z7m4xq7x4z7m4xq7x4z7m4",
+        50,
+        "farmer",
+        "origin",
+        "notes",
+      );
+
+    // The listing at 1000x market value is created...
+    await cropChain
+      .connect(oracle)
+      .createListing(batchId, 10, ethers.parseEther("1000"));
+
+    // ...but the purchase reverts instead of silently bypassing price protection.
+    await expect(
+      cropChain
+        .connect(buyer)
+        .buyFromListing(1, 1, { value: ethers.parseEther("1000") }),
+    ).to.be.revertedWith("TWAP deviation too high");
+  });
+
+  it("allows purchase at a fair price with only a single spot observation", async function () {
+    const { cropChain, buyer, oracle } = await deployFixture();
+
+    const cropType = ethers.keccak256(ethers.toUtf8Bytes("LENTIL"));
+    const batchId = ethers.keccak256(ethers.toUtf8Bytes("BATCH-008"));
+    const unitPrice = ethers.parseEther("1");
+
+    await cropChain.setRole(oracle.address, Roles.Oracle);
+    await cropChain.connect(oracle).recordSpotPrice(cropType, unitPrice);
+    await cropChain.setRole(oracle.address, Roles.Farmer);
+
+    await cropChain
+      .connect(oracle)
+      .createBatch(
+        batchId,
+        cropType,
+        "ipfs://bafybeigdyrztqz4xq7x4z7m4xq7x4z7m4xq7x4z7m4",
+        50,
+        "farmer",
+        "origin",
+        "notes",
+      );
+
+    await cropChain.connect(oracle).createListing(batchId, 10, unitPrice);
+
+    await expect(
+      cropChain.connect(buyer).buyFromListing(1, 1, { value: unitPrice }),
+    ).to.not.be.reverted;
+
+    expect(await cropChain.pendingWithdrawals(oracle.address)).to.equal(
+      unitPrice,
+    );
+  });
+
   it("restricts circuit breaker and TWAP tuning to the admin role", async function () {
     const { cropChain, buyer } = await deployFixture();
 
@@ -213,6 +309,10 @@ describe("CropChain Security Refactor", function () {
     const batchId = ethers.keccak256(ethers.toUtf8Bytes("BATCH-005"));
     const unitPrice = ethers.parseEther("1");
 
+    // Price the crop so the listing passes the oracle-price gate; this test
+    // only validates custody, not pricing.
+    await cropChain.setRole(oracle.address, Roles.Oracle);
+    await cropChain.connect(oracle).recordSpotPrice(cropType, unitPrice);
     await cropChain.setRole(oracle.address, Roles.Farmer);
     await cropChain.setRole(mandi.address, Roles.Mandi);
 


### PR DESCRIPTION
## 📌 Overview

This PR closes the cold-start price-protection hole in the `CropChain` marketplace. `getTwapPrice` returns `0` whenever `_priceObservations[cropTypeHash]` is empty, and `buyFromListing` skipped the `_withinDeviation` check entirely when `twapPrice == 0`, so a seller could list — and a buyer could purchase — at an arbitrarily inflated `unitPriceWei` (e.g., 1000× market value) for any crop that had never been priced by the oracle. `createListing` now requires the crop type to have been priced (`require(latestOraclePrice[cropTypeHash] > 0, "Crop type not priced")`), and `buyFromListing` falls back to `latestOraclePrice` when the TWAP window has no observations and always enforces the deviation guard, reverting with `"No oracle price for crop type"` if the crop has never been priced at all.

## 🛠️ Type of Change
- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #923

---

## 🧪 Testing & Verification
- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA)

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This change adds regression coverage in `smart-contracts/test/security.refactor.test.js`: (1) `createListing` reverts with `"Crop type not priced"` for an unpriced crop, (2) a listing created at 1000× the single spot observation still reverts at purchase with `"TWAP deviation too high"`, and (3) a fair-priced purchase succeeds with only a single spot observation. The existing custody-validation test now records a spot price first since pricing is now a listing precondition. Full suite: 37 passing.
