### PR TITLE
fix(realCropBatchService): surface 4xx/5xx server errors instead of masking as offline success

### DIFF
--- a/frontend/src/services/realCropBatchService.ts
+++ b/frontend/src/services/realCropBatchService.ts
@@ -6,6 +6,16 @@ import { offlineStorage } from "./offlineStorage";
 const isOnline = () =>
   typeof navigator !== "undefined" ? navigator.onLine : true;
 
+/**
+ * A request failure should only fall back to the offline store when the
+ * request never reached the server (offline / network-level failure), i.e.
+ * there is no HTTP response attached. A 4xx/5xx response means the server
+ * received and rejected the payload, which must be surfaced to the UI
+ * instead of being masked as an offline "success" and later re-synced.
+ */
+const isNetworkOrOfflineError = (error: any): boolean =>
+  !error || !error.response;
+
 export interface BatchData {
   batchId: string;
   farmerName: string;
@@ -55,9 +65,14 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.post("/batches", formData);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkOrOfflineError(error)) {
+          // Server rejected the submission (4xx/5xx): surface it to the UI
+          // instead of masking it as an offline "success".
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online creation failed, falling back to offline mode:",
+          "[realCropBatchService] Online creation failed (network/offline), falling back to offline mode:",
           error,
         );
       }
@@ -110,9 +125,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkOrOfflineError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Online getBatch failed (network/offline), falling back to offline storage:",
           error,
         );
       }
@@ -127,9 +145,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/public/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkOrOfflineError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getPublicBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Online getPublicBatch failed (network/offline), falling back to offline storage:",
           error,
         );
       }
@@ -150,9 +171,12 @@ export const realCropBatchService = {
           updateData,
         );
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkOrOfflineError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online update failed, falling back to offline mode:",
+          "[realCropBatchService] Online update failed (network/offline), falling back to offline mode:",
           error,
         );
       }


### PR DESCRIPTION
## Summary
Fixes #1235

`realCropBatchService` forwarded **every** `createBatch`/`getBatch`/`getPublicBatch`/`updateBatch` failure to the offline store and returned it as success (`frontend/src/services/realCropBatchService.ts`). When the server rejected a submission with `400`/`404`/`500`, the user saw a fabricated `TEMP-*` batch as if registration succeeded, and a later queued re-sync pushed the rejected payload back at the server.

## Fix
Only fall back to the offline store when the request genuinely failed to reach the server (offline / network-level failure). A 4xx/5xx server response now re-throws so the UI surfaces the real error.

Added a small helper:
```ts
// No HTTP response attached => request never reached the server.
const isNetworkOrOfflineError = (error: any): boolean =>
  !error || !error.response;
```

Applied to the `catch` of `createBatch`, `getBatch`, `getPublicBatch`, and `updateBatch`:
```diff
- } catch (error) {
-   console.warn("[realCropBatchService] Online creation failed, falling back to offline mode:", error);
- }
+ } catch (error: any) {
+   if (!isNetworkOrOfflineError(error)) {
+     // Server rejected the submission (4xx/5xx): surface it to the UI
+     // instead of masking it as an offline "success".
+     throw error;
+   }
+   console.warn("[realCropBatchService] Online creation failed (network/offline), falling back to offline mode:", error);
+ }
```

`getAllBatches` (a read that already degrades to the offline list) is intentionally left unchanged so the list view stays usable during transient failures.

## Behavior
| Failure type | Before | After |
|---|---|---|
| Offline / network (no response) | offline fallback | offline fallback (unchanged) |
| Server 4xx/5xx (has response) | masked as offline "success" | re-thrown → UI shows the real error |

## Files
- `frontend/src/services/realCropBatchService.ts`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
