### PR TITLE
fix(server): remove dead blockchain init block that threw swallowed ReferenceError

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -17,14 +17,6 @@ const PORT = process.env.PORT || 3001;
 
 const server = http.createServer(app);
 
-const PROVIDER_URL = process.env.INFURA_URL;
-const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
-const PRIVATE_KEY = process.env.PRIVATE_KEY;
-
-let provider;
-let contractInstance;
-let wallet;
-
 // ─── Production safety guard ─────────────────────────────────────────────────
 // Refuse to start if production is configured without secure key management.
 // This prevents accidental deploys with a plaintext PRIVATE_KEY.
@@ -40,23 +32,13 @@ if (process.env.NODE_ENV === 'production' && !process.env.AWS_SECRET_ARN) {
 }
 // ─────────────────────────────────────────────────────────────────────────────
 
-if (PROVIDER_URL && CONTRACT_ADDRESS && PRIVATE_KEY) {
-  try {
-    provider = new ethers.JsonRpcProvider(PROVIDER_URL);
-    wallet = new ethers.Wallet(PRIVATE_KEY, provider);
-    contractInstance = new ethers.Contract(
-      CONTRACT_ADDRESS,
-      blockchainService.getContractABI(),
-      wallet,
-    );
-    logger.info("Blockchain contract instance initialized");
-  } catch (error) {
-    logger.error("Failed to initialize blockchain connection", {
-      error: error.message,
-    });
-    contractInstance = null;
-  }
-}
+// The blockchain provider/wallet/contract are initialized through
+// blockchainService.initialize() during startup (see startup/bootstrap.js ->
+// config/blockchain.js), which imports ethers and the contract ABI correctly.
+// A previous duplicate init block here referenced `ethers` and
+// `blockchainService` without importing them, so it always threw a swallowed
+// ReferenceError ("Failed to initialize blockchain connection") while its
+// module-local results were never read anywhere. It has been removed.
 
 socketService.initializeSocketIO(server);
 logger.info("Socket.IO integration complete");


### PR DESCRIPTION
## Summary
Fixes #1238

`backend/server.js` constructed `new ethers.JsonRpcProvider`/`Wallet`/`Contract(... blockchainService.getContractABI() ...)` but **never imported** `ethers` or `blockchainService` in that file. When `INFURA_URL`/`CONTRACT_ADDRESS`/`PRIVATE_KEY` were set, the block threw `ReferenceError: ethers is not defined`, which the surrounding `catch` swallowed — so the app logged `Failed to initialize blockchain connection` on every boot and continued with `contractInstance = null`. A real connection was never attempted through this path.

## Fix
The real blockchain connection is already initialized correctly at startup via `blockchainService.initialize()` → `config/blockchain.js` (which imports `ethers` and the contract ABI). See `startup/bootstrap.js:46`. The duplicate block in `server.js` was dead code — its module-local `provider`/`wallet`/`contractInstance` were never read anywhere. Per the issue's guidance ("or drops the unused block"), I removed the dead block and its unused locals, keeping the production safety guard intact.

## Files
- `backend/server.js`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._