### PR TITLE
fix(worker): resolve environment variables and load wallet safely in initializeBlockchain

### DIFF
--- a/backend/services/blockchainWorker.js
+++ b/backend/services/blockchainWorker.js
@@ -96,28 +96,56 @@ const contractABI = [
  * Async because the signer may come from an encrypted keystore / KMS / Vault.
  * @returns {Promise<boolean>} True when the worker has a connected contract
  */
-function initializeBlockchain() {
+async function initializeBlockchain() {
   if (initPromise) return initPromise;
 
-  if (!PROVIDER_URL || !CONTRACT_ADDRESS || !PRIVATE_KEY) {
-    logger.warn(
-      "[Worker] Blockchain not configured - running in simulation mode",
-    );
-    return false;
-  }
+  initPromise = (async () => {
+    const providerUrl =
+      process.env.PROVIDER_URL ||
+      process.env.INFURA_URL ||
+      process.env.SEPOLIA_URL;
+    const contractAddress = process.env.CONTRACT_ADDRESS;
+    const privateKey =
+      process.env.PRIVATE_KEY ||
+      process.env.ETH_PRIVATE_KEY ||
+      process.env.BLOCKCHAIN_PRIVATE_KEY;
 
-  try {
-    provider = new ethers.JsonRpcProvider(PROVIDER_URL);
-    wallet = new ethers.Wallet(PRIVATE_KEY, provider);
-    contract = new ethers.Contract(CONTRACT_ADDRESS, contractABI, wallet);
-    logger.info("✓ Worker blockchain connection initialized");
-    return true;
-  } catch (error) {
-    logger.error("[Worker] Failed to initialize blockchain:", {
-      error: error.message,
-    });
-    return false;
-  }
+    if (
+      !providerUrl ||
+      !contractAddress ||
+      (!privateKey && !process.env.ORACLE_KEYSTORE_PATH)
+    ) {
+      logger.warn(
+        "[Worker] Blockchain not configured - running in simulation mode",
+      );
+      return false;
+    }
+
+    try {
+      provider = new ethers.JsonRpcProvider(providerUrl);
+      wallet =
+        (await loadWallet(provider, "oracle").catch(() => null)) ||
+        (privateKey ? new ethers.Wallet(privateKey, provider) : null);
+
+      if (!wallet) {
+        logger.warn(
+          "[Worker] Blockchain wallet could not be loaded - running in simulation mode",
+        );
+        return false;
+      }
+
+      contract = new ethers.Contract(contractAddress, contractABI, wallet);
+      logger.info("✓ Worker blockchain connection initialized");
+      return true;
+    } catch (error) {
+      logger.error("[Worker] Failed to initialize blockchain:", {
+        error: error.message,
+      });
+      return false;
+    }
+  })();
+
+  return initPromise;
 }
 
 /**

--- a/backend/tests/blockchainWorkerInit.test.js
+++ b/backend/tests/blockchainWorkerInit.test.js
@@ -1,0 +1,21 @@
+const { initializeBlockchain } = require('../services/blockchainWorker');
+
+describe('Blockchain Worker Initialization', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+    });
+
+    it('returns false and enables simulation mode without throwing ReferenceError when env vars are missing', async () => {
+        delete process.env.PROVIDER_URL;
+        delete process.env.INFURA_URL;
+        delete process.env.SEPOLIA_URL;
+        delete process.env.CONTRACT_ADDRESS;
+        delete process.env.PRIVATE_KEY;
+        delete process.env.ETH_PRIVATE_KEY;
+
+        const isConfigured = await initializeBlockchain();
+        expect(isConfigured).toBe(false);
+    });
+});


### PR DESCRIPTION
### Summary
Fixed `ReferenceError` during blockchain worker initialization by resolving environment variables (`providerUrl`, `contractAddress`, `privateKey`) safely with fallback support and keystore loading.

### Changes Made
- Declared and resolved `providerUrl`, `contractAddress`, and `privateKey` in `initializeBlockchain()` in `backend/services/blockchainWorker.js`.
- Added support for `ETH_PRIVATE_KEY` / `BLOCKCHAIN_PRIVATE_KEY` fallbacks and keystore wallet loading.
- Memoized async `initPromise` to prevent initialization race conditions.
- Added unit test in `backend/tests/blockchainWorkerInit.test.js`.

### Fixes
Fixes #982
