### PR TITLE
fix(batchController): validate date-range and allow-list sort on GET /batches

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -352,10 +352,26 @@ exports.getBatches = async (req, res) => {
     if (start || end) {
       query.createdAt = {};
       if (start) {
-        query.createdAt.$gte = new Date(start);
+        const startDateObj = new Date(start);
+        if (Number.isNaN(startDateObj.getTime())) {
+          return res
+            .status(400)
+            .json(apiResponse.errorResponse("Invalid 'start' date. Use ISO 8601 format (e.g. 2024-01-01)."));
+        }
+        query.createdAt.$gte = startDateObj;
       }
       if (end) {
-        query.createdAt.$lte = new Date(end);
+        const endDateObj = new Date(end);
+        if (Number.isNaN(endDateObj.getTime())) {
+          return res
+            .status(400)
+            .json(apiResponse.errorResponse("Invalid 'end' date. Use ISO 8601 format (e.g. 2024-01-01)."));
+        }
+        query.createdAt.$lte = endDateObj;
+      }
+      // Drop an empty object if both ends were absent/invalid-but-silenced.
+      if (!query.createdAt.$gte && !query.createdAt.$lte) {
+        delete query.createdAt;
       }
     }
 
@@ -367,8 +383,21 @@ exports.getBatches = async (req, res) => {
     );
     const skip = (pageNumber - 1) * limitNumber;
 
+    // Allow-list sort keys so a client cannot inject arbitrary/malformed
+    // sort fields into the Mongoose query.
+    const ALLOWED_SORT_FIELDS = new Set([
+      "createdAt",
+      "updatedAt",
+      "batchId",
+      "cropType",
+      "quantity",
+      "farmerName",
+      "status",
+      "currentStage",
+    ]);
+    const safeSortBy = ALLOWED_SORT_FIELDS.has(sortBy) ? sortBy : "createdAt";
     const sort = {};
-    sort[sortBy] = sortOrder.toLowerCase() === "asc" ? 1 : -1;
+    sort[safeSortBy] = sortOrder.toLowerCase() === "asc" ? 1 : -1;
 
     // Use lean() for read-only queries to skip Mongoose document hydration
     const batches = await Batch.find(query)
@@ -711,7 +740,4 @@ exports.getIoTData = async (req, res) => {
         ),
       );
   }
-};
-
-.catch(err => console.error("Promise.all failed:", err));
 };


### PR DESCRIPTION
## Summary
Fixes #1237

`getAllBatches` (`backend/controllers/batchController.js`) parsed `start`/`end` with bare `new Date(start)` and passed the raw client `sortBy` straight into `.sort({...})`:
- `GET /api/batches?start=notadate` → Mongoose `CastError` → `500`.
- `GET /api/batches?sortBy=<arbitrary-key>` → arbitrary/malformed sort field forwarded into the query.

## Fix
- **Dates:** validate with `Number.isNaN(date.getTime())` and return `400` with a clear message for invalid `start`/`end`; empty/absent ends no longer leave an empty `createdAt` object on the query.
- **Sort:** restrict `sortBy` to an allow-list of real fields (`createdAt`, `updatedAt`, `batchId`, `cropType`, `quantity`, `farmerName`, `status`, `currentStage`), falling back to `createdAt` for anything else. Default behaviour (no `sortBy` → `createdAt` desc) is unchanged.

```diff
- if (start) { query.createdAt.$gte = new Date(start); }
- if (end) { query.createdAt.$lte = new Date(end); }
+ if (start) {
+   const startDateObj = new Date(start);
+   if (Number.isNaN(startDateObj.getTime())) return res.status(400).json(apiResponse.errorResponse("Invalid 'start' date..."));
+   query.createdAt.$gte = startDateObj;
+ }
+ const ALLOWED_SORT_FIELDS = new Set(["createdAt", "updatedAt", "batchId", ...]);
+ const safeSortBy = ALLOWED_SORT_FIELDS.has(sortBy) ? sortBy : "createdAt";
+ sort[safeSortBy] = sortOrder.toLowerCase() === "asc" ? 1 : -1;
```

## Also fixes a pre-existing syntax error
The file on `main` ends with an orphaned top-level `.catch(err => console.error("Promise.all failed:", err));` (not attached to any Promise), which is invalid JS and made the **whole module fail to load** (`SyntaxError: Unexpected token '.'`). I removed this dead line so the file compiles; without this, neither my change nor the existing handler could run. The existing `exports.*` assignments continue to define `module.exports`.

## Files
- `backend/controllers/batchController.js`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
