### PR TITLE
fix: stop SSE bulk-job polling on client disconnect (#931)

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -852,7 +852,12 @@ const getBulkJobStatus = async (req, res) => {
 const streamBulkJobEvents = async (req, res) => {
   const { jobId } = req.params;
 
+  let clientDisconnected = false;
+
   const writeEvent = (event, data) => {
+    if (clientDisconnected || res.writableEnded || res.destroyed) {
+      return;
+    }
     res.write(`event: ${event}\n`);
     res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
@@ -894,13 +899,14 @@ const streamBulkJobEvents = async (req, res) => {
 
   // If client disconnects, stop polling.
   req.on("close", () => {
+    clientDisconnected = true;
     safeClose();
   });
 
   try {
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
+    while (!clientDisconnected) {
       const jobDoc = await BulkVerificationJob.findById(jobId);
+      if (clientDisconnected) break;
       const job =
         jobDoc && typeof jobDoc.lean === "function"
           ? await jobDoc.lean()
@@ -989,6 +995,7 @@ const streamBulkJobEvents = async (req, res) => {
       }
 
       await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      if (clientDisconnected) break;
     }
   } catch (error) {
     try {


### PR DESCRIPTION
## Fix Issue #931 SSE bulk-job stream continues polling after client disconnect

### Description

The `/bulk-jobs/:jobId/events` SSE endpoint used an unconditional `while (true)` polling loop. On client disconnect, only `res.end()` was called the loop never received a signal, so it kept calling `BulkVerificationJob.findById()` every second, attempting `res.write()` after the response ended, wasting DB resources, and potentially throwing `ERR_STREAM_WRITE_AFTER_END`.

### Changes

- Added a `clientDisconnected` flag that is set in the `req.on("close")` handler.
- Replaced `while (true)` with `while (!clientDisconnected)` so polling stops immediately on disconnect.
- Guarded every `res.write()` in `writeEvent()` with a writability check (`clientDisconnected || res.writableEnded || res.destroyed`).
- Added `if (clientDisconnected) break;` after each `await` (DB query and sleep) so no further query or write happens after the connection closes.
- Reused the existing `safeClose()` helper; removed the stale `eslint-disable no-constant-condition` pragma.

### Root Cause

The polling loop had no disconnect condition, and `writeEvent()` wrote without checking whether the response was still writable. Disconnecting the client did not terminate the loop.

### Behavior Preserved

- API route, authentication, authorization, polling interval, event names, payload format, response headers, database queries, and success/error responses are all unchanged.
- SSE behavior is identical while the client is connected.

### Acceptance Criteria

- [x] Client disconnect immediately exits the polling loop.
- [x] No further `BulkVerificationJob.findById()` calls after disconnect.
- [x] `writeEvent()` never writes to an ended response.
- [x] No `ERR_STREAM_WRITE_AFTER_END` errors.
- [x] Existing SSE behavior unchanged while connected.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update

### Checklist

- [x] I have performed a self-review of my own code.
- [x] My changes are limited to Issue #931 only.
- [x] Syntax verified (`node --check`).
- [x] Follows Node.js SSE best practices.

### Files Changed

- `backend/controllers/verificationController.js`
