### PR TITLE
fix: restore malformed GitHub Actions workflow jobs (#932)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,6 @@ jobs:
   # Job 6: ML Service Tests
   ml-service-tests:
     name: ML Service Tests
-  # Job 6: Mobile Tests
-  mobile-tests:
-    name: Mobile Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -209,6 +206,20 @@ jobs:
       - name: Install ML dependencies
         working-directory: ml-service/
         run: pip install -r requirements.txt
+
+      - name: Validate ML Service
+        working-directory: ml-service/
+        run: python -m py_compile app.py train.py
+
+  # Job 7: Mobile Tests
+  mobile-tests:
+    name: Mobile Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -224,19 +235,73 @@ jobs:
         working-directory: mobile/
         run: npm run test:ci
 
-  # Job 7: Docker Security Scan
-  # Job 6: Terraform Validation
+  # Job 8: Terraform Validation
   terraform-checks:
     name: Terraform Format and Validate
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: infrastructure/
-  # Job 6: Docker Security Scan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+  # Job 9: Docker Security Scan
   docker-security-scan:
     name: Trivy Scan (${{ matrix.service.name }})
     runs-on: ubuntu-latest
-  # Job 8: Publish Docker Images
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: backend
+            context: backend/
+            dockerfile: backend/Dockerfile.dev
+          - name: frontend
+            context: frontend/
+            dockerfile: frontend/Dockerfile.dev
+          - name: ml-service
+            context: ml-service/
+            dockerfile: ml-service/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Image
+        run: docker build -t cropchain/${{ matrix.service.name }}:latest -f ${{ matrix.service.dockerfile }} ${{ matrix.service.context }}
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'cropchain/${{ matrix.service.name }}:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: ${{ matrix.service.name }}
+
+  # Job 10: Publish Docker Images
   docker-publish:
     name: Publish Docker Images to GHCR
     runs-on: ubuntu-latest
@@ -259,47 +324,11 @@ jobs:
           - name: ml-service
             context: ml-service/
             dockerfile: ml-service/Dockerfile
-  # Job 9: SBOM Generation
-  sbom-generation:
-    name: Generate Software Bill of Materials (SBOM)
-  # Job 10: ML Service Checks
-  ml-service-checks:
-    name: ML Service Checks
-    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform Format
-        run: terraform fmt -check
-
-      - name: Terraform Init
-        run: terraform init -backend=false
-
-      - name: Terraform Validate
-        run: terraform validate
-      - name: Build Image
-        run: docker build -t cropchain/${{ matrix.service.name }}:latest -f ${{ matrix.service.dockerfile }} ${{ matrix.service.context }}
-
-      - name: Run Trivy Vulnerability Scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'cropchain/${{ matrix.service.name }}:latest'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '1'
-
-      - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: ${{ matrix.service.name }}
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -326,27 +355,24 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Job 11: SBOM Generation
+  sbom-generation:
+    name: Generate Software Bill of Materials (SBOM)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Generate SBOM (SPDX)
         uses: anchore/sbom-action@v0
         with:
           path: .
           format: spdx-json
           artifact-name: cropchain-sbom.spdx.json
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: "pip"
 
-      - name: Install dependencies
-        working-directory: ml-service/
-        run: pip install -r requirements.txt
-
-      - name: Validate ML Service
-        working-directory: ml-service/
-        run: python -m py_compile app.py train.py
-
-  # Job 11: Docker Validation
+  # Job 12: Docker Validation
   docker-validation:
     name: Docker Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
           category: ${{ matrix.service.name }}


### PR DESCRIPTION
## 📌 Overview

This PR fixes the malformed GitHub Actions workflow reported in #932. Multiple jobs in `.github/workflows/ci.yml` were missing required fields, causing GitHub to reject the workflow (runs finished in 0 seconds, no jobs were created, `total_count: 0`).

The fix restores each malformed job with its required `runs-on` and `steps`, resolves the undefined `matrix.service` usage, and relocates misplaced steps back to their correct jobs.

## 🛠️ Type of Change

- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (CI workflow validation, Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #932

---

## 🧪 Testing & Verification

- [ ] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA) — **NA** (no contract changes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA) — **NA** (no frontend changes)
- [x] **Integration:** Verified CI workflow validates and creates jobs? — **Yes** (`actionlint` reports 0 problems; workflow YAML parses; all 12 jobs have `runs-on` + `steps`)

### Changes

- Restored `ml-service-tests` with required `runs-on` and `steps`
- Restored `terraform-checks` (Terraform format/init/validate steps)
- Restored `docker-security-scan` and added the missing `strategy.matrix` definition for `matrix.service`
- Restored `docker-publish` (GHCR login/metadata/build-push steps)
- Restored `sbom-generation` with `runs-on` and steps
- Moved misplaced ML/Python steps out of `mobile-tests` into `ml-service-tests`
- Removed the redundant `ml-service-checks` job after restoring all of its misplaced steps to their correct jobs (no other job references it via `needs`)
- Corrected workflow job ordering and comment numbering

### Result

- Workflow validates successfully with `actionlint` (0 problems)
- All jobs now define the required GitHub Actions schema fields (`runs-on`, `steps`, valid `needs`, valid matrix references)
- The workflow is able to create and execute jobs on `push` and `pull_request`

---

## 📸 Screenshots / Demos

_N/A_

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

The removed `ml-service-checks` job was fully redundant: every one of its steps belonged to another job (Terraform checks, Docker security scan, Docker publish, SBOM generation, ML service validation) and was restored there. Keeping it would have recreated the empty-job defect this issue reports. Verified via `git grep` that no job references `ml-service-checks` in `needs`.
