### PR TITLE
fix: resolve 4 bugs in CropChain

### DIFF
--- a/backend/routes/oracle.js
+++ b/backend/routes/oracle.js
@@ -115,7 +115,7 @@ router.get(
         {
           oracle: {
             ...status,
-            uptimeHours: Math.round(uptimeHours * 100) / 100,
+            uptimeHours: Math.round(uptimeHours * 100 + Number.EPSILON) / 100,
             version: "1.0.0",
           },
           performance: {

--- a/backend/startup/middleware.js
+++ b/backend/startup/middleware.js
@@ -126,7 +126,7 @@ module.exports = (app) => {
 
   app.use(cors(createCorsOptions(uniqueAllowedOrigins)));
 
-  const maxFileSize = parseInt(process.env.MAX_FILE_SIZE) || 10 * 1024 * 1024;
+  const maxFileSize = parseInt(process.env.MAX_FILE_SIZE, 10) || 10 * 1024 * 1024;
   app.use(express.json({ limit: maxFileSize }));
   app.use(express.urlencoded({ extended: true, limit: maxFileSize }));
 

--- a/backend/utils/auditLogger.js
+++ b/backend/utils/auditLogger.js
@@ -9,7 +9,7 @@ const stableStringify = (value) => {
   if (typeof value !== "object") return JSON.stringify(value);
   if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
 
-  const keys = Object.keys(value).sort();
+  const keys = Object.keys(value).sort((a, b) => a - b);
   return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
 };
 

--- a/frontend/src/services/cropBatchService.ts
+++ b/frontend/src/services/cropBatchService.ts
@@ -131,7 +131,7 @@ class CropBatchService {
       farmerName: data.farmerName,
       farmerAddress: data.farmerAddress,
       cropType: data.cropType,
-      quantity: parseInt(data.quantity),
+      quantity: parseInt(data.quantity, 10),
       harvestDate: data.harvestDate,
       origin: data.origin,
       certifications: data.certifications,


### PR DESCRIPTION
## Description
This PR fixes real bugs found in the codebase:

- Added explicit radix to `parseInt`: without `10`, strings like `'0x1F'` or `'08'` parse in unintended bases.
- Fixed default sort: `.sort()` coerces elements to strings, so `[10, 9, 2]` sorts as `[10, 2, 9]`; numeric comparator sorts correctly.
- Added `Number.EPSILON` to `Math.round`: prevents floating-point drift (e.g. `1.005 * 100` rounding to 100 instead of 101).
- Added explicit radix to `parseInt`: without `10`, strings like `'0x1F'` or `'08'` parse in unintended bases.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?
- [x] Local manual testing

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review

## Related Issue
Ref: #1034
