### PR TITLE
security: fail closed on missing ML_API_KEY and use constant-time key comparison (fixes #1325)

### DIFF
--- a/backend/services/mlService.js
+++ b/backend/services/mlService.js
@@ -4,7 +4,9 @@ const axios = require("axios");
 const logger = require("../utils/logger");
 
 const ML_SERVICE_URL = process.env.ML_SERVICE_URL || "http://localhost:5001";
-const ML_API_KEY = process.env.ML_API_KEY || "change-me-in-production";
+// No fallback default: a missing key must fail closed instead of silently
+// sending a publicly-known credential (see #1325).
+const ML_API_KEY = process.env.ML_API_KEY;
 
 const MAX_RETRIES = 3;
 const BASE_DELAY = 200;
@@ -16,6 +18,16 @@ const BASE_DELAY = 200;
  * @param {string} cropType 
  */
 async function predictQuality(temperature, humidity, cropType) {
+  if (!ML_API_KEY) {
+    const error = new Error(
+      "ML_API_KEY is not configured. Set the ML_API_KEY environment variable " +
+        "to a strong random secret (`openssl rand -hex 32`) matching the " +
+        "ml-service deployment before calling the crop recommendation endpoint.",
+    );
+    logger.error("ML Service /quality aborted", { error: error.message });
+    throw error;
+  }
+
   let lastError;
 
   const payload = {

--- a/backend/tests/mlService.test.js
+++ b/backend/tests/mlService.test.js
@@ -1,0 +1,41 @@
+jest.mock("axios");
+
+describe("mlService credential handling (fail-closed, see #1325)", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.ML_API_KEY;
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it("throws immediately when ML_API_KEY is not configured (no default fallback)", async () => {
+    const mlService = require("../services/mlService");
+
+    await expect(mlService.predictQuality(24, 60, "tomato")).rejects.toThrow(
+      "ML_API_KEY is not configured",
+    );
+  });
+
+  it("sends the configured ML_API_KEY as the X-API-Key header", async () => {
+    process.env.ML_API_KEY = "super-secret-key-1234";
+    const axios = require("axios");
+    axios.post.mockResolvedValue({ data: { riskScore: 10.5 } });
+
+    const mlService = require("../services/mlService");
+    const result = await mlService.predictQuality(24, 60, "tomato");
+
+    expect(result).toEqual({ riskScore: 10.5 });
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining("/quality"),
+      expect.objectContaining({ temperature: 24, humidity: 60, cropType: "tomato" }),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-API-Key": "super-secret-key-1234" }),
+      }),
+    );
+  });
+});

--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -1,6 +1,7 @@
 import os
 import io
 import base64
+import hmac
 import numpy as np
 import joblib
 from functools import wraps
@@ -24,14 +25,23 @@ limiter = Limiter(
 )
 
 # ── API key authentication ─────────────────────────────────────────────────
-API_KEY = os.environ.get("ML_API_KEY", "change-me-in-production")
+# Fail closed: never boot with a publicly-known default credential. The old
+# fallback ("change-me-in-production") was hardcoded in the repo, so anyone
+# could bypass the X-API-Key guard on an unconfigured deployment.
+API_KEY = os.environ.get("ML_API_KEY")
+if not API_KEY:
+    raise RuntimeError(
+        "ML_API_KEY environment variable is required to start the ML service. "
+        "Set it to a strong random secret (openssl rand -hex 32) and make sure "
+        "it matches ML_API_KEY configured for the CropChain backend."
+    )
 
 
 def require_api_key(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         api_key = request.headers.get("X-API-Key")
-        if not api_key or api_key != API_KEY:
+        if not api_key or not hmac.compare_digest(api_key, API_KEY):
             return jsonify({"error": "Unauthorized"}), 401
         return f(*args, **kwargs)
     return decorated


### PR DESCRIPTION
## Summary

Fixes #1325 — the ML service authentication shipped with an **identical, publicly-known default API key** (`change-me-in-production`) hardcoded in **two** places. If `ML_API_KEY` was unset, anyone who read the source could authenticate to the ML endpoints.

## Problem

- `backend/services/mlService.js:7` → `process.env.ML_API_KEY || "change-me-in-production"` — the fallback was sent as the `X-API-Key` header on every `/quality` call.
- `ml-service/app.py` → `os.environ.get("ML_API_KEY", "change-me-in-production")` with a plain `!=` comparison (timing-unsafe) — the exact default value was public, so an unconfigured deployment ran with **known** credentials.

## Changes

**`ml-service/app.py`**
- `API_KEY = os.environ.get("ML_API_KEY")` — the default is removed.
- **Fail closed:** the service refuses to start (`RuntimeError` with a clear message) when `ML_API_KEY` is missing, instead of silently booting with a public credential.
- Constant-time comparison via `hmac.compare_digest`.

**`backend/services/mlService.js`**
- `const ML_API_KEY = process.env.ML_API_KEY;` — no fallback.
- `predictQuality()` throws a descriptive error when the key is unset. Callers already guard this path (`batchController.recordIoTData` wraps it in try/catch and logs a warning), so the batch/IoT features keep working — they just no longer risk sending a known secret.

**`backend/tests/mlService.test.js`** (new)
- Verifies the fail-closed behaviour when the key is unset.
- Verifies the configured key is sent as `X-API-Key`.

## Why this is safe

- `docker-compose.yml` already sets `ML_API_KEY=development-api-key` for local dev.
- `docker-compose.prod.yml` already passes `ML_API_KEY=${ML_API_KEY}`.
- `deploy-aws.sh` already auto-generates a random secret when unset.
- `.env.example` already documents `ML_API_KEY=...` for the backend.

## Verification

- `python -m py_compile ml-service/app.py` passes.
- `npx jest tests/mlService.test.js` → 2/2 pass.
- Full backend suite: no new failures (existing failures are pre-existing Babel parse errors in `batchService.js` / `blockchainQueue.js`, unrelated to this change).