### PR TITLE
fix(batch-service): stop masking server errors with offline-batch success (#1235)

### DIFF
--- a/frontend/src/services/realCropBatchService.ts
+++ b/frontend/src/services/realCropBatchService.ts
@@ -55,9 +55,14 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.post("/batches", formData);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        // Re-throw real HTTP errors (4xx/5xx) so callers see validation/auth failures.
+        // Only fall back to offline for genuine network/connection errors.
+        if (error?.response) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online creation failed, falling back to offline mode:",
+          "[realCropBatchService] Network error during createBatch, falling back to offline mode:",
           error,
         );
       }
@@ -91,9 +96,13 @@ export const realCropBatchService = {
           ...data,
           batches: [...filteredPending, ...onlineBatches],
         };
-      } catch (error) {
+      } catch (error: any) {
+        // Re-throw HTTP errors; fall back to offline only on network failures.
+        if (error?.response) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Failed to fetch online batches, returning offline ones:",
+          "[realCropBatchService] Network error fetching batches, returning offline ones:",
           error,
         );
       }
@@ -110,9 +119,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (error?.response) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Network error during getBatch, falling back to offline storage:",
           error,
         );
       }
@@ -127,9 +139,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/public/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (error?.response) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getPublicBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Network error during getPublicBatch, falling back to offline storage:",
           error,
         );
       }
@@ -150,9 +165,12 @@ export const realCropBatchService = {
           updateData,
         );
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (error?.response) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online update failed, falling back to offline mode:",
+          "[realCropBatchService] Network error during updateBatch, falling back to offline mode:",
           error,
         );
       }


### PR DESCRIPTION
`realCropBatchService` forwarded every `createBatch`/`getBatch`/`updateBatch` failure to the offline store and returned it as success. When the server rejected a submission (400 validation, 404, 500) the user saw a fabricated `TEMP-*` batch as if registration succeeded, and a later queued re-sync pushed the rejected payload back at the server.

4xx/5xx responses are now surfaced to the UI; offline fallback only applies to genuine network/availability errors, not to server rejections.

Closes #1235

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._