### PR TITLE
fix(add-batch): mint per-batch IPFS CID instead of fixed placeholder (#1236)

### DIFF
--- a/frontend/src/app/add-batch/page.tsx
+++ b/frontend/src/app/add-batch/page.tsx
@@ -10,7 +10,12 @@ import { sanitizeObject } from "../../lib/sanitize";
 import { batchFormSchema } from "../../lib/schemas";
 import { InlineAlert } from "../../components/InlineAlert";
 import { ethers } from "ethers";
-import { getContract, getSigner, hasMetaMask } from "../../utils/web3";
+import {
+  getContract,
+  getSigner,
+  hasMetaMask,
+  uploadBatchMetadataToIPFS,
+} from "../../utils/web3";
 
 const AddBatchContent: React.FC = () => {
   const { t } = useTranslation();
@@ -135,10 +140,29 @@ const AddBatchContent: React.FC = () => {
                 id: "web3-sync",
               });
 
+              // Upload per-batch metadata to IPFS (replaces hardcoded CID)
+              const ipfsCID = await uploadBatchMetadataToIPFS({
+                batchId: batch.batchId,
+                farmerName: batch.farmerName,
+                farmerAddress: batch.farmerAddress,
+                cropType: batch.cropType,
+                quantity: batch.quantity,
+                harvestDate: batch.harvestDate,
+                origin: batch.origin,
+                certifications: batch.certifications,
+                description: batch.description,
+                createdAt: batch.createdAt,
+              });
+              if (!ipfsCID) {
+                throw new Error(
+                  "Failed to upload batch metadata to IPFS. Check Pinata credentials.",
+                );
+              }
+
               const tx = await contract.createBatch(
                 ethers.encodeBytes32String(batch.batchId),
                 ethers.encodeBytes32String(batch.cropType.toUpperCase()),
-                "QmYwAPJhy5n2aBhajbN7yXq3TqK6Lj5ee2ov3333333333", // 46-char valid IPFS CID
+                ipfsCID,
                 BigInt(batch.quantity),
                 batch.farmerName,
                 batch.origin,

--- a/frontend/src/utils/web3.ts
+++ b/frontend/src/utils/web3.ts
@@ -49,3 +49,55 @@ export const getContract = async (): Promise<ethers.Contract | null> => {
   if (!signer) return null;
   return new ethers.Contract(getContractAddress(), cropChainABI, signer);
 };
+
+/**
+ * Upload batch metadata to IPFS via Pinata and return a real per-batch CID.
+ * Falls back to null when Pinata credentials are absent so callers can
+ * decide whether to proceed with an empty CID rather than a fake one.
+ */
+export const uploadBatchMetadataToIPFS = async (
+  metadata: Record<string, unknown>,
+): Promise<string | null> => {
+  const apiKey =
+    typeof process !== "undefined" ? process.env.NEXT_PUBLIC_PINATA_API_KEY : undefined;
+  const secretKey =
+    typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_PINATA_SECRET_API_KEY
+      : undefined;
+
+  if (!apiKey || !secretKey) {
+    console.warn(
+      "IPFS upload skipped: Pinata credentials not configured. Set NEXT_PUBLIC_PINATA_API_KEY and NEXT_PUBLIC_PINATA_SECRET_API_KEY.",
+    );
+    return null;
+  }
+
+  try {
+    const res = await fetch(
+      "https://api.pinata.cloud/pinning/pinJSONToIPFS",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          pinata_api_key: apiKey,
+          pinata_secret_api_key: secretKey,
+        },
+        body: JSON.stringify({
+          pinataContent: metadata,
+          pinataMetadata: { name: `cropchain-batch-${metadata.batchId ?? "unknown"}` },
+        }),
+      },
+    );
+
+    if (!res.ok) {
+      console.error("IPFS upload failed:", res.status, await res.text());
+      return null;
+    }
+
+    const data = await res.json();
+    return data.IpfsHash ?? null;
+  } catch (err) {
+    console.error("IPFS upload error:", err);
+    return null;
+  }
+};


### PR DESCRIPTION
`frontend/src/app/add-batch/page.tsx` passed the literal CID `QmYwAPJhy5n2aBhajbN7yXq3TqK6Lj5ee2ov3333333333` to `contract.createBatch(...)` for every batch, so every on-chain provenance record stored an identical `ipfsCID`, destroying batch-specific provenance value.

Each batch is now minted with a per-batch IPFS descriptor derived from its own data, and the mint step fails loudly when no real CID is available rather than silently recording the placeholder.

Closes #1236

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._