### PR TITLE
fix(redis): handle BullMQ connection error events to prevent worker crash on Redis loss

### DIFF
--- a/backend/config/redis.js
+++ b/backend/config/redis.js
@@ -94,10 +94,32 @@ function getRedisConnection() {
  * @returns {Redis} New Redis connection instance
  */
 function createQueueConnection() {
-  return new Redis({
+  const connection = new Redis({
     ...connectionOptions,
     maxRetriesPerRequest: null, // BullMQ requires this to be null
   });
+
+  // BullMQ does not attach an 'error' listener to the user-provided
+  // connection. If the ioredis client emits 'error' with no listener
+  // (e.g. during a Redis failover / socket disconnect), Node treats it as
+  // an unhandled error and the process crashes with
+  // UnhandledPromiseRejectionError. Log the error here and let ioredis
+  // recover via retryStrategy / reconnectOnError instead of crashing.
+  connection.on("error", (err) => {
+    logger.error("❌ BullMQ Redis connection error", {
+      error: err.message,
+    });
+  });
+  connection.on("close", () => {
+    logger.warn("⚠️ BullMQ Redis connection closed");
+  });
+  connection.on("reconnecting", (delay) => {
+    logger.warn(
+      `🔄 BullMQ Redis reconnecting in ${delay}ms...`,
+    );
+  });
+
+  return connection;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #1291

When Redis experiences a transient failover / socket disconnect, the BullMQ worker process crashes with an unhandled `error` event (surfaced as `UnhandledPromiseRejectionError`), halting all background blockchain transaction processing:

```
[INFO] [BlockchainWorker]: Worker initialized listening on queue 'blockchain-tx'
ERROR [ioredis]: Connection to 127.0.0.1:6379 failed - connect ECONNREFUSED
node:events:497
      throw er; // Unhandled 'error' event
Error: Connection is closed.
    at Redis.sendCommand (.../ioredis/built/redis/index.js:636:24)
    at Worker.retry (.../bullmq/dist/cjs/classes/worker.js:154:18)
Emitted 'error' event at:
    at Redis.emit (.../ioredis/built/redis/index.js:342:14)
```

## Root cause
`createQueueConnection()` (`backend/config/redis.js`) returns a raw `new Redis({...})` with **no `'error'` listener attached**. BullMQ does not attach one to the user-provided connection either. In Node, an `EventEmitter` that emits `'error'` with no listener throws and crashes the process. During a Redis drop, BullMQ's internal `Worker.retry` triggers an `'error'` emission on the ioredis client → no listener → crash.

Note: `getRedisConnection()` (the shared app connection) already attaches an `'error'` handler — only the BullMQ-specific `createQueueConnection()` (used by the Worker, Queue, and QueueEvents) was missing it.

## Fix
Attach `'error'` / `'close'` / `'reconnecting'` listeners to each BullMQ connection created by `createQueueConnection()`. The `'error'` listener logs the failure instead of crashing the process, and ioredis then recovers via the existing `retryStrategy` / `reconnectOnError` with backoff.

```diff
function createQueueConnection() {
- return new Redis({
-   ...connectionOptions,
-   maxRetriesPerRequest: null,
- });
+ const connection = new Redis({
+   ...connectionOptions,
+   maxRetriesPerRequest: null,
+ });
+ connection.on("error", (err) => {
+   logger.error("❌ BullMQ Redis connection error", { error: err.message });
+ });
+ connection.on("close", () => { logger.warn("⚠️ BullMQ Redis connection closed"); });
+ connection.on("reconnecting", (delay) => { logger.warn(`🔄 BullMQ Redis reconnecting in ${delay}ms...`); });
+ return connection;
}
```

This covers the Worker, Queue, and QueueEvents connections (all built via `createQueueConnection()`).

## Behavior
| Event | Before | After |
|---|---|---|
| Redis drop / failover | process crash (`UnhandledPromiseRejectionError`) | logged + ioredis reconnects with backoff |

## Files
- `backend/config/redis.js`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._
