### PR TITLE
ci: add docker image publishing and cosign keyless signing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,72 @@
+name: Docker Publish and Sign
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build, Push, and Sign Docker Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # Required for keyless signing with Cosign
+
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [backend, frontend, ml-service]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+        with:
+          cosign-release: 'v2.2.4'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-${{ matrix.service }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.service }}
+          file: ./${{ matrix.service }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Sign the published Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}


### PR DESCRIPTION
## 📌 Overview
This PR introduces **Docker image signing using Cosign** to improve the integrity and authenticity of published container images. By digitally signing images as part of the CI/CD pipeline using GitHub OIDC keyless signing, users and deployment platforms can verify that images originate from trusted sources and have not been tampered with.

## 🛠️ Type of Change

- [ ] ⛓️ **Smart Contract** (Solidity changes, Gas optimization)
- [ ] 💻 **Frontend** (UI/UX, React components, Tailwind)
- [ ] ⚙️ **Backend** (API routes, MongoDB schemas, Middleware)
- [ ] 📄 **Documentation** (README, Roadmap updates)
- [x] 🧪 **Testing** (CI/CD Pipeline, Security)

---

## 🔗 Related Issue

Closes #1192 

---

## 🧪 Testing & Verification

- [ ] **Smart Contracts:** `npx hardhat test` passed? NA
- [ ] **Frontend:** Verified on Mobile/Desktop responsiveness? NA
- [ ] **Integration:** Verified `ethers.js` connectivity with local/testnet node? NA

---

## 📸 Screenshots / Demos

N/A (Security/CI change)

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
* Added `.github/workflows/docker-publish.yml` to automatically build, push, and sign Docker images.
* Configured a build matrix to process `backend`, `frontend`, and `ml-service` independently.
* Utilized `sigstore/cosign-installer` to inject Cosign into the runner environment.
* Configured keyless signing via GitHub OIDC (`id-token: write` permission) to eliminate key management overhead.
* The workflow triggers on the creation of new version tags (e.g., `v1.0.0`).
