### PR TITLE
fix(auth): revoke JWT access tokens on logout via jti blacklist (#1290)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,6 +9,7 @@ const apiResponse = require('../utils/apiResponse');
 const { verifyMessage } = require('ethers');
 const { VALID_ROLES, ROLES } = require('../constants/permissions');
 const logger = require('../utils/logger');
+const { revokeToken } = require('../services/tokenBlacklist');
 require('dotenv').config();
 const Redis = require('ioredis');
 const { toNumber, toDecimal, fromDecimal } = require('../utils/decimalHelpers');
@@ -734,7 +735,16 @@ const refreshSession = async (req, res) => {
   }
 };
 
-const logoutUser = (req, res) => {
+const logoutUser = async (req, res) => {
+  // Revoke the specific access token so it cannot be reused after logout.
+  // `req.jwt` is attached by the `protect` middleware after signature verify.
+  try {
+    if (req.jwt) {
+      await revokeToken(req.jwt);
+    }
+  } catch (err) {
+    logger.error('Failed to revoke token on logout', { error: err.message });
+  }
   clearRefreshCookie(res);
   return res.json(apiResponse.successResponse(null, "Logout successful"));
 };
@@ -750,6 +760,16 @@ const deleteAccount = async (req, res) => {
         }
 
         await User.findByIdAndDelete(req.user._id);
+
+        // Revoke the caller's current access token so a captured token cannot
+        // be reused after the issuing account is deleted.
+        try {
+            if (req.jwt) {
+                await revokeToken(req.jwt);
+            }
+        } catch (err) {
+            logger.error('Failed to revoke token on account deletion', { error: err.message });
+        }
 
         clearRefreshCookie(res);
 

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -3,6 +3,7 @@ const User = require("../models/User");
 const Batch = require("../models/Batch");
 const { PERMISSIONS, ROLES, isAdminRole } = require("../constants/permissions");
 const RBACService = require("../services/rbacService");
+const { isRevoked } = require("../services/tokenBlacklist");
 const logger = require("../utils/logger");
 
 const protect = async (req, res, next) => {
@@ -22,6 +23,24 @@ const protect = async (req, res, next) => {
         .json({ error: "Not authorized", message: "Token is empty" });
 
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
+
+    // Reject tokens that have been explicitly revoked (logout / account
+    // deactivation). Tokens issued before this fix carry no `jti` and are
+    // skipped here, still subject to the tokenVersion check below.
+    if (decoded.jti && (await isRevoked(decoded))) {
+      logger.warn(`[AuthMiddleware] Revoked token used for user ${decoded.id} (jti: ${decoded.jti})`);
+      return res
+        .status(401)
+        .json({
+          error: "Not authorized",
+          message: "Token has been revoked. Please log in again.",
+        });
+    }
+
+    // Expose the decoded payload so downstream handlers (e.g. logout) can revoke
+    // this specific token without re-parsing the header.
+    req.jwt = decoded;
+
     const user = await User.findById(decoded.id).select("-password");
 
     if (!user)

--- a/backend/services/tokenBlacklist.js
+++ b/backend/services/tokenBlacklist.js
@@ -1,0 +1,152 @@
+/**
+ * JWT Revocation Blacklist (#1290)
+ *
+ * Access JWTs are stateless and remain cryptographically valid until natural
+ * expiry, so logout / account deletion / admin deactivation left captured
+ * tokens usable. This service maintains a revocation set keyed by the token's
+ * `jti` (JWT ID), with an automatic TTL equal to the token's remaining
+ * lifetime so entries self-expire and cannot grow unbounded.
+ *
+ * Storage strategy (graceful degradation):
+ *   1. Redis via the shared ioredis connection (`jwt_blacklist:<jti>`,
+ *      `PX` = remaining ms). Used in production where Redis is configured.
+ *   2. In-memory Map fallback when Redis is unavailable / not configured
+ *      (tests, local dev without Redis, or a Redis outage). Entries still
+ *      expire via a scheduled sweep.
+ *
+ * The blacklist is best-effort on top of the existing `tokenVersion` check in
+ * the auth middleware: `tokenVersion` invalidates *all* of a user's tokens
+ * after a password change / explicit version bump; the blacklist invalidates a
+ * *specific* token immediately on logout without disturbing other sessions.
+ */
+
+const crypto = require("crypto");
+const logger = require("../utils/logger");
+
+const BLACKLIST_PREFIX = "jwt_blacklist:";
+const SWEEP_INTERVAL_MS = 60_000;
+
+let redisConnection = null;
+let inMemoryBlacklist = new Map(); // jti -> expiryMs (Date.now())
+let sweepTimer = null;
+
+function getRedis() {
+  if (redisConnection) return redisConnection;
+  try {
+    // Lazy require to avoid a hard dependency at module load (e.g. tests that
+    // mock ioredis). If Redis is not configured, this returns null and we fall
+    // back to the in-memory store.
+    const { getRedisConnection } = require("../config/redis");
+    const conn = getRedisConnection();
+    redisConnection = conn || null;
+  } catch {
+    redisConnection = null;
+  }
+  return redisConnection;
+}
+
+function ensureSweep() {
+  if (sweepTimer) return;
+  const now = Date.now();
+  for (const [jti, exp] of inMemoryBlacklist) {
+    if (exp <= now) inMemoryBlacklist.delete(jti);
+  }
+  sweepTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [jti, exp] of inMemoryBlacklist) {
+      if (exp <= now) inMemoryBlacklist.delete(jti);
+    }
+  }, SWEEP_INTERVAL_MS);
+  if (sweepTimer.unref) sweepTimer.unref();
+}
+
+/**
+ * Remaining lifetime (ms) of a decoded JWT, floored to 0.
+ * @param {{ exp?: number }} decoded - decoded JWT payload
+ * @returns {number}
+ */
+function remainingTtlMs(decoded) {
+  if (!decoded || typeof decoded.exp !== "number") return 0;
+  return Math.max(0, decoded.exp * 1000 - Date.now());
+}
+
+/**
+ * Revoke a specific decoded JWT so it is rejected by the auth middleware
+ * until its natural expiry.
+ * @param {{ jti?: string, exp?: number }} decoded - decoded JWT payload
+ * @returns {Promise<boolean>} true if the token was revoked
+ */
+async function revokeToken(decoded) {
+  if (!decoded || !decoded.jti) return false;
+  const ttlMs = remainingTtlMs(decoded);
+  if (ttlMs <= 0) return false; // already expired, nothing to revoke
+
+  const key = BLACKLIST_PREFIX + decoded.jti;
+  const conn = getRedis();
+  if (conn) {
+    try {
+      await conn.set(key, "1", "PX", ttlMs);
+      return true;
+    } catch (err) {
+      logger.warn("[TokenBlacklist] Redis revoke failed, using in-memory fallback", {
+        error: err.message,
+      });
+    }
+  }
+  inMemoryBlacklist.set(decoded.jti, Date.now() + ttlMs);
+  ensureSweep();
+  return true;
+}
+
+/**
+ * Check whether a decoded JWT has been revoked.
+ * @param {{ jti?: string }} decoded - decoded JWT payload
+ * @returns {Promise<boolean>} true if revoked (must reject)
+ */
+async function isRevoked(decoded) {
+  if (!decoded || !decoded.jti) return false;
+  const conn = getRedis();
+  if (conn) {
+    try {
+      const result = await conn.get(BLACKLIST_PREFIX + decoded.jti);
+      return result != null;
+    } catch (err) {
+      logger.warn("[TokenBlacklist] Redis check failed, using in-memory fallback", {
+        error: err.message,
+      });
+    }
+  }
+  const exp = inMemoryBlacklist.get(decoded.jti);
+  if (exp == null) return false;
+  if (exp <= Date.now()) {
+    inMemoryBlacklist.delete(decoded.jti);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Generate a fresh, unique JWT ID (RFC 7519 `jti`).
+ * @returns {string}
+ */
+function generateJti() {
+  return crypto.randomUUID();
+}
+
+/** Test-only: clear the in-memory store and detach the sweep timer. */
+function __reset() {
+  inMemoryBlacklist = new Map();
+  if (sweepTimer) {
+    clearInterval(sweepTimer);
+    sweepTimer = null;
+  }
+}
+
+module.exports = {
+  revokeToken,
+  isRevoked,
+  generateJti,
+  remainingTtlMs,
+  BLACKLIST_PREFIX,
+  __reset,
+};

--- a/backend/tests/tokenBlacklist.test.js
+++ b/backend/tests/tokenBlacklist.test.js
@@ -1,0 +1,165 @@
+/**
+ * Regression tests for #1290: JWT access tokens must become invalid immediately
+ * on logout / account deletion via a revocation blacklist, rather than
+ * remaining valid until natural expiry.
+ */
+
+// Mock ioredis with a real in-memory map so the Redis code path is exercised
+// with persistence (set -> get round-trips correctly).
+let mockRedisClient;
+jest.mock("ioredis", () => {
+  const store = new Map();
+  mockRedisClient = {
+    get: jest.fn(async (k) => (store.has(k) ? store.get(k) : null)),
+    set: jest.fn(async (k, v) => { store.set(k, v); return "OK"; }),
+    del: jest.fn(async (k) => { store.delete(k); return 1; }),
+    on: jest.fn(),
+    quit: jest.fn().mockResolvedValue("OK"),
+    disconnect: jest.fn(),
+  };
+  return jest.fn(() => mockRedisClient);
+});
+
+jest.mock("../models/Batch", () => ({}));
+jest.mock("../services/rbacService", () => ({}));
+jest.mock("../models/User", () => ({ findById: jest.fn() }));
+
+const jwt = require("jsonwebtoken");
+const tokenBlacklist = require("../services/tokenBlacklist");
+const generateToken = require("../utils/generateToken");
+
+const SECRET = "test-jwt-secret-1290";
+
+beforeAll(() => {
+  process.env.JWT_SECRET = SECRET;
+  process.env.JWT_ACCESS_EXPIRES_IN = "1h";
+});
+
+afterEach(() => {
+  tokenBlacklist.__reset();
+  jest.clearAllMocks();
+});
+
+// Mongoose-style chainable mock: findById(...).select(...) is a thenable that
+// resolves to the user document. Installed once at module load so the same
+// module instances (tokenBlacklist, protect) are shared across tests.
+const User = require("../models/User");
+const user = {
+  _id: { toString: () => "u1" },
+  role: "farmer",
+  status: "active",
+  tokenVersion: 0,
+  toObject: () => ({
+    _id: "u1",
+    role: "farmer",
+    status: "active",
+    tokenVersion: 0,
+  }),
+};
+const chain = {
+  select: jest.fn(() => chain),
+  then: (resolve, reject) => Promise.resolve(user).then(resolve, reject),
+};
+User.findById.mockImplementation(() => chain);
+
+const { protect } = require("../middleware/auth");
+
+describe("tokenBlacklist (#1290)", () => {
+  it("generateToken emits a unique jti on every token", () => {
+    const d1 = jwt.verify(generateToken("user1", "farmer", "Name", 0), SECRET);
+    const d2 = jwt.verify(generateToken("user1", "farmer", "Name", 0), SECRET);
+    expect(d1.jti).toBeTruthy();
+    expect(d2.jti).toBeTruthy();
+    expect(d1.jti).not.toBe(d2.jti);
+  });
+
+  it("isRevoked returns false for a fresh, non-revoked token", async () => {
+    const decoded = jwt.verify(generateToken("u1", "farmer", "n", 0), SECRET);
+    expect(await tokenBlacklist.isRevoked(decoded)).toBe(false);
+  });
+
+  it("revokeToken then isRevoked returns true (Redis path)", async () => {
+    const decoded = jwt.verify(generateToken("u1", "farmer", "n", 0), SECRET);
+    expect(await tokenBlacklist.isRevoked(decoded)).toBe(false);
+    expect(await tokenBlacklist.revokeToken(decoded)).toBe(true);
+    expect(await tokenBlacklist.isRevoked(decoded)).toBe(true);
+    expect(mockRedisClient.set).toHaveBeenCalledWith(
+      tokenBlacklist.BLACKLIST_PREFIX + decoded.jti,
+      "1",
+      "PX",
+      expect.any(Number),
+    );
+  });
+
+  it("falls back to in-memory when Redis throws", async () => {
+    const decoded = jwt.verify(generateToken("u1", "farmer", "n", 0), SECRET);
+    mockRedisClient.set.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    mockRedisClient.get.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    expect(await tokenBlacklist.revokeToken(decoded)).toBe(true);
+    // in-memory path is used for both revoke and check when Redis fails
+    expect(await tokenBlacklist.isRevoked(decoded)).toBe(true);
+  });
+
+  it("revocation is token-specific: a different jti is unaffected", async () => {
+    const a = jwt.verify(generateToken("u1", "farmer", "n", 0), SECRET);
+    const b = jwt.verify(generateToken("u1", "farmer", "n", 0), SECRET);
+    await tokenBlacklist.revokeToken(a);
+    expect(await tokenBlacklist.isRevoked(a)).toBe(true);
+    expect(await tokenBlacklist.isRevoked(b)).toBe(false);
+  });
+
+  it("revokeToken is a no-op for a payload without jti (backwards compat)", async () => {
+    const noJti = jwt.sign({ id: "u1", tokenVersion: 0 }, SECRET, {
+      expiresIn: "1h",
+    });
+    const decoded = jwt.verify(noJti, SECRET);
+    expect(decoded.jti).toBeUndefined();
+    expect(await tokenBlacklist.revokeToken(decoded)).toBe(false);
+    expect(await tokenBlacklist.isRevoked(decoded)).toBe(false);
+  });
+
+  it("revokeToken is a no-op for an already-expired token", async () => {
+    const expired = jwt.sign({ id: "u1", jti: "x", exp: 1 }, SECRET);
+    const decoded = jwt.decode(expired);
+    expect(await tokenBlacklist.revokeToken(decoded)).toBe(false);
+  });
+});
+
+describe("auth middleware protect() revocation (#1290)", () => {
+  it("rejects a revoked token with 401 even though the signature is valid", async () => {
+    const token = generateToken("u1", "farmer", "n", 0);
+    const decoded = jwt.verify(token, SECRET);
+    await tokenBlacklist.revokeToken(decoded);
+
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await protect(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("revoked") }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("admits a valid, non-revoked token and attaches req.jwt (jti)", async () => {
+    const token = generateToken("u1", "farmer", "n", 0);
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await protect(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.jwt.jti).toBeTruthy();
+  });
+
+  it("legacy token without jti is not rejected by the blacklist", async () => {
+    const token = jwt.sign({ id: "u1", tokenVersion: 0 }, SECRET, {
+      expiresIn: "1h",
+    });
+    const req = { headers: { authorization: `Bearer ${token}` } };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    await protect(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/backend/utils/generateToken.js
+++ b/backend/utils/generateToken.js
@@ -1,8 +1,14 @@
 const jwt = require("jsonwebtoken");
 require("dotenv").config();
+const { generateJti } = require("../services/tokenBlacklist");
 
+/**
+ * Sign a short-lived access JWT. Includes a unique `jti` so an individual
+ * token can be revoked (e.g. on logout) via the JWT blacklist, and `iat`/`exp`
+ * are set by jsonwebtoken for blacklist TTL bookkeeping.
+ */
 const generateToken = (id, role, name, tokenVersion = 0) => {
-  return jwt.sign({ id, role, name, tokenVersion }, process.env.JWT_SECRET, {
+  return jwt.sign({ id, role, name, tokenVersion, jti: generateJti() }, process.env.JWT_SECRET, {
     expiresIn: process.env.JWT_ACCESS_EXPIRES_IN || "15m",
   });
 };


### PR DESCRIPTION
## Summary

Access JWTs are stateless: once signed they remain cryptographically valid until their natural expiry (the access token's `JWT_ACCESS_EXPIRES_IN`), regardless of what the user or an admin does afterwards. The auth middleware verified only the signature and `tokenVersion`, so logging out (`POST /api/auth/logout`) or deleting/deactivating the issuing account did **not** invalidate the access token — an attacker holding a captured `accessToken` could keep calling protected endpoints (batch creation, transfer approval) until the token expired on its own. This PR adds a per-token revocation blacklist keyed by the JWT `jti`, checked on every authenticated request, and writes to it on logout and account deletion.

## Problem (reproduction from the issue)

1. `POST /api/auth/login` → copy `accessToken`.
2. `GET /api/auth/me` with `Authorization: Bearer <accessToken>` → 200.
3. `POST /api/auth/logout`.
4. `GET /api/auth/me` again with the **same** old `accessToken` → still **200** (should be 401).

The previous `logoutUser` only cleared the refresh-token cookie and never revoked the access token, and `deleteAccount` deleted the user record without invalidating the caller's current access token. The middleware had no notion of an individually-revoked token — only the coarse `tokenVersion` check (which invalidates *all* of a user's tokens and is intended for password changes, not per-session logout).

## Fix

**1. Token blacklist service — `backend/services/tokenBlacklist.js` (new)**
- `revokeToken(decoded)`: writes `jwt_blacklist:<jti>` → `"1"` with `PX` set to the token's **remaining lifetime** (`exp - now`), so entries self-expire exactly when the token would have expired anyway — the set can never grow unbounded and requires no manual pruning.
- `isRevoked(decoded)`: returns whether a token's `jti` is currently on the blacklist.
- `generateJti()`: cryptographically unique JWT ID (`crypto.randomUUID()`).
- **Graceful degradation**: backed by Redis via the existing shared ioredis connection; if Redis is unavailable or a Redis call throws (outage, `ECONNREFUSED`), it transparently falls back to an in-memory `Map` with a scheduled expiry sweep, so the feature degrades safely and is testable without a live Redis.
- This is layered on top of the existing `tokenVersion` check: `tokenVersion` invalidates *all* of a user's tokens after a password change; the blacklist invalidates a *specific* token immediately on logout without disturbing other valid sessions.

**2. Issue tokens with a `jti` — `backend/utils/generateToken.js`**
- `generateToken()` now signs with a fresh `jti` on every call. `jsonwebtoken` already sets `iat`/`exp`, which the blacklist uses for TTL.

**3. Check the blacklist in the auth middleware — `backend/middleware/auth.js`**
- `protect()`: after `jwt.verify`, if the token carries a `jti` (post-fix tokens) and it is revoked, respond `401` with `"Token has been revoked. Please log in again."` and log a security warning (`[AuthMiddleware] Revoked token used for user ... (jti: ...)`). The decoded payload is attached as `req.jwt` so downstream handlers (logout, account deletion) can revoke the *specific* token without re-parsing the header.
- **Backwards compatible**: tokens issued before this fix carry no `jti` and are skipped by the blacklist — they remain subject to the existing `tokenVersion` check and expire on their own.

**4. Revoke on logout / account deletion — `backend/controllers/authController.js`**
- `logoutUser` (now `async`) calls `revokeToken(req.jwt)` before clearing the refresh cookie.
- `deleteAccount` calls `revokeToken(req.jwt)` after deleting the user record, so a captured token cannot be reused against the (now-deleted) account's resources.
- Both wrap the revocation in a `try/catch` so a Redis failure cannot prevent the logout/deletion response.

## Verification

- New `backend/tests/tokenBlacklist.test.js` — **10 tests, all passing**:
  - `generateToken` emits a unique `jti` on every token.
  - `isRevoked` is `false` for a fresh token.
  - `revokeToken` then `isRevoked` returns `true` (Redis path; asserts `set` is called with the `jwt_blacklist:` prefix and a `PX` TTL).
  - Falls back to the in-memory store when Redis `set`/`get` throws (`ECONNREFUSED`).
  - Revocation is **token-specific** — a different `jti` is unaffected (so multi-device sessions aren't all killed on one logout).
  - `revokeToken` is a no-op on a payload without `jti` (backwards compat) and on an already-expired token.
  - `protect()` rejects a revoked token with 401 even though the signature is valid; admits a valid non-revoked token and attaches `req.jwt.jti`; and does **not** reject a legacy (no-`jti`) token via the blacklist.
- Run output logs visibly show `[AuthMiddleware] Revoked token used for user u1 (jti: ...)` on the revoked-token request, matching the issue's expected security alert.
- No regression in the existing `tests/authController.test.js` (4/4 passing).
- `node --check` passes for all edited files.

## Behaviour preserved

- `jsonwebtoken` signature verification, `TokenExpiredError` / `JsonWebTokenError` handling, the `tokenVersion` check, the `status !== "active"` 403, and all RBAC middleware are unchanged.
- Refresh-token cookie clearing on logout is unchanged.
- Existing issued tokens (no `jti`) continue to work until natural expiry and are not falsely rejected.

## Changes

- `backend/services/tokenBlacklist.js` — new: revocation service (Redis + in-memory fallback, `jti` generator, TTL bookkeeping).
- `backend/utils/generateToken.js` — sign access tokens with `jti`.
- `backend/middleware/auth.js` — `protect()` checks the blacklist, attaches `req.jwt`.
- `backend/controllers/authController.js` — `logoutUser` and `deleteAccount` revoke the caller's token.
- `backend/tests/tokenBlacklist.test.js` — new regression tests (10 tests).

Closes #1290
