### PR TITLE
ci: update Stale Issues and PR Management workflow configuration

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,26 +1,71 @@
-name: "Stale Issue and PR Management"
+name: "Stale Issues and PRs"
 
 on:
   schedule:
+    # Runs daily at midnight UTC
     - cron: "0 0 * * *"
-  workflow_dispatch:
-
-permissions:
-  issues: write
-  pull-requests: write
+    
+  workflow_dispatch: # Allows manual trigger from the Actions tab
 
 jobs:
   stale:
+    name: Mark and Close Stale Issues & PRs
     runs-on: ubuntu-latest
+    
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
-      - uses: actions/stale@v9
+      - name: Run Stale Action
+        uses: actions/stale@v9
         with:
-          stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
-          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Time thresholds
+          days-before-stale: 14
+          days-before-close: 7
+
+          # Labels applied when items are marked stale
           stale-issue-label: "stale"
           stale-pr-label: "stale"
+
+          # Reset stale timer if new activity occurs
+          remove-stale-when-updated: true
+
+          # Warning messages when items become stale
+          
+          stale-issue-message: >
+            This issue has had no activity for **14 days** and has been
+            marked as `stale`. If this is still relevant, please leave a
+            comment or push an update within the next **7 days**, otherwise
+            it will be closed automatically to keep the tracker clean.
+
+          stale-pr-message: >
+            This pull request has had no activity for **14 days** and
+            has been marked as `stale`. If this is still being worked on,
+            please push a commit or leave a comment within the next **7 days**,
+            otherwise it will be closed automatically.
+
+          # Messages posted upon automatic closure
+          
+          close-issue-message: >
+            This issue has been automatically closed after 21 days of
+            inactivity. If still relevant, please open a new issue with
+            updated context. Thank you for contributing!
+
+          close-pr-message: >
+            This pull request has been automatically closed after 21 days
+            of inactivity. Please reopen or raise a fresh PR rebased on the
+            latest main branch if you would like to continue. Thank you!
+
+          # Labels to exempt from auto-stale logic
+          
           exempt-issue-labels: "bug,enhancement,security,help wanted"
           exempt-pr-labels: "bug,enhancement,security,help wanted"
-          days-before-stale: 60
-          days-before-close: 7
+
+          # Rate-limiting and ordering controls
+          
           operations-per-run: 100
+          ascending: true
+          


### PR DESCRIPTION
## 📌 Overview
This pull request updates our `.github/workflows/stale.yml` configuration to optimize how stale issues and pull requests are managed. 

**Key Changes:**
* Reduced inactivity timeout from **60 days down to 14 days** before an item is marked as stale.
* Set a **7-day window** after being marked stale before automatic closure (total 21 days of inactivity).
* Added custom, professional warning and closure messages for both issues and pull requests.
* Re-aligned exempt labels (`bug, enhancement, security, help wanted`) to protect core tracking categories.
* Enabled `remove-stale-when-updated: true` to automatically clear stale status if activity resumes.

## 🛠️ Type of Change

- [x] CI devops

---

## 🔗 Related Issue

Closes #1333 
---

## 🧪 Testing & Verification
* *Note: Workflow tested via GitHub Actions workflow_dispatch manual trigger.*

---
## 📸 Screenshots / Demos

*(Not applicable for CI workflow configuration changes, but you can manually verify the action runs successfully from the **Actions** tab in your repository after merging.)*

---

## ✅ PR Checklist

- [x] My code follows the project's style guidelines.
- [x] I have commented my code, particularly in complex areas (e.g., Smart Contract logic).
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings.

---

## 💬 Additional Notes
This update will help keep the GitHub issue tracker and pull request list clean by automatically flagging abandoned or outdated items much faster than the previous 60-day window


gssoc 
