### PR TITLE
fix: align oracle getBatch ABI with CropBatch struct and restore 404 for missing batches (fixes #1326)

### DIFF
--- a/backend/config/blockchain.js
+++ b/backend/config/blockchain.js
@@ -12,7 +12,7 @@ const PRIVATE_KEY = process.env.PRIVATE_KEY;
 const contractABI = [
   "event BatchCreated(bytes32 indexed batchId, string ipfsCID, uint256 quantity, address indexed creator)",
   "event BatchUpdated(bytes32 indexed batchId, uint8 stage, string actorName, string location, address indexed updatedBy)",
-  "function getBatch(bytes32 batchId) view returns (tuple(bytes32 batchId, bytes32 cropTypeHash, string ipfsCID, uint256 quantity, uint256 createdAt, address creator, bool exists, bool isRecalled))",
+  "function getBatch(bytes32 batchId) view returns (tuple(bytes32 batchId, bytes32 cropTypeHash, string ipfsCID, uint256 quantity, uint256 createdAt, address creator, bool exists, bool isRecalled, int256 currentTemperature, int256 currentHumidity, bool isSpoiled))",
   "function getTotalBatches() view returns (uint256)",
   "function getBatchIdByIndex(uint256 index) view returns (bytes32)",
   "function createBatch(bytes32 batchId, bytes32 cropTypeHash, string calldata ipfsCID, uint256 quantity, string calldata actorName, string calldata location, string calldata notes) returns (bool)",

--- a/backend/services/oracleService.js
+++ b/backend/services/oracleService.js
@@ -21,7 +21,7 @@ class OracleService {
       "event IoTDataRequested(bytes32 indexed batchId, address requester)",
       "event IoTDataFulfilled(bytes32 indexed batchId, int256 temperature, int256 humidity, bool isSpoiled)",
       "function fulfillIoTData(bytes32 batchId, int256 temperature, int256 humidity) external",
-      "function getBatch(bytes32 batchId) view returns (tuple(address farmer, uint256 quantity, string stage, bool exists, int256 temperature, int256 humidity, bool isSpoiled))",
+      "function getBatch(bytes32 batchId) view returns (tuple(bytes32 batchId, bytes32 cropTypeHash, string ipfsCID, uint256 quantity, uint256 createdAt, address creator, bool exists, bool isRecalled, int256 currentTemperature, int256 currentHumidity, bool isSpoiled))",
     ];
   }
 
@@ -370,21 +370,63 @@ class OracleService {
 
       const batchData = await this.contract.getBatch(batchId);
 
+      if (!batchData.exists) {
+        return {
+          batchId: ethers.decodeBytes32String(batchId),
+          exists: false,
+          temperature: null,
+          humidity: null,
+          isSpoiled: false,
+        };
+      }
+
+      // getBatch (CropChain.sol:534) returns the full 11-field CropBatch
+      // struct; the real sensor readings live in currentTemperature /
+      // currentHumidity / isSpoiled (see #1326).
       return {
         batchId: ethers.decodeBytes32String(batchId),
-        temperature: batchData.temperature
-          ? batchData.temperature.toNumber() / 10
+        temperature: batchData.currentTemperature != null
+          ? Number(batchData.currentTemperature) / 10
           : null,
-        humidity: batchData.humidity ? batchData.humidity.toNumber() : null,
+        humidity: batchData.currentHumidity != null
+          ? Number(batchData.currentHumidity)
+          : null,
         isSpoiled: batchData.isSpoiled || false,
-        exists: batchData.exists || false,
+        exists: true,
       };
     } catch (error) {
-      logger.error(
-        `❌ Failed to get IoT data for batch ${batchId}:`,
-        { error: error.message },
+      // getBatch carries the batchExists modifier, so querying a missing batch
+      // reverts instead of returning exists=false. Map that revert to a clean
+      // "batch not found" (404) while still surfacing genuine RPC failures.
+      const isRevert =
+        error?.code === "CALL_EXCEPTION" ||
+        error?.info?.error?.code === "CALL_EXCEPTION" ||
+        /execution reverted/i.test(error?.shortMessage || error?.message || "");
+
+      if (!isRevert) {
+        logger.error(
+          `❌ Failed to get IoT data for batch ${batchId}:`,
+          { error: error.message },
+        );
+        throw error;
+      }
+
+      logger.warn(
+        `⚠️ batch ${batchId} getBatch reverted (batch does not exist): ${error.message}`,
       );
-      throw error;
+      let decodedBatchId = batchId;
+      try {
+        decodedBatchId = ethers.decodeBytes32String(batchId);
+      } catch {
+        // keep raw batchId if it is not a decodable bytes32
+      }
+      return {
+        batchId: decodedBatchId,
+        exists: false,
+        temperature: null,
+        humidity: null,
+        isSpoiled: false,
+      };
     }
   }
 }

--- a/backend/tests/oracleService.iotData.test.js
+++ b/backend/tests/oracleService.iotData.test.js
@@ -1,0 +1,77 @@
+jest.mock("../utils/logger", () => ({ info: jest.fn(), error: jest.fn(), warn: jest.fn() }));
+
+const { ethers } = require("ethers");
+const oracleService = require("../services/oracleService");
+
+// 32-byte (64 hex char) bytes32 batch id, valid for decodeBytes32String
+const BATCH_ID = ethers.encodeBytes32String("CROP-2024-0001");
+
+// Shape of a decoded CropChain.getBatch return (full 11-field CropBatch struct)
+const makeBatchData = (overrides = {}) => ({
+  batchId: BATCH_ID,
+  cropTypeHash: "0xabcd",
+  ipfsCID: "QmExampleCid",
+  quantity: 100n,
+  createdAt: 1700000000n,
+  creator: "0x0000000000000000000000000000000000000001",
+  exists: true,
+  isRecalled: false,
+  currentTemperature: 245n,
+  currentHumidity: 60n,
+  isSpoiled: false,
+  ...overrides,
+});
+
+describe("OracleService.getBatchIoTData (getBatch ABI alignment, #1326)", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("reads temperature/humidity from currentTemperature/currentHumidity fields", async () => {
+    oracleService.contract = {
+      getBatch: jest.fn().mockResolvedValue(makeBatchData()),
+    };
+
+    const data = await oracleService.getBatchIoTData(BATCH_ID);
+
+    expect(data.exists).toBe(true);
+    expect(data.temperature).toBe(24.5); // hundredths stored on-chain -> degrees
+    expect(data.humidity).toBe(60);
+    expect(data.isSpoiled).toBe(false);
+  });
+
+  it("reports isSpoiled from the real isSpoiled field, not isRecalled", async () => {
+    oracleService.contract = {
+      getBatch: jest.fn().mockResolvedValue(
+        makeBatchData({ isRecalled: true, isSpoiled: false }),
+      ),
+    };
+
+    const data = await oracleService.getBatchIoTData(BATCH_ID);
+    expect(data.isSpoiled).toBe(false);
+    expect(data.exists).toBe(true);
+  });
+
+  it("returns exists=false when getBatch reverts (missing batch) instead of throwing", async () => {
+    oracleService.contract = {
+      getBatch: jest.fn().mockRejectedValue({
+        code: "CALL_EXCEPTION",
+        shortMessage: "execution reverted: batch does not exist",
+        message: "CALL_EXCEPTION: execution reverted: batch does not exist",
+      }),
+    };
+
+    const data = await oracleService.getBatchIoTData(BATCH_ID);
+    expect(data.exists).toBe(false);
+    expect(data.temperature).toBeNull();
+    expect(data.humidity).toBeNull();
+  });
+
+  it("re-throws non-revert errors (e.g. network failures) as 500-able errors", async () => {
+    oracleService.contract = {
+      getBatch: jest.fn().mockRejectedValue(new Error("Network connection lost")),
+    };
+
+    await expect(oracleService.getBatchIoTData(BATCH_ID)).rejects.toThrow(
+      "Network connection lost",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1326 — the oracle service declared a `getBatch(bytes32)` ABI whose return tuple did **not** match the actual `CropBatch` struct in `CropChain.sol`. Because ethers decodes ABI responses positionally, every field was read from the wrong slot and `/api/oracle/batch/:batchId/iot-data` returned **timestamps as temperature and addresses as humidity**.

## Problem

Declared (7 fields) vs actual `CropBatch` (`smart-contracts/contracts/CropChain.sol:32-44` — 11 fields):

| Declared field | Actual slot decoded | Result |
|---|---|---|
| `farmer` (address) | `bytes32 batchId` | right-aligned batch ID as an address |
| `quantity` (uint256) | `bytes32 cropTypeHash` | raw crop-type hash |
| `stage` (string) | `string ipfsCID` | the IPFS CID as a "stage" |
| `exists` (bool) | `uint256 quantity` | true whenever quantity > 0 |
| `temperature` (int256) | `uint256 createdAt` | **creation timestamp shown as °C** |
| `humidity` (int256) | `address creator` | **creator wallet shown as humidity %** |
| `isSpoiled` (bool) | `bool isRecalled` | the recall flag, not spoilage |

Additionally, `getBatch` carries the `batchExists` modifier, so querying a **missing** batch **reverts** (panics) → the route returned 500 instead of a clean 404.

## Changes

**`backend/services/oracleService.js`**
- `_contractABI.getBatch` → full 11-field tuple matching `CropBatch` (adds `currentTemperature`, `currentHumidity`, `isSpoiled`).
- `getBatchIoTData()` reads the real sensor fields:
  - `temperature` from `currentTemperature` (hundredths → degrees, unchanged `/10` convention)
  - `humidity` from `currentHumidity`
  - `isSpoiled` from the real `isSpoiled` field
- **404 semantics restored:** a revert caused by the `batchExists` modifier is mapped to `{ exists: false }` (route returns 404). Genuine RPC/network errors are still re-thrown → 500.

**`backend/config/blockchain.js`**
- `getBatch` ABI aligned with the same 11-field tuple. This is backward compatible: `blockchainService.js` and `blockchainWorker.js` read only the first 8 named fields, whose positions are unchanged.

**`backend/tests/oracleService.iotData.test.js`** (new)
- Decodes a fixture `getBatch` result and asserts temperature/humidity come from `currentTemperature`/`currentHumidity`.
- Verifies `isSpoiled` is read from the real field (not `isRecalled`).
- Verifies a reverting `getBatch` (missing batch) resolves to `exists: false` rather than throwing.
- Verifies non-revert errors are still propagated.

## Verification

- `npx jest tests/oracleService.iotData.test.js tests/oracleService.test.js` → 6/6 pass (existing oracle tests unaffected).
- `blockchainListener`/`oracleStats` suites still pass.
- Full backend suite: no new failures (remaining failures are pre-existing Babel parse errors in `batchService.js` / `blockchainQueue.js`, unrelated to this change).