### PR TITLE
fix(exporters): neutralize CSV formula injection (#1300)

### DIFF
--- a/frontend/src/utils/exporters.test.ts
+++ b/frontend/src/utils/exporters.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { generateBatchCSVString, sanitizeCsvCell } from "./exporters";
+import type { ExportableBatch } from "./exporters";
+
+describe("sanitizeCsvCell (CWE-1236 formula injection)", () => {
+  it("prefixes values that start with formula trigger characters", () => {
+    expect(sanitizeCsvCell("=HYPERLINK(\"http://bad.test\",\"Click\")")).toBe(
+      "'=HYPERLINK(\"http://bad.test\",\"Click\")",
+    );
+    expect(sanitizeCsvCell("+1+1")).toBe("'+1+1");
+    expect(sanitizeCsvCell("-2+3")).toBe("'-2+3");
+    expect(sanitizeCsvCell("@SUM(A1:A2)")).toBe("'@SUM(A1:A2)");
+  });
+
+  it("prefixes tab- and carriage-return-prefixed values", () => {
+    expect(sanitizeCsvCell("\tcmd")).toBe("'\tcmd");
+    expect(sanitizeCsvCell("\rcmd")).toBe("'\rcmd");
+  });
+
+  it("leaves benign values untouched", () => {
+    expect(sanitizeCsvCell("Wheat")).toBe("Wheat");
+    expect(sanitizeCsvCell("Batch #123")).toBe("Batch #123");
+    expect(sanitizeCsvCell("1,000 kg")).toBe("1,000 kg");
+  });
+
+  it("coerces non-strings and handles nullish", () => {
+    expect(sanitizeCsvCell(42)).toBe("42");
+    expect(sanitizeCsvCell(0)).toBe("0");
+    expect(sanitizeCsvCell(null)).toBe("");
+    expect(sanitizeCsvCell(undefined)).toBe("");
+  });
+
+  it("does not false-positive on a value that merely contains a trigger char mid-string", () => {
+    expect(sanitizeCsvCell("a=b")).toBe("a=b");
+    expect(sanitizeCsvCell("hello @user")).toBe("hello @user");
+  });
+});
+
+describe("generateBatchCSVString", () => {
+  const baseBatch: ExportableBatch = {
+    batchId: "BATCH-1",
+    cropType: "Wheat",
+    farmerName: "Jane Farmer",
+    farmerAddress: "1 Farm Lane",
+    origin: "Pune",
+    quantity: 100,
+    harvestDate: "2026-01-01",
+    status: "Harvested",
+    currentStage: "Storage",
+    certifications: "Organic",
+    description: "Premium wheat",
+    updates: [
+      {
+        timestamp: "2026-01-02T10:00:00Z",
+        stage: "Transport",
+        location: "Mumbai",
+        actor: "Driver X",
+        txHash: "0xabc",
+        notes: "Refrigerated",
+      },
+    ],
+  };
+
+  it("escapes embedded quotes and preserves a normal batch round-trip", () => {
+    const csv = generateBatchCSVString({
+      ...baseBatch,
+      farmerName: 'Jane "Farmer"',
+    });
+    expect(csv).toContain('"Jane ""Farmer"""');
+    expect(csv).toContain('"BATCH-1","Wheat"');
+  });
+
+  it("neutralizes a formula payload in every user-controlled cell", () => {
+    const csv = generateBatchCSVString({
+      ...baseBatch,
+      cropType: '=HYPERLINK("http://bad.test","Click")',
+      farmerName: "+Inject",
+      description: "@SUM(A1)",
+      updates: [
+        {
+          timestamp: "2026-01-02T10:00:00Z",
+          stage: "=cmd|'/c calc'!A1",
+          location: "-2+3",
+          actor: "\tbad",
+          notes: "@evil",
+        },
+      ],
+    });
+
+    // No cell may start (after the opening quote) with a trigger character.
+    // i.e. the char immediately following each opening `"` must not be = + - @ \t \r
+    // unless it is the single-quote sanitizer prefix.
+    const cellPattern = /"(=|\+|-|@|\t|\r)/g;
+    expect(csv).not.toMatch(cellPattern);
+
+    // Sanitizer prefix is present for the affected values.
+    expect(csv).toContain("'=HYPERLINK");
+    expect(csv).toContain("'+Inject");
+    expect(csv).toContain("'@SUM(A1)");
+    expect(csv).toContain("'=cmd|'/c calc'!A1");
+    expect(csv).toContain("'-2+3");
+    expect(csv).toContain("'\tbad");
+    expect(csv).toContain("'@evil");
+  });
+
+  it("does not mangle numeric quantity/temperature/humidity fields", () => {
+    const csv = generateBatchCSVString({
+      ...baseBatch,
+      quantity: 0,
+      updates: [{ temperature: 0, humidity: 0 }],
+    });
+    expect(csv).toContain('"0"');
+  });
+});

--- a/frontend/src/utils/exporters.ts
+++ b/frontend/src/utils/exporters.ts
@@ -30,6 +30,38 @@ export interface ExportableBatch {
 }
 
 /**
+ * Neutralizes CSV formula injection (CWE-1236).
+ *
+ * Spreadsheet apps (Excel, Google Sheets, LibreOffice) treat a cell whose
+ * value begins with `=`, `+`, `-`, `@`, a tab, or a carriage return as a
+ * formula and may execute it when the CSV is opened. Prefixing such values
+ * with a single quote forces them to be interpreted as literal text; the
+ * leading quote is silently stripped by the spreadsheet on display.
+ *
+ * This runs before quote/escaping so the sanitizer sees the raw value.
+ */
+function sanitizeCsvCell(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  const str = typeof value === "string" ? value : String(value);
+  if (/^[=+\-@\t\r]/.test(str)) {
+    return `'${str}`;
+  }
+  return str;
+}
+
+/**
+ * Quotes and escapes a single CSV cell value, applying formula-injection
+ * protection first. Static headers are not user-controlled and are passed
+ * through unchanged by callers.
+ */
+function csvCell(value: unknown): string {
+  const sanitized = sanitizeCsvCell(value);
+  // Escape embedded double quotes and wrap in quotes so commas/newlines in the
+  // value cannot break out of the cell.
+  return `"${sanitized.replace(/"/g, '""')}"`;
+}
+
+/**
  * Generates and triggers download of a CSV supply chain data file
  */
 export function generateBatchCSVString(batch: ExportableBatch): string {
@@ -49,17 +81,17 @@ export function generateBatchCSVString(batch: ExportableBatch): string {
 
   const id = batch.batchId || batch.id || "N/A";
   const row = [
-    `"${id}"`,
-    `"${batch.cropType || ""}"`,
-    `"${batch.farmerName || ""}"`,
-    `"${batch.farmerAddress || ""}"`,
-    `"${batch.origin || ""}"`,
-    `"${batch.quantity || ""}"`,
-    `"${batch.harvestDate || ""}"`,
-    `"${batch.status || ""}"`,
-    `"${batch.currentStage || ""}"`,
-    `"${batch.certifications || ""}"`,
-    `"${batch.description || ""}"`,
+    csvCell(id),
+    csvCell(batch.cropType),
+    csvCell(batch.farmerName),
+    csvCell(batch.farmerAddress),
+    csvCell(batch.origin),
+    csvCell(batch.quantity || ""),
+    csvCell(batch.harvestDate),
+    csvCell(batch.status),
+    csvCell(batch.currentStage),
+    csvCell(batch.certifications),
+    csvCell(batch.description),
   ];
 
   let csvContent = headers.join(",") + "\n" + row.join(",") + "\n\n";
@@ -70,14 +102,14 @@ export function generateBatchCSVString(batch: ExportableBatch): string {
   if (batch.updates && batch.updates.length > 0) {
     batch.updates.forEach((update) => {
       const updateRow = [
-        `"${update.timestamp ? new Date(update.timestamp).toLocaleString() : ""}"`,
-        `"${update.stage || ""}"`,
-        `"${update.location || ""}"`,
-        `"${update.updatedBy || update.actor || ""}"`,
-        `"${update.temperature !== undefined ? update.temperature : ""}"`,
-        `"${update.humidity !== undefined ? update.humidity : ""}"`,
-        `"${update.txHash || ""}"`,
-        `"${update.notes || ""}"`,
+        csvCell(update.timestamp ? new Date(update.timestamp).toLocaleString() : ""),
+        csvCell(update.stage || ""),
+        csvCell(update.location || ""),
+        csvCell(update.updatedBy || update.actor || ""),
+        csvCell(update.temperature !== undefined ? update.temperature : ""),
+        csvCell(update.humidity !== undefined ? update.humidity : ""),
+        csvCell(update.txHash || ""),
+        csvCell(update.notes || ""),
       ];
       csvContent += updateRow.join(",") + "\n";
     });
@@ -87,6 +119,8 @@ export function generateBatchCSVString(batch: ExportableBatch): string {
 
   return csvContent;
 }
+
+export { sanitizeCsvCell };
 
 export function exportBatchToCSV(batch: ExportableBatch): void {
   const csvContent = generateBatchCSVString(batch);


### PR DESCRIPTION
## Summary

The supply-chain CSV export escaped commas and quotes but did not protect cells whose values start with a spreadsheet formula trigger character (`=`, `+`, `-`, `@`, tab, or CR). A malicious or accidental field value such as a crop type, farmer name, or stage note of `=HYPERLINK("http://bad.test","Click")` would be executed as a formula when the exported CSV was opened in Excel / Google Sheets / LibreOffice (CWE-1236 — CSV formula injection). This PR adds formula-injection protection to the CSV export path.

## Problem

`generateBatchCSVString` in `frontend/src/utils/exporters.ts` built each cell by hand as `"${value}"` with only quote-escaping. It never inspected the *first character* of the value. Spreadsheet applications treat a leading `=`, `+`, `-`, `@`, tab, or carriage return as the start of a formula, so any user-controlled field that began with one of those characters would be evaluated on open rather than displayed as text. Every user-controlled cell in the export was affected: batch fields (`cropType`, `farmerName`, `farmerAddress`, `origin`, `quantity`, `harvestDate`, `status`, `currentStage`, `certifications`, `description`) and every supply-chain timeline field (`stage`, `location`, `actor`, `temperature`, `humidity`, `txHash`, `notes`).

## Fix

Introduce a `sanitizeCsvCell(value)` guard that detects values beginning with a formula trigger character and prefixes them with a single quote (`'`). Spreadsheets treat a leading single quote as the literal-text marker and silently strip it on display, so the value renders identically to the user but can never be executed as a formula. `sanitizeCsvCell` is wrapped by a shared `csvCell(value)` helper that also performs the existing quote/escaping, and every dynamic cell in `generateBatchCSVString` now goes through `csvCell` instead of being quoted by hand. Static header strings are not user-controlled and are unchanged.

Behaviour preserved:
- Quote-escaping still doubles embedded `"` (`Jane "Farmer"` → `"Jane ""Farmer"""`).
- `null`/`undefined` cells render as empty, numbers are coerced normally (`0` is kept, not dropped).
- Values that merely *contain* `=`/`@` mid-string (e.g. `a=b`, `hello @user`) are not affected — only values that *start* with a trigger character are neutralized.

## Verification

- Added `frontend/src/utils/exporters.test.ts` with 8 tests: trigger-character prefixing for `= + - @ \t \r`, benign-value pass-through, nullish/number coercion, mid-string non-triggering, embedded-quote escaping round-trip, and a payload test that asserts no cell in the generated CSV begins (after its opening quote) with a trigger character across every user-controlled field including the timeline.
- The pre-existing `frontend/src/test/exporters.test.ts` (3 tests) still passes.
- `npx vitest run src/utils/exporters.test.ts` → **8/8 passing**.

## Note on the issue's referenced paths

The issue lists `apps/web/src/lib/comparisonExport.ts` and `apps/web/tests/compare-pricing.test.tsx`, which do not exist in this repository (the frontend lives under `frontend/`, not `apps/web/`, and the compare page itself has no CSV export). The actual CSV export utility is `frontend/src/utils/exporters.ts` (used by the batch journey export), and that is the path fixed here. The same sanitization pattern is applicable to any future CSV export added to the compare page.

## Changes

- `frontend/src/utils/exporters.ts` — add `sanitizeCsvCell` + `csvCell`, route every dynamic cell through `csvCell`, export `sanitizeCsvCell`.
- `frontend/src/utils/exporters.test.ts` — new regression tests (8 tests).

Closes #1300
