### PR TITLE
fix: update HTML lang attribute to reflect i18n locale changes

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Providers } from "./providers";
 import Header from "../components/Header";
 import AIChatbot from "../components/AIChatbot";
 import OfflineIndicator from "../components/OfflineIndicator";
+import { LanguageProvider } from "../components/LanguageProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -42,15 +43,17 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col">
-        <Providers>
-          <div className="min-h-screen bg-gradient-to-br from-green-50/40 to-blue-50/40 dark:from-black dark:to-black text-foreground transition-colors duration-200">
-            <OfflineIndicator />
-            <Header />
-            <main className="container mx-auto px-4 py-8">{children}</main>
-            <BackToTop />
-            <AIChatbot />
-          </div>
-        </Providers>
+        <LanguageProvider>
+          <Providers>
+            <div className="min-h-screen bg-gradient-to-br from-green-50/40 to-blue-50/40 dark:from-black dark:to-black text-foreground transition-colors duration-200">
+              <OfflineIndicator />
+              <Header />
+              <main className="container mx-auto px-4 py-8">{children}</main>
+              <BackToTop />
+              <AIChatbot />
+            </div>
+          </Providers>
+        </LanguageProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/LanguageProvider.tsx
+++ b/frontend/src/components/LanguageProvider.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [lang, setLang] = useState<string>("en");
+  const { i18n } = useTranslation();
+
+  useEffect(() => {
+    // Get initial language from i18n
+    const currentLang = i18n.resolvedLanguage || i18n.language || "en";
+    setLang(currentLang);
+
+    // Update the html lang attribute when language changes
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = currentLang;
+    }
+
+    // Listen for language changes
+    const handleLanguageChange = (lng: string) => {
+      setLang(lng);
+      if (typeof document !== "undefined") {
+        document.documentElement.lang = lng;
+      }
+    };
+
+    i18n.on("languageChanged", handleLanguageChange);
+
+    return () => {
+      i18n.off("languageChanged", handleLanguageChange);
+    };
+  }, [i18n]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary

This PR fixes the HTML `lang` attribute to dynamically update when users switch between languages using the i18n language switcher.

## Related Issue

🔗 **Issue #1132** - [HTML lang attribute stays en when user switches to Hindi or Marathi via i18n](https://github.com/Nitya-003/CropChain/issues/1132)

Fixes #1132

## Bug Description

`frontend/src/app/layout.tsx` hardcoded `<html lang="en">` even though the application supports English (`en`), Hindi (`hi`), and Marathi (`mr`) through i18next.

When the user changes the application language, the HTML `lang` attribute was not updated, causing:
- Incorrect screen reader pronunciation
- Broken browser language detection
- WCAG 3.1.1 (Language of Page) non-compliance
- Poor SEO for non-English content

## Changes Made

### New File: `frontend/src/components/LanguageProvider.tsx`

A client component that:
1. Gets the initial language from i18n configuration
2. Updates `document.documentElement.lang` when the language changes
3. Listens for `languageChanged` events to keep the attribute in sync

### Modified: `frontend/src/app/layout.tsx`

Wrapped the app content with the `LanguageProvider` component to enable dynamic language attribute updates.

## Before vs After

### Before
- User switches to Hindi
- `<html>` remains `<html lang="en">` ❌
- Screen reader uses English pronunciation for Hindi content

### After
- User switches to Hindi
- `<html>` updates to `<html lang="hi">` ✅
- Screen reader uses Hindi pronunciation for Hindi content

## Impact

- **Accessibility**: WCAG 3.1.1 compliance improved
- **Screen Readers**: Proper pronunciation of content in each language
- **Browser Features**: Correct language detection and translation prompts
- **SEO**: Search engines properly index content by language

## Testing

1. Launch the frontend application
2. Open browser DevTools
3. Inspect the `<html>` element - verify `lang="en"`
4. Change language to Hindi using the language switcher
5. Inspect `<html>` again - verify `lang="hi"`
6. Repeat for Marathi - verify `lang="mr"`

## Files Changed

- Added: `frontend/src/components/LanguageProvider.tsx`
- Modified: `frontend/src/app/layout.tsx`