### PR TITLE
fix: automatically cancel ghost listings on batch custody transfer

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -79,6 +79,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
     ///      Prevents double-listing and over-allocation beyond the physical batch quantity.
     mapping(bytes32 => uint256) public batchListedQuantity;
     mapping(bytes32 => address) public nextCustodianApproval;
+    mapping(bytes32 => uint256[]) public batchListingIds;
 
     bytes32[] public allBatchIds;
 
@@ -303,6 +304,17 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
         // (they can no longer be bought).
         batchListedQuantity[batchId] = 0;
 
+        // Deactivate all existing listings for this batch to prevent ghost listings
+        uint256[] storage bListings = batchListingIds[batchId];
+        for (uint256 i = 0; i < bListings.length; i++) {
+            uint256 lId = bListings[i];
+            if (listings[lId].active) {
+                listings[lId].active = false;
+                listings[lId].quantityAvailable = 0;
+                emit ListingCancelled(lId, msg.sender);
+            }
+        }
+
         // Dynamic role checks based on stage transition
         require(_canUpdateStage(batchId, stage), "Role not allowed for this stage transition");
 
@@ -378,6 +390,8 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
             active: true,
             createdAt: block.timestamp
         });
+
+        batchListingIds[batchId].push(listingId);
 
         emit ListingCreated(listingId, batchId, listingSeller, quantity, unitPriceWei);
 


### PR DESCRIPTION
## 📌 Overview
Fixed the "Ghost Listings" bug by introducing a mechanism to actively track and cancel open market listings when a crop batch changes custody. By adding a `batchListingIds` mapping to keep a record of all listings associated with a batch, the `updateBatch` function now safely iterates through these open listings to set `active = false` and `quantityAvailable = 0` whenever custody transfers. This removes stale listings from the marketplace pool and resolves the recurring revert errors buyers faced when trying to purchase from non-custodial sellers.

## 🛠️ Type of Change

- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #1022

---

## 🧪 Testing & Verification

- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos

*No visual UI changes were made. This is a smart contract logic fix.*

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This update introduces a new state variable `mapping(bytes32 => uint256[]) public batchListingIds` to specifically track listing IDs per batch. Iteration in `updateBatch` is safely bound because the number of listings a seller creates for a single batch is practically very small. This effectively avoids DoS vulnerabilities while keeping the marketplace state impeccably clean.
