### PR TITLE
fix(verification): bound bulk CSV parse with a row cap to prevent OOM (#1310)

### DIFF
--- a/backend/controllers/verificationController.js
+++ b/backend/controllers/verificationController.js
@@ -723,13 +723,35 @@ const bulkIssueCredentials = async (req, res) => {
     const maxRowsPerJob =
       parseInt(process.env.MAX_BULK_ROWS_PER_JOB, 10) || 5000;
 
+    // Hard cap on the number of rows parseCSV will materialize, independent of
+    // MAX_BULK_ROWS_PER_JOB (which only bounds validated/accepted rows). This
+    // stops a maliciously large CSV (many short rows within the byte cap) from
+    // OOMing the process during parsing. See #1310.
+    const MAX_BULK_CSV_ROWS =
+      parseInt(process.env.MAX_BULK_CSV_ROWS, 10) || 100000;
+
     const {
       validateHeadersExact,
       safeHeaderKey,
     } = require("../utils/bulkCsvValidation");
 
-    // Strict parse + header validation.
-    const recordsRaw = bulkVerificationService.parseCSV(csvText);
+    // Strict parse + header validation. parseCSV throws BulkCsvRowLimitError
+    // (mapped to a 400 below) if the row count exceeds MAX_BULK_CSV_ROWS.
+    let recordsRaw;
+    try {
+      recordsRaw = bulkVerificationService.parseCSV(csvText, {
+        maxRows: MAX_BULK_CSV_ROWS,
+      });
+    } catch (parseErr) {
+      if (parseErr instanceof bulkVerificationService.BulkCsvRowLimitError) {
+        return res.status(400).json(
+          apiResponse.validationErrorResponse([
+            `CSV exceeds the maximum of ${MAX_BULK_CSV_ROWS} rows. Please split the file and retry.`,
+          ]),
+        );
+      }
+      throw parseErr;
+    }
     if (!Array.isArray(recordsRaw) || recordsRaw.length === 0) {
       return res
         .status(400)

--- a/backend/services/bulkVerificationService.js
+++ b/backend/services/bulkVerificationService.js
@@ -15,11 +15,25 @@ const {
 } = require("./verificationSecurityService");
 
 /**
+ * Error thrown when a bulk CSV exceeds the configured row cap during parsing.
+ * Surfaced as a 400 by the controller so a maliciously large file cannot OOM
+ * the process by forcing unbounded in-memory record accumulation. See #1310.
+ */
+class BulkCsvRowLimitError extends Error {
+  constructor(maxRows) {
+    super(`CSV row limit exceeded (max ${maxRows} data rows)`);
+    this.name = "BulkCsvRowLimitError";
+    this.code = "BULK_CSV_ROW_LIMIT_EXCEEDED";
+    this.maxRows = maxRows;
+  }
+}
+
+/**
  * Parses CSV text adhering to RFC-4180 standards (supporting quoted fields, escaped quotes, commas, and multiline values).
  * @param {string} csvText - Raw CSV content
  * @returns {Array<Object>} List of parsed objects mapped to lowercase headers
  */
-const parseCSV = (csvText) => {
+const parseCSV = (csvText, { maxRows } = {}) => {
   const lines = [];
   let currentLine = [];
   let currentField = "";
@@ -48,6 +62,9 @@ const parseCSV = (csvText) => {
         currentLine.length > 0 &&
         (currentLine.length > 1 || currentLine[0] !== "")
       ) {
+        if (maxRows != null && lines.length > maxRows) {
+          throw new BulkCsvRowLimitError(maxRows);
+        }
         lines.push(currentLine);
       }
       currentLine = [];
@@ -521,4 +538,5 @@ module.exports = {
   processJob,
   retryJob,
   reconstructRetryRecords,
+  BulkCsvRowLimitError,
 };

--- a/backend/tests/verificationBulkRowLimit.test.js
+++ b/backend/tests/verificationBulkRowLimit.test.js
@@ -1,0 +1,58 @@
+process.env.NODE_ENV = "test";
+
+const bulkVerificationService = require("../services/bulkVerificationService");
+
+const { parseCSV, BulkCsvRowLimitError } = bulkVerificationService;
+
+const VALID_HEADER = "userId,walletAddress,action\n";
+
+function row(n) {
+  return `user${n},0xabc123000000000000000000000000000000000${n},ISSUE_CREDENTIAL`;
+}
+
+describe("bulkVerificationService.parseCSV row-cap (#1310)", () => {
+  it("parses normally when row count is within the cap", () => {
+    const csv = VALID_HEADER + [row(1), row(2), row(3)].join("\n");
+    const records = parseCSV(csv, { maxRows: 100 });
+    expect(records).toHaveLength(3);
+    expect(records[0].userid).toBe("user1");
+  });
+
+  it("throws BulkCsvRowLimitError when rows exceed the cap (bounded, no OOM)", () => {
+    // Build a CSV with more data rows than the cap. Without the cap, parseCSV
+    // would materialize the entire array in memory (the #1310 DoS vector).
+    const tooMany = 51;
+    const csv =
+      VALID_HEADER +
+      Array.from({ length: tooMany }, (_, i) => row(i + 1)).join("\n");
+
+    expect(() => parseCSV(csv, { maxRows: 10 })).toThrow(BulkCsvRowLimitError);
+    expect(() => parseCSV(csv, { maxRows: 10 })).toThrow(/row limit exceeded/);
+  });
+
+  it("aborts early: does not accumulate the full row array before throwing", () => {
+    // A pathological CSV (header + 50_000 short rows) that would otherwise build
+    // a 50_000-element array. The cap must throw well before completion.
+    const big = VALID_HEADER + Array.from({ length: 50000 }, (_, i) => row(i + 1)).join("\n");
+    expect(() => parseCSV(big, { maxRows: 100 })).toThrow(BulkCsvRowLimitError);
+  });
+
+  it("does not enforce a cap when maxRows is omitted (backward compatible)", () => {
+    const csv = VALID_HEADER + [row(1), row(2)].join("\n");
+    const records = parseCSV(csv); // no options -> uncapped (legacy callers)
+    expect(records).toHaveLength(2);
+  });
+
+  it("BulkCsvRowLimitError carries a stable code and maxRows", () => {
+    try {
+      parseCSV(VALID_HEADER + Array.from({ length: 5 }, (_, i) => row(i + 1)).join("\n"), {
+        maxRows: 2,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BulkCsvRowLimitError);
+      expect(err.code).toBe("BULK_CSV_ROW_LIMIT_EXCEEDED");
+      expect(err.maxRows).toBe(2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`POST /api/verification/bulk/issue-credential` already defended against oversized uploads with a Multer byte cap (default 5MB) and per-admin + per-IP rate limiters (`bulkCsvJobAdminLimiter`, `bulkCsvJobIpLimiter` — 2 jobs/hour each). However, the CSV **parser** itself had no row bound: `bulkVerificationService.parseCSV` walked the entire uploaded string and materialized every row into an in-memory array before any downstream validation ran. A CSV that fits within the 5MB byte cap but contains a very large number of short rows (e.g. two million `id,addr,action` lines) therefore forced unbounded heap allocation and synchronous parsing on the event loop, producing the `ERR_OUT_OF_MEMORY` / Denial-of-Service condition described in the issue:

```
INFO [Verification]: Starting bulk CSV parse job...
<--- Last few GCs --->
[21450:0x04cf120] 32100 ms: Mark-sweep 2046.5 (2080.1) MB -> 2045.9 (2080.1) MB
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

This PR closes the gap by bounding the parser, not just the upload.

## Fix

**`backend/services/bulkVerificationService.js`**
- `parseCSV(csvText, { maxRows })` now accepts a row cap. As lines are parsed, once the accumulated line count would exceed `maxRows` it throws a typed `BulkCsvRowLimitError` (`code: "BULK_CSV_ROW_LIMIT_EXCEEDED"`) and **aborts early** — it does not continue accumulating the full row array. This is the "stream sanitization" the issue asks for: a bounded, fail-fast parse instead of an unbounded one.
- The check fires *during* parsing (inside the newline-handling branch where rows are pushed), so a pathological CSV throws long before it can exhaust memory.
- `BulkCsvRowLimitError` is exported so callers can distinguish it from generic parse failures.
- When `maxRows` is omitted the function behaves exactly as before — backward compatible with existing callers and the existing unit tests (`verificationBulk.test.js` parser tests still pass).

**`backend/controllers/verificationController.js`**
- `bulkIssueCredentials` now passes `MAX_BULK_CSV_ROWS` (env-configurable, default `100000`) into `parseCSV`.
- It wraps the parse call in a targeted `try/catch` that maps `BulkCsvRowLimitError` to a **400** with a clear message (`CSV exceeds the maximum of N rows. Please split the file and retry.`) rather than letting it fall through to the generic 500 / process-level crash path.
- This bound is independent of `MAX_BULK_ROWS_PER_JOB` (which caps *validated/accepted* rows after parsing) — it caps the parser itself, which is the DoS surface.

## Why this is the right layer

- The Multer byte cap (5MB) cannot, on its own, prevent the attack: 5MB of 12-byte rows is ~400k rows, and a higher byte cap (some deployments raise it) scales the row count linearly. A row cap is the direct bound on the memory/time of the parser.
- The per-IP/per-admin rate limiters already exist and are tight (2 jobs/hour). They reduce *frequency* but a single allowed job can still OOM the process — so the parser bound is necessary regardless of the rate limiters.
- Failing fast with a typed error and a 400 keeps the process alive and gives the admin client actionable feedback, instead of the `FATAL ERROR: Reached heap limit` process crash from the issue.

## Verification

- New `backend/tests/verificationBulkRowLimit.test.js` — **5 tests, all passing**:
  - `parses normally when row count is within the cap` — happy path unaffected.
  - `throws BulkCsvRowLimitError when rows exceed the cap (bounded, no OOM)` — a 51-row CSV with `maxRows: 10` throws the typed error with `/row limit exceeded/`.
  - `aborts early: does not accumulate the full row array before throwing` — a 50,000-row CSV with `maxRows: 100` throws instead of building the 50k-element array.
  - `does not enforce a cap when maxRows is omitted (backward compatible)` — legacy uncapped callers behave as before.
  - `BulkCsvRowLimitError carries a stable code and maxRows` — `code === "BULK_CSV_ROW_LIMIT_EXCEEDED"`, `maxRows` exposed.
- The existing `parseCSV` unit tests in `verificationBulk.test.js` (standard CSV, quoted fields, empty-line skipping) remain compatible — they call `parseCSV(csv)` with no options, which takes the uncapped backward-compatible path.

```
PASS tests/verificationBulkRowLimit.test.js
  bulkVerificationService.parseCSV row-cap (#1310)
    ✓ parses normally when row count is within the cap
    ✓ throws BulkCsvRowLimitError when rows exceed the cap (bounded, no OOM)
    ✓ aborts early: does not accumulate the full row array before throwing
    ✓ does not enforce a cap when maxRows is omitted (backward compatible)
    ✓ BulkCsvRowLimitError carries a stable code and maxRows
Tests: 5 passed
```

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `MAX_BULK_CSV_BYTES` | 5 MB | Multer upload size cap (existing) |
| `MAX_BULK_CSV_ROWS` | 100000 | New — max rows `parseCSV` will materialize before aborting |
| `MAX_BULK_ROWS_PER_JOB` | 5000 | Existing — cap on validated/accepted rows per job |
| `BULK_JOB_RATE_LIMIT_ADMIN_MAX` / `BULK_JOB_RATE_LIMIT_IP_MAX` | 2 / 2 per hour | Existing per-admin & per-IP rate limits |

## Changes

- `backend/services/bulkVerificationService.js` — `parseCSV` row cap + `BulkCsvRowLimitError`, exported.
- `backend/controllers/verificationController.js` — pass `MAX_BULK_CSV_ROWS` to `parseCSV`, map `BulkCsvRowLimitError` → 400.
- `backend/tests/verificationBulkRowLimit.test.js` — new regression tests (5 tests).

Closes #1310
