### PR TITLE
fix(ci): restore malformed workflow jobs for Issue #932

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,9 @@ jobs:
   docker-security-scan:
     name: Trivy Scan (${{ matrix.service.name }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,6 @@ jobs:
   # Job 6: ML Service Tests
   ml-service-tests:
     name: ML Service Tests
-  # Job 6: Mobile Tests
-  mobile-tests:
-    name: Mobile Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -209,6 +206,20 @@ jobs:
       - name: Install ML dependencies
         working-directory: ml-service/
         run: pip install -r requirements.txt
+
+      - name: Validate ML Service
+        working-directory: ml-service/
+        run: python -m py_compile app.py train.py
+
+  # Job 7: Mobile Tests
+  mobile-tests:
+    name: Mobile Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -224,19 +235,73 @@ jobs:
         working-directory: mobile/
         run: npm run test:ci
 
-  # Job 7: Docker Security Scan
-  # Job 6: Terraform Validation
+  # Job 8: Terraform Validation
   terraform-checks:
     name: Terraform Format and Validate
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: infrastructure/
-  # Job 6: Docker Security Scan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+  # Job 9: Docker Security Scan
   docker-security-scan:
     name: Trivy Scan (${{ matrix.service.name }})
     runs-on: ubuntu-latest
-  # Job 8: Publish Docker Images
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - name: backend
+            context: backend/
+            dockerfile: backend/Dockerfile.dev
+          - name: frontend
+            context: frontend/
+            dockerfile: frontend/Dockerfile.dev
+          - name: ml-service
+            context: ml-service/
+            dockerfile: ml-service/Dockerfile
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Image
+        run: docker build -t cropchain/${{ matrix.service.name }}:latest -f ${{ matrix.service.dockerfile }} ${{ matrix.service.context }}
+
+      - name: Run Trivy Vulnerability Scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'cropchain/${{ matrix.service.name }}:latest'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: ${{ matrix.service.name }}
+
+  # Job 10: Publish Docker Images
   docker-publish:
     name: Publish Docker Images to GHCR
     runs-on: ubuntu-latest
@@ -259,47 +324,11 @@ jobs:
           - name: ml-service
             context: ml-service/
             dockerfile: ml-service/Dockerfile
-  # Job 9: SBOM Generation
-  sbom-generation:
-    name: Generate Software Bill of Materials (SBOM)
-  # Job 10: ML Service Checks
-  ml-service-checks:
-    name: ML Service Checks
-    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform Format
-        run: terraform fmt -check
-
-      - name: Terraform Init
-        run: terraform init -backend=false
-
-      - name: Terraform Validate
-        run: terraform validate
-      - name: Build Image
-        run: docker build -t cropchain/${{ matrix.service.name }}:latest -f ${{ matrix.service.dockerfile }} ${{ matrix.service.context }}
-
-      - name: Run Trivy Vulnerability Scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'cropchain/${{ matrix.service.name }}:latest'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '1'
-
-      - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: ${{ matrix.service.name }}
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -326,27 +355,24 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  # Job 11: SBOM Generation
+  sbom-generation:
+    name: Generate Software Bill of Materials (SBOM)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Generate SBOM (SPDX)
         uses: anchore/sbom-action@v0
         with:
           path: .
           format: spdx-json
           artifact-name: cropchain-sbom.spdx.json
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-          cache: "pip"
 
-      - name: Install dependencies
-        working-directory: ml-service/
-        run: pip install -r requirements.txt
-
-      - name: Validate ML Service
-        working-directory: ml-service/
-        run: python -m py_compile app.py train.py
-
-  # Job 11: Docker Validation
+  # Job 12: Docker Validation
   docker-validation:
     name: Docker Validation
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && hashFiles('trivy-results.sarif') != ''
         with:
           sarif_file: 'trivy-results.sarif'
           category: ${{ matrix.service.name }}


### PR DESCRIPTION
## Summary

This PR supersedes the previously reverted PR #949. It restores the malformed GitHub Actions workflow jobs for Issue #932 and includes the applicable review feedback by explicitly granting the security-events: write permission required for SARIF uploads.

## Changes

- **docker-security-scan job:** Added explicit permissions block with contents: read and security-events: write to enable the upload-sarif@v3 step to function correctly.

## Copilot Review Feedback

Other Copilot suggestions were evaluated but intentionally left unchanged because they are pre-existing improvements outside the scope of Issue #932:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Python 3.10 vs 3.11 mismatch | Out of scope | Pre-existing version discrepancy; CI only runs py_compile, not runtime tests |
| Use epository_owner instead of epository | Out of scope | GHCR normalizes case; current naming works correctly |
| Pin 	rivy-action to SHA/release | Out of scope | Best practice, not a fix for malformed workflow structure |