### PR TITLE
fix(rate-limit): stop bypass via spoofed forwarded host headers (#1230)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -24,6 +24,16 @@ connectDB();
 
 const app = express();
 
+// Trust proxy hops so req.ip reflects the real client IP behind a reverse proxy.
+// Configurable: set TRUST_PROXY to the number of proxies, a CIDR, or 'true'/'false'.
+// Default to 1 (one proxy hop) in production, false in test/dev.
+const trustProxySetting = process.env.TRUST_PROXY;
+if (trustProxySetting !== undefined) {
+  app.set("trust proxy", trustProxySetting === "true" ? true : trustProxySetting);
+} else if (process.env.NODE_ENV === "production") {
+  app.set("trust proxy", 1);
+}
+
 // ==================== MIDDLEWARE SETUP ====================
 setupMiddleware(app);
 

--- a/backend/middleware/abuseRateLimiter.js
+++ b/backend/middleware/abuseRateLimiter.js
@@ -7,14 +7,12 @@ const DEFAULT_WINDOW_MS =
   parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10) || 15 * 60 * 1000;
 
 const buildKeyGenerator = ({ useUserId }) => {
-  // If req.user exists and has an id, use it. Otherwise fall back to IP.
+  // req.ip respects the app's "trust proxy" setting, which validates the
+  // proxy hop count rather than trusting a client-supplied header verbatim.
+  // Reading req.headers["x-forwarded-for"] directly allowed any client to
+  // spoof a unique IP per request and bypass rate limiting entirely.
   return (req) => {
-    const ip = (
-      req.headers["x-forwarded-for"] ||
-      req.ip ||
-      req.connection?.remoteAddress ||
-      ""
-    ).toString();
+    const ip = (req.ip || req.connection?.remoteAddress || "").toString();
     const userId = req.user?.id || req.user?._id;
 
     if (useUserId && userId) {
@@ -48,12 +46,7 @@ const createAbuseAwareLimiter = ({
     standardHeaders: true,
     legacyHeaders: false,
     handler: (req, res /*, next, options */) => {
-      const ip = (
-        req.headers["x-forwarded-for"] ||
-        req.ip ||
-        req.connection?.remoteAddress ||
-        ""
-      ).toString();
+      const ip = (req.ip || req.connection?.remoteAddress || "").toString();
       const userId = req.user?.id || req.user?._id || null;
 
       // Audit logging (no sensitive details to client)


### PR DESCRIPTION
`createAbuseAwareLimiter` keyed the rate-limit bucket off `req.headers[x-forwarded-for]` while the app never called `app.set(trust proxy, ...)`. The header is wholly client-controlled, so each request with a fresh header value got a fresh bucket, nullifying auth/registration/verification rate limits.

- Configures `app.set(trust proxy, ...)` so Express derives the real client IP correctly.
- The limiter no longer trusts a raw client-supplied `X-Forwarded-For` for bucket keying.

Closes #1230

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._