### PR TITLE
fix(ml-service): return 422 for non-numeric/NaN fields in /predict-yield

### DIFF
--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -2,6 +2,7 @@ import os
 import io
 import base64
 import hmac
+import math
 import numpy as np
 import joblib
 from functools import wraps
@@ -88,6 +89,33 @@ def validate_input(data):
     return errors
 
 
+YIELD_NUMERIC_FIELDS = ("area_hectares", "avg_temperature", "expected_rainfall")
+
+
+def parse_yield_numeric(body):
+    """Parse and validate the numeric fields for /predict-yield.
+
+    Missing fields are allowed (the handler applies sensible defaults); only
+    values that are present but non-numeric or NaN/inf are rejected. Returns
+    (values, errors) where `values` maps field -> parsed float for the valid
+    present fields.
+    """
+    values, errors = {}, []
+    for field in YIELD_NUMERIC_FIELDS:
+        if field not in body or body[field] is None:
+            continue
+        try:
+            val = float(body[field])
+        except (TypeError, ValueError):
+            errors.append(f"'{field}' must be a number")
+            continue
+        if math.isnan(val) or math.isinf(val):
+            errors.append(f"'{field}' must be a finite number")
+            continue
+        values[field] = val
+    return values, errors
+
+
 def analyze_crop_image(pil_image):
     """
     Computer Vision Analysis for crop leaf health & quality assessment.
@@ -163,10 +191,14 @@ def predict_yield():
     if not body:
         return jsonify({"error": "Request body must be JSON"}), 400
 
+    parsed, validation_errors = parse_yield_numeric(body)
+    if validation_errors:
+        return jsonify({"error": "Validation failed", "details": validation_errors}), 422
+
     crop = body.get("crop", "unknown")
-    area = float(body.get("area_hectares", 0))
-    temp = float(body.get("avg_temperature", 25))
-    rainfall = float(body.get("expected_rainfall", 100))
+    area = parsed.get("area_hectares", 0)
+    temp = parsed.get("avg_temperature", 25)
+    rainfall = parsed.get("expected_rainfall", 100)
 
     if area <= 0:
         return jsonify({"error": "area_hectares must be > 0"}), 422

--- a/ml-service/test_predict_yield.py
+++ b/ml-service/test_predict_yield.py
@@ -1,0 +1,82 @@
+"""
+Test suite for ML Service /predict-yield numeric validation (issue #1234).
+"""
+
+import unittest
+from app import app, API_KEY
+
+
+class TestPredictYieldValidation(unittest.TestCase):
+    def setUp(self):
+        self.app = app.test_client()
+        self.headers = {"X-API-Key": API_KEY}
+
+    def test_non_numeric_area_returns_422(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={"crop": "wheat", "area_hectares": "abc"},
+        )
+        self.assertEqual(res.status_code, 422)
+        body = res.get_json()
+        self.assertEqual(body["error"], "Validation failed")
+        self.assertTrue(any("area_hectares" in d for d in body["details"]))
+
+    def test_nan_area_returns_422(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={"crop": "wheat", "area_hectares": "NaN"},
+        )
+        self.assertEqual(res.status_code, 422)
+        body = res.get_json()
+        self.assertEqual(body["error"], "Validation failed")
+        self.assertTrue(any("finite" in d for d in body["details"]))
+
+    def test_non_numeric_temperature_returns_422(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={"crop": "wheat", "area_hectares": 10, "avg_temperature": "hot"},
+        )
+        self.assertEqual(res.status_code, 422)
+        body = res.get_json()
+        self.assertTrue(any("avg_temperature" in d for d in body["details"]))
+
+    def test_inf_rainfall_returns_422(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={"crop": "wheat", "area_hectares": 10, "expected_rainfall": "Infinity"},
+        )
+        self.assertEqual(res.status_code, 422)
+        body = res.get_json()
+        self.assertTrue(any("finite" in d for d in body["details"]))
+
+    def test_valid_request_still_succeeds(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={
+                "crop": "wheat",
+                "area_hectares": 10.5,
+                "avg_temperature": 24,
+                "expected_rainfall": 120,
+            },
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.get_json()
+        self.assertEqual(body["crop"], "wheat")
+        self.assertIn("expected_yield_tons", body)
+
+    def test_missing_numeric_fields_use_defaults_and_succeed(self):
+        res = self.app.post(
+            "/predict-yield",
+            headers=self.headers,
+            json={"crop": "wheat", "area_hectares": 10},
+        )
+        self.assertEqual(res.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

In `ml-service/app.py`, the `POST /predict-yield` handler converted request fields with bare `float(...)` calls and no error handling:
- Non-numeric values (e.g. `{"area_hectares": "abc"}`) raised `ValueError` → generic **500**.
- `NaN`/`Infinity` values parsed fine but propagated through `temp_modifier`/`rain_modifier` into `round(expected_yield, 2)`, yielding invalid JSON.

### Fix
Added `parse_yield_numeric()`, which validates each present numeric field (`area_hectares`, `avg_temperature`, `expected_rainfall`):
- non-numeric → `422` with `{"error": "Validation failed", "details": [...]}`
- `NaN`/`inf` → `422`
- missing fields keep the existing default behaviour (no regression)

This matches the structured `422` pattern already used by the `/predict` and `/quality` handlers.

## Tests
Added `ml-service/test_predict_yield.py` (unittest) covering:
- non-numeric `area_hectares` → 422
- `NaN` area → 422
- non-numeric `avg_temperature` → 422
- `Infinity` rainfall → 422
- valid request → 200
- missing numeric fields (defaults) → 200

All 6 tests pass (`ML_API_KEY=test-key python -m unittest test_predict_yield`).

Closes #1234

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._