### PR TITLE
fix: set status to 'active' on user registration

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -173,6 +173,7 @@ const registerUser = async (req, res) => {
       email,
       password: hashedPassword,
       role,
+      status: "active",
     });
 
     if (user) {
@@ -628,6 +629,7 @@ const walletRegister = async (req, res) => {
       walletAddress: normalizedAddress,
       role,
       password: await bcrypt.hash(randomPassword, 12), // Secure random password for wallet users
+      status: "active",
     });
 
     attachRefreshCookie(res, user);


### PR DESCRIPTION
## Summary

This PR fixes Issue #1228: newly registered users cannot log in because `User.status` defaults to `"pending"` and nothing in the codebase ever activates self-registered accounts. Both `loginUser` and `walletLogin` hard-reject non-active accounts, and the `protect` middleware blocks all authenticated routes for non-active users, leaving self-registered accounts permanently stuck.

## Changes

- **`registerUser` (`backend/controllers/authController.js:170-176`):** Added `status: "active"` to the `User.create` call so email/password registrations produce immediately usable accounts.
- **`walletRegister` (`backend/controllers/authController.js:625-631`):** Added `status: "active"` to the `User.create` call so wallet-based registrations produce immediately usable accounts.

##Fixes #1228

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1228:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Change default status in `User.js` schema from `"pending"` to `"active"` | Out of scope | The `"pending"` default is intentional for admin-created accounts that require approval; only self-registration paths need immediate activation |
| Add email verification flow before activation | Out of scope | Pre-existing feature gap; introduces new infrastructure (email service, token storage) beyond a targeted bugfix |
| Add admin approval workflow for self-registered users | Out of scope | Pre-existing feature gap; would require new UI, endpoints, and notification system |
