### PR TITLE
fix: prevent owner role modification in grantStakeholderRole

### DIFF
--- a/smart-contracts/contracts/CropChain.sol
+++ b/smart-contracts/contracts/CropChain.sol
@@ -596,6 +596,7 @@ contract CropChain is Pausable, ReentrancyGuard, AccessControl {
 
     function grantStakeholderRole(bytes32 role, address account) external onlyRole(DEFAULT_ADMIN_ROLE) nonReentrant {
         require(account != address(0), "Invalid address");
+        require(account != owner, "Cannot change owner role");
         require(
             role == FARMER_ROLE || role == MANDI_ROLE || role == TRANSPORTER_ROLE || role == RETAILER_ROLE || role == ORACLE_ROLE,
             "Invalid stakeholder role"


### PR DESCRIPTION
## 📌 Overview
Fixed an AccessControl discrepancy vulnerability where `grantStakeholderRole` could unintentionally bypass owner role protections. The legacy `setRole` function correctly guards against modifying the deployer/owner's role to prevent them from being locked out of core admin mappings. However, the newer `grantStakeholderRole` function was missing this critical safeguard. This update introduces the `require(account != owner, "Cannot change owner role");` check into `grantStakeholderRole`, ensuring the contract state remains perfectly consistent and protected across both legacy and OpenZeppelin role structures.

## 🛠️ Type of Change

- [x] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [ ] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue

Closes #1024 

---

## 🧪 Testing & Verification

- [x] **Smart Contracts:** `npx hardhat test` passed? (Yes)
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? (NA)
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA)

---

## 📸 Screenshots / Demos

*No visual UI changes were made. This is a smart contract access control and security optimization.*

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes

This targeted patch ensures that an admin, script, or multi-sig can confidently manage and rotate standard supply chain roles without the silent risk of accidentally demoting the original contract owner to a lower-tier stakeholder (such as `Farmer` or `Mandi`). This prevents potential lock-outs from legacy `ActorRole.Admin` checks.
