### PR TITLE
fix(verification): allow mandi role for credential issuance (#929)

### DIFF
--- a/backend/services/didService.js
+++ b/backend/services/didService.js
@@ -1,7 +1,7 @@
 const { ethers } = require("ethers");
 const logger = require("../utils/logger");
 const User = require("../models/User");
-const { isAdminRole } = require("../constants/permissions");
+const { isAdminRole, ROLES } = require("../constants/permissions");
 const {
   buildVerificationMessage,
   CHALLENGE_ACTIONS,
@@ -78,7 +78,10 @@ class DIDService {
         throw new Error("User not found");
       }
 
-      if (!verifier || !isAdminRole(verifier.role)) {
+      if (
+        !verifier ||
+        (!isAdminRole(verifier.role) && verifier.role !== ROLES.MANDI)
+      ) {
         try {
           await VerificationEvent.create({
             action: "credential_issued",


### PR DESCRIPTION
## 📌 Overview

This PR fixes the authorization inconsistency reported in **Issue #929**.

The route for `POST /verification/issue` already authorizes users with the following roles:

* `admin`
* `super_admin`
* `mandi`

However, the service layer (`backend/services/didService.js`) only accepted roles recognized by `isAdminRole()`, which excludes `mandi`. As a result, requests from `mandi` users passed route authorization but were rejected during credential issuance with:

> Only Mandi officers (admins) can verify users

This PR aligns the service-layer authorization with the route by allowing the `mandi` role while preserving defense-in-depth authorization checks.

### Changes

* Imported the shared `ROLES` constant from `backend/constants/permissions`.
* Updated the verifier authorization check in `didService.js` to accept `ROLES.MANDI` in addition to `admin` and `super_admin`.
* Preserved all existing credential issuance logic, validation, blockchain interactions, and error handling.

---

## 🛠️ Type of Change

* [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
* [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
* [x] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
* [ ] 📄 **Documentation** (README, Roadmap updates)
* [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #929

---

## 🧪 Testing & Verification

* [x] **Smart Contracts:** `npx hardhat test` passed? (Yes/No/NA) — **NA**
* [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes/No/NA) — **NA**
* [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (Yes/No/NA) — **NA**

### Verification Performed

* ✅ `node --check backend/services/didService.js` passes.
* ✅ Verified that `admin`, `super_admin`, and `mandi` successfully pass the authorization check.
* ✅ Verified that unauthorized roles (e.g. `farmer`) continue to be rejected with the existing authorization error.
* ✅ Confirmed that `revokeCredential()` authorization remains unchanged because its route is intentionally admin-only.

---

## 📸 Screenshots / Demos

N/A

---

## ✅ PR Checklist

* [x] My code follows the project's style guidelines.
* [ ] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
* [ ] I have updated the documentation accordingly.
* [x] My changes generate no new warnings.

---

## 💬 Additional Notes

* This change is strictly limited to **Issue #929**.
* Only the credential issuance authorization check was updated.
* No routes, middleware, schemas, blockchain interactions, credential issuance logic, or API responses were modified.
* A pre-existing unrelated test failure caused by the `recordIoTData` import in `routes/index.js` was observed during local verification and is outside the scope of this PR.