### PR TITLE
fix(auth): clear local session state on token refresh failure

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -54,6 +54,16 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const [isWalletConnected, setIsWalletConnected] = useState(false);
 
   useEffect(() => {
+    const handleAuthLogout = () => {
+      setUser(null);
+      setIsWalletConnected(false);
+      setAuthToken(null);
+    };
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("auth:logout", handleAuthLogout);
+    }
+
     const initAuth = async () => {
       try {
         const response = await authService.refreshSession();
@@ -69,6 +79,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       }
     };
     initAuth();
+
+    return () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("auth:logout", handleAuthLogout);
+      }
+    };
   }, []);
 
   const checkWalletConnected = async () => {

--- a/frontend/src/services/__tests__/apiClient.test.ts
+++ b/frontend/src/services/__tests__/apiClient.test.ts
@@ -1,0 +1,37 @@
+import { apiClient } from "../apiClient";
+import { tokenService } from "../token.service";
+
+describe("apiClient response interceptor", () => {
+  beforeEach(() => {
+    tokenService.clearAccessToken();
+    localStorage.clear();
+  });
+
+  it("clears token, removes user from localStorage, and dispatches auth:logout event on refresh failure", async () => {
+    tokenService.setAccessToken("expired-token");
+    localStorage.setItem("user", JSON.stringify({ id: "1", name: "Test User" }));
+
+    const logoutListener = vi.fn();
+    window.addEventListener("auth:logout", logoutListener);
+
+    // Mock apiClient.post for /auth/refresh failure
+    const postSpy = vi.spyOn(apiClient, "post").mockRejectedValueOnce(new Error("Refresh token expired"));
+
+    try {
+      // Simulate 401 error response on an API call
+      await apiClient.interceptors.response.handlers[0].rejected({
+        response: { status: 401 },
+        config: { url: "/profile", headers: {} },
+      });
+    } catch (err) {
+      // Interceptor should reject the request
+    }
+
+    expect(tokenService.getAccessToken()).toBeNull();
+    expect(localStorage.getItem("user")).toBeNull();
+    expect(logoutListener).toHaveBeenCalled();
+
+    window.removeEventListener("auth:logout", logoutListener);
+    postSpy.mockRestore();
+  });
+});

--- a/frontend/src/services/apiClient.ts
+++ b/frontend/src/services/apiClient.ts
@@ -66,6 +66,10 @@ apiClient.interceptors.response.use(
 
           if (!nextToken) {
             tokenService.clearAccessToken();
+            if (typeof window !== "undefined") {
+              localStorage.removeItem("user");
+              window.dispatchEvent(new Event("auth:logout"));
+            }
             return null;
           }
 
@@ -73,6 +77,10 @@ apiClient.interceptors.response.use(
           return nextToken;
         } catch (err) {
           tokenService.clearAccessToken();
+          if (typeof window !== "undefined") {
+            localStorage.removeItem("user");
+            window.dispatchEvent(new Event("auth:logout"));
+          }
           return null;
         } finally {
           refreshPromise = null;


### PR DESCRIPTION
## 📌 Overview
Fixes a bug where a failed token refresh (`/auth/refresh`) left the frontend in an inconsistent authenticated-looking state. Previously, when refresh failed, `apiClient.ts` cleared the in-memory `accessToken` via `tokenService` but left user data in `localStorage` and `AuthContext` untouched — so the UI kept showing the user as logged in even though authenticated requests would fail. Users were stuck until they manually cleared storage or refreshed the page.

This PR fixes it by performing full session cleanup and dispatching an `auth:logout` event whenever token refresh fails, so the app consistently and cleanly drops back to an unauthenticated state.

## 🛠️ Type of Change
- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [x] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (Hardhat tests, Jest/Vitest)

---

## 🔗 Related Issue
Closes #967 

---

## 🧪 Testing & Verification
- [ ] **Smart Contracts:** `npx hardhat test` passed? (NA)
- [x] **Frontend:** Verified on Mobile/Desktop responsiveness? (Yes)
- [x] **Integration:** Verified `ethers.js` connectivity with local/testnet node? (NA — auth flow only, no ethers.js interaction in this change)

**Key Changes:**
- **`frontend/src/services/apiClient.ts`**: Updated the response interceptor's `refreshPromise` failure logic to clear the `tokenService` access token, remove `"user"` from `localStorage`, and dispatch an `auth:logout` custom browser event.
- **`frontend/src/context/AuthContext.tsx`**: Added a global `auth:logout` window event listener to automatically reset React state (`setUser(null)`), clear socket authentication (`setAuthToken(null)`), and reset wallet state (`setIsWalletConnected(false)`).
- **`frontend/src/services/__tests__/apiClient.test.ts`**: Added a unit test verifying token clearance, `localStorage` cleanup, and event dispatch behavior on refresh failure.

**Verification Steps:**
1. **Automated Unit Test** — Run `apiClient.test.ts` to verify interceptor behavior on `/auth/refresh` rejection.
2. **Manual Test**:
   - Log into the frontend application.
   - Inject an invalid/expired access token into memory and invalidate the refresh session cookie/token on the backend.
   - Trigger an authenticated request.
   - Verify that when `/auth/refresh` fails, `localStorage` user data is cleared and the UI immediately updates to an unauthenticated state without hanging or requiring a page reload.

---

## ✅ PR Checklist
- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [ ] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.
- [x] Tested locally and confirmed bug resolution
- [x] Added unit test coverage for session cleanup
- [x] Verified backward compatibility with existing auth flows (`login`, `logout`, `walletLogin`)

---

## 💬 Additional Notes
This fix targets a session-consistency bug rather than a new feature. No breaking changes to existing auth flows — `login`, `logout`, and `walletLogin` were manually verified to still work as expected.

---
