### PR TITLE
fix(add-batch): mint per-batch provenance descriptor instead of fixed placeholder CID

### DIFF
--- a/frontend/src/app/add-batch/page.tsx
+++ b/frontend/src/app/add-batch/page.tsx
@@ -135,10 +135,28 @@ const AddBatchContent: React.FC = () => {
                 id: "web3-sync",
               });
 
+              // Build a per-batch provenance descriptor instead of a fixed
+              // placeholder CID so every on-chain record uniquely identifies
+              // the batch's data. TODO: replace with a real IPFS pin
+              // (Pinata / web3.storage / nft.storage) once configured, then
+              // use the returned CID here.
+              const provenanceMetadata = {
+                batchId: batch.batchId,
+                cropType: batch.cropType,
+                quantity: batch.quantity,
+                farmerName: batch.farmerName,
+                origin: batch.origin,
+                description: batch.description || "Initial harvest recorded",
+                recordedAt: batch.createdAt || new Date().toISOString(),
+              };
+              const ipfsDescriptor = ethers.id(
+                JSON.stringify(provenanceMetadata),
+              );
+
               const tx = await contract.createBatch(
                 ethers.encodeBytes32String(batch.batchId),
                 ethers.encodeBytes32String(batch.cropType.toUpperCase()),
-                "QmYwAPJhy5n2aBhajbN7yXq3TqK6Lj5ee2ov3333333333", // 46-char valid IPFS CID
+                ipfsDescriptor,
                 BigInt(batch.quantity),
                 batch.farmerName,
                 batch.origin,


### PR DESCRIPTION
## Summary
Fixes #1236

`frontend/src/app/add-batch/page.tsx` passed the literal CID `"QmYwAPJhy5n2aBhajbN7yXq3TqK6Lj5ee2ov3333333333"` to `contract.createBatch(...)` for every batch, so every on-chain `BatchCreated` event stored an identical `ipfsCID`, destroying the value of batch-specific provenance data.

## Fix
Build a per-batch provenance descriptor from the batch's own data (batchId, cropType, quantity, farmerName, origin, description, recordedAt) and hash it with `ethers.id(...)` (sha-256) to produce a unique, deterministic descriptor that is minted on-chain instead of the constant placeholder. Each batch now records a distinct `ipfsCID` that uniquely identifies that batch's data.

The repo currently has no IPFS pinning integration configured, so a real resolvable CID isn't available yet. A `TODO` marks the spot to swap this descriptor for a real IPFS pin (Pinata / web3.storage / nft.storage) once configured — at which point `ipfsDescriptor` is replaced by the returned CID.

```diff
- "QmYwAPJhy5n2aBhajbN7yXq3TqK6Lj5ee2ov3333333333", // 46-char valid IPFS CID
+ const provenanceMetadata = {
+   batchId: batch.batchId, cropType: batch.cropType, quantity: batch.quantity,
+   farmerName: batch.farmerName, origin: batch.origin,
+   description: batch.description || "Initial harvest recorded",
+   recordedAt: batch.createdAt || new Date().toISOString(),
+ };
+ const ipfsDescriptor = ethers.id(JSON.stringify(provenanceMetadata));
+ // ... ipfsDescriptor passed as the ipfsCID arg
```

## Files
- `frontend/src/app/add-batch/page.tsx`

## Notes
The on-chain mint path runs only when `hasMetaMask()` is true, so the existing component tests (jsdom, no `window.ethereum`) do not exercise this block and remain unaffected.

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
