### PR TITLE
fix(server): import ethers + blockchainService to fix dead blockchain init (#1238)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,8 @@ const blockchainQueue = require("./services/blockchainQueue");
 const blockchainWorker = require("./services/blockchainWorker");
 const notificationQueue = require("./jobs/queue");
 const notificationWorker = require("./jobs/worker");
+const { ethers } = require("ethers");
+const blockchainService = require("./services/blockchainService");
 
 setupErrorHandling();
 


### PR DESCRIPTION
`backend/server.js` constructed `new ethers.JsonRpcProvider`, `new ethers.Wallet`, and `new ethers.Contract(..., blockchainService.getContractABI(), ...)` but never `require(\ethers\)` or `require(\./services/blockchainService\)` in that file. When the env vars were set, a `ReferenceError: ethers is not defined` was thrown and swallowed by the surrounding `catch`, so the app logged "Failed to initialize blockchain connection" and continued with `contractInstance = null` while a real connection was never attempted.

Adds the missing `require(\ethers\)` and `require(\./services/blockchainService\)` so initialization actually runs.

Closes #1238

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._