### PR TITLE
fix(compare): prevent CSV formula injection in batch export (#1300)

### DIFF
--- a/frontend/src/test/exporters.test.ts
+++ b/frontend/src/test/exporters.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   generateBatchCSVString,
   generateBatchPDFHTML,
+  sanitizeCsvCell,
   ExportableBatch,
 } from "../utils/exporters";
 
@@ -55,6 +56,90 @@ describe("PDF & CSV Exporters Utility Test Suite", () => {
       expect(csv).toContain('"farmer"');
       expect(csv).toContain('"Ludhiana Farm"');
       expect(csv).toContain('"mandi"');
+    });
+  });
+
+  describe("sanitizeCsvCell - CSV/Formula injection protection", () => {
+    it("prefixes values starting with = (HYPERLINK attack)", () => {
+      const payload = '=HYPERLINK("http://bad.test","Click")';
+      const cell = sanitizeCsvCell(payload);
+      // Leading = must be defanged with a leading single quote, never left bare.
+      expect(cell).toBe(`"'=HYPERLINK(""http://bad.test"",""Click"")"`);
+      expect(cell.startsWith(`"=`)).toBe(false);
+    });
+
+    it("prefixes values starting with + - @ and tab/CR", () => {
+      // Each value gets a leading single-quote prefix to neutralize the trigger char.
+      expect(sanitizeCsvCell("+1+1")).toBe(`"'+1+1"`);
+      expect(sanitizeCsvCell("-DDE")).toBe(`"'-DDE"`);
+      expect(sanitizeCsvCell("@SUM(A1:A2)")).toBe(`"'@SUM(A1:A2)"`);
+      expect(sanitizeCsvCell("\tignored")).toBe(`"'\tignored"`);
+      expect(sanitizeCsvCell("\rignored")).toBe(`"'\rignored"`);
+    });
+
+    it("leaves normal values untouched (only RFC 4180 quoting)", () => {
+      expect(sanitizeCsvCell("Rice")).toBe('"Rice"');
+      expect(sanitizeCsvCell("1200")).toBe('"1200"');
+    });
+
+    it("doubles embedded double-quotes per RFC 4180", () => {
+      expect(sanitizeCsvCell('He said "hi"')).toBe('"He said ""hi"""');
+    });
+
+    it("handles leading whitespace before a formula prefix", () => {
+      // Spreadsheet apps trim leading whitespace before evaluating a formula.
+      const cell = sanitizeCsvCell("   =cmd|...");
+      expect(cell).toBe(`"'   =cmd|..."`);
+      expect(cell.startsWith(`"=`)).toBe(false);
+    });
+
+    it("does NOT defang a value that merely contains = mid-string", () => {
+      // Only a leading formula-trigger char is dangerous.
+      expect(sanitizeCsvCell("a=b")).toBe('"a=b"');
+    });
+  });
+
+  describe("generateBatchCSVString - formula injection end-to-end", () => {
+    it("defangs a malicious brand/crop name in the exported CSV", () => {
+      const malicious: ExportableBatch = {
+        batchId: "BATCH-EVIL",
+        cropType: '=HYPERLINK("http://bad.test","Click")',
+        farmerName: "+SUM(A1:A2)",
+        origin: "@cmd|calc!A0",
+        quantity: 10,
+        harvestDate: "2026-01-01",
+        description: "Normal text",
+        updates: [
+          {
+            timestamp: "2026-01-01T00:00:00Z",
+            stage: "-DDE",
+            location: "loc",
+            notes: '=cmd|"/c calc"!A0',
+          },
+        ],
+      };
+      const csv = generateBatchCSVString(malicious);
+
+      // The defanged single-quote prefix must be present for each malicious value.
+      expect(csv).toContain(`"'=HYPERLINK`);
+      expect(csv).toContain(`"'+SUM`);
+      expect(csv).toContain(`"'@cmd`);
+      expect(csv).toContain(`"'=cmd`);
+
+      // No data cell may begin (after the opening quote) with a bare formula trigger.
+      const dataRows = csv
+        .split("\n")
+        .filter((l) => l.startsWith('"') && !l.startsWith('"---'));
+      dataRows.forEach((row) => {
+        const cells = row.match(/"(?:[^"]|"")*"/g) || [];
+        cells.forEach((c) => {
+          const inner = c.slice(1, -1).replace(/""/g, '"');
+          const trimmed = inner.trimStart();
+          if (trimmed.length) {
+            expect(["=", "+", "-", "@", "\t", "\r"]).not.toContain(trimmed[0]);
+          }
+        });
+      });
     });
   });
 

--- a/frontend/src/utils/exporters.ts
+++ b/frontend/src/utils/exporters.ts
@@ -29,6 +29,34 @@ export interface ExportableBatch {
   updates?: BatchTimelineUpdate[];
 }
 
+const FORMULA_TRIGGERS = ["=", "+", "-", "@", "\t", "\r", "\n"];
+
+/**
+ * Escapes a single CSV cell value.
+ *
+ * 1. Doubles embedded double-quotes per RFC 4180 and wraps the value in quotes.
+ * 2. Guards against CSV/Formula injection: if the cell starts with a character
+ *    that spreadsheet apps interpret as a formula (=, +, -, @) or a control
+ *    char (tab/CR/LF) — including when preceded only by whitespace — it is
+ *    prefixed with a single quote so Excel/Google Sheets/LibreOffice treat it
+ *    as plain text instead of executing it (e.g. `=HYPERLINK(...)`,
+ *    `=cmd|...`, `+1+1`, leading-tab tricks).
+ *
+ * Returns the quoted, ready-to-embed cell string.
+ */
+export function sanitizeCsvCell(value: string | number | undefined | null): string {
+  const raw = value === undefined || value === null ? "" : String(value);
+  // Detect a formula trigger either as the literal first char, or as the first
+  // non-whitespace char (spreadsheets ignore leading spaces before a formula).
+  const firstNonWs = raw.replace(/^\s+/, "")[0];
+  const isDangerous =
+    (raw.length > 0 && FORMULA_TRIGGERS.includes(raw[0])) ||
+    (firstNonWs !== undefined && FORMULA_TRIGGERS.includes(firstNonWs));
+  const safe = isDangerous ? `'${raw}` : raw;
+  // RFC 4180: wrap in quotes and double any embedded quotes.
+  return `"${safe.replace(/"/g, '""')}"`;
+}
+
 /**
  * Generates and triggers download of a CSV supply chain data file
  */
@@ -49,17 +77,17 @@ export function generateBatchCSVString(batch: ExportableBatch): string {
 
   const id = batch.batchId || batch.id || "N/A";
   const row = [
-    `"${id}"`,
-    `"${batch.cropType || ""}"`,
-    `"${batch.farmerName || ""}"`,
-    `"${batch.farmerAddress || ""}"`,
-    `"${batch.origin || ""}"`,
-    `"${batch.quantity || ""}"`,
-    `"${batch.harvestDate || ""}"`,
-    `"${batch.status || ""}"`,
-    `"${batch.currentStage || ""}"`,
-    `"${batch.certifications || ""}"`,
-    `"${batch.description || ""}"`,
+    sanitizeCsvCell(id),
+    sanitizeCsvCell(batch.cropType || ""),
+    sanitizeCsvCell(batch.farmerName || ""),
+    sanitizeCsvCell(batch.farmerAddress || ""),
+    sanitizeCsvCell(batch.origin || ""),
+    sanitizeCsvCell(batch.quantity || ""),
+    sanitizeCsvCell(batch.harvestDate || ""),
+    sanitizeCsvCell(batch.status || ""),
+    sanitizeCsvCell(batch.currentStage || ""),
+    sanitizeCsvCell(batch.certifications || ""),
+    sanitizeCsvCell(batch.description || ""),
   ];
 
   let csvContent = headers.join(",") + "\n" + row.join(",") + "\n\n";
@@ -70,14 +98,14 @@ export function generateBatchCSVString(batch: ExportableBatch): string {
   if (batch.updates && batch.updates.length > 0) {
     batch.updates.forEach((update) => {
       const updateRow = [
-        `"${update.timestamp ? new Date(update.timestamp).toLocaleString() : ""}"`,
-        `"${update.stage || ""}"`,
-        `"${update.location || ""}"`,
-        `"${update.updatedBy || update.actor || ""}"`,
-        `"${update.temperature !== undefined ? update.temperature : ""}"`,
-        `"${update.humidity !== undefined ? update.humidity : ""}"`,
-        `"${update.txHash || ""}"`,
-        `"${update.notes || ""}"`,
+        sanitizeCsvCell(update.timestamp ? new Date(update.timestamp).toLocaleString() : ""),
+        sanitizeCsvCell(update.stage || ""),
+        sanitizeCsvCell(update.location || ""),
+        sanitizeCsvCell(update.updatedBy || update.actor || ""),
+        sanitizeCsvCell(update.temperature !== undefined ? update.temperature : ""),
+        sanitizeCsvCell(update.humidity !== undefined ? update.humidity : ""),
+        sanitizeCsvCell(update.txHash || ""),
+        sanitizeCsvCell(update.notes || ""),
       ];
       csvContent += updateRow.join(",") + "\n";
     });


### PR DESCRIPTION
## What
Fixes #1300 — the compare/batch CSV export could execute spreadsheet formulas (CSV/Formula injection, CWE-1236).

## Why
`generateBatchCSVString` in `frontend/src/utils/exporters.ts` only quoted values (handling commas/quotes) but did not neutralize cells that start with formula-trigger characters. If a batch field (crop type, farmer name, notes, timeline values) begins with `=`, `+`, `-`, `@` or a control char (tab/CR/LF), spreadsheet apps like Excel/Google Sheets/LibreOffice may interpret the cell as a formula when the exported CSV is opened — e.g. `=HYPERLINK("http://bad.test","Click")` or `=cmd|...` payloads.

> Note: the issue references \`apps/web/src/lib/comparisonExport.ts\` and \`apps/web/tests/compare-pricing.test.tsx\`, but those paths do not exist in this repo. The actual vulnerable path used by the compare/batch export is \`frontend/src/utils/exporters.ts\` (\`generateBatchCSVString\`), so the fix is applied there.

## How
- Add a `sanitizeCsvCell(value)` helper to `frontend/src/utils/exporters.ts`:
  - RFC 4180 doubles embedded double-quotes and wraps the value in quotes.
  - Prefixes any cell whose first (or first non-whitespace) char is a formula trigger (`= + - @ \\t \\r \\n`) with a single quote so spreadsheet apps render it as plain text. Leading-whitespace detection is included because spreadsheets trim leading spaces before evaluating a formula.
- Apply `sanitizeCsvCell` to every metadata cell and every timeline cell in `generateBatchCSVString`.

## Tests
- Extend `frontend/src/test/exporters.test.ts` with:
  - `sanitizeCsvCell` unit tests: `=`/HYPERLINK, `+`/`-`/`@`/tab/CR, leading-whitespace, no false positives on mid-string `=` or normal text, quote-escaping.
  - An end-to-end formula-injection test on `generateBatchCSVString` asserting no data cell begins (after the opening quote) with a bare formula trigger.

\`\`\`
npx vitest run src/test/exporters.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)
\`\`\`

The pre-existing parse error in \`src/app/compare/page.tsx\` (on \`main\`, unrelated to this change) still blocks the sibling \`page.test.tsx\` suite from running; that is out of scope for this issue.

## Risk
Low. Change is localized to CSV cell sanitization in the batch export helper; normal text values pass through unchanged (only quoted per RFC 4180), which is also the correct CSV behavior.

---
_This pull request was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._