### PR TITLE
fix(batchService): expose hash+notes on public batch so Track Batch verification works

### DIFF
--- a/backend/services/batchService.js
+++ b/backend/services/batchService.js
@@ -307,6 +307,15 @@ class BatchService {
         actor: update.actor,
         location: update.location,
         timestamp: update.timestamp,
+        // notes is part of the hash-chain serialization, and the public
+        // tracking UI renders it as each update's description, so it must
+        // be exposed for the client to (a) verify the ledger and
+        // (b) show the journey description.
+        notes: update.notes,
+        // hash is required by the client's verifyHashChain() — omitting it
+        // makes every public batch report as "tampered" (missing hash is
+        // treated as a break in the ledger).
+        hash: update.hash,
       })),
       qrCode: batchData.qrCode,
       carbonFootprint: batchData.carbonFootprint,

--- a/backend/tests/batch.test.js
+++ b/backend/tests/batch.test.js
@@ -180,6 +180,7 @@ describe("Batch API Endpoints", () => {
             location: "Test Origin",
             timestamp: "2024-01-01T00:00:00.000Z",
             notes: "Initial harvest recorded",
+            hash: "abc123hash",
           },
         ],
         currentTemperature: 72,
@@ -219,7 +220,15 @@ describe("Batch API Endpoints", () => {
     expect(res.body.data.batch).not.toHaveProperty("pendingApprovalId");
     expect(res.body.data.batch).not.toHaveProperty("approvalHistory");
     expect(res.body.data.batch.updates[0]).not.toHaveProperty("_id");
-    expect(res.body.data.batch.updates[0]).not.toHaveProperty("notes");
+    // notes and hash are intentionally exposed on the public endpoint: notes
+    // is part of the hash-chain serialization and is rendered as each update's
+    // description, and hash is required for the client's verifyHashChain().
+    expect(res.body.data.batch.updates[0]).toHaveProperty("notes");
+    expect(res.body.data.batch.updates[0]).toHaveProperty("hash");
+    expect(res.body.data.batch.updates[0].notes).toEqual(
+      "Initial harvest recorded",
+    );
+    expect(res.body.data.batch.updates[0].hash).toEqual("abc123hash");
   });
 
   it("should return 404 for a missing public tracking batch", async () => {


### PR DESCRIPTION
## Summary
Fixes #1338

The public Track Batch page (`/track-batch`) flags **every** legitimate batch as **"LEDGER INTEGRITY BREACH: TAMPERING DETECTED"**, making the tracking page unusable:

1. **Every public batch is flagged as tampered.** `toPublicBatch` (`backend/services/batchService.js`) stripped the `hash` field from each update when building the public response. The client's `verifyHashChain()` (`frontend/src/utils/crypto.ts`) treats a missing `hash` as a break in the ledger (`return false`), so `setIsTampered(true)` fires for **every** public batch — consumers scanning a QR code see a false tamper banner even though the batch is legitimate.

2. **Hash-chain verification can never succeed even with the hash.** `calculateUpdateHash` (server) and `verifyHashChain` (client) both serialize `notes` into the hash input. Since `toPublicBatch` also stripped `notes`, the client would recompute the hash with `notes=""` while the server used the real notes → guaranteed mismatch.

## Fix
`backend/services/batchService.js` — `toPublicBatch` now exposes `notes` and `hash` on each public update:
```diff
  updates: (batchData.updates || []).map((update) => ({
    stage: update.stage,
    actor: update.actor,
    location: update.location,
    timestamp: update.timestamp,
+   notes: update.notes,   // part of hash serialization + rendered as the update description
+   hash: update.hash,     // required by client verifyHashChain()
  })),
```

### Why exposing `notes`/`hash` publicly is correct
- `notes` is supply-chain provenance text (e.g. "Initial harvest recorded", "Arrived at mandi") that the Track Batch timeline already renders as each update's description (`description: update.notes || ...`). It is intentionally public provenance, not private data.
- `hash` is a SHA-256 of the public update fields + previous hash. Exposing it is the entire point of a tamper-evident ledger — consumers verify the chain client-side.
- Private fields (`_id`, `farmerId`, `farmerAddress`, `farmerWalletAddress`, `blockchainHash`, `syncStatus`, `pendingApprovalId`, `approvalHistory`) remain stripped.

## Test
`backend/tests/batch.test.js` — the public-batch test previously asserted `updates[0]` has **no** `notes` (encoding the buggy behavior). Updated to assert `notes` and `hash` are present, and the mock update now carries a `hash` reflecting the real schema.

## Scope / related
This PR is scoped strictly to the `toPublicBatch` hash/notes defect (#1338). A separate pre-existing `SyntaxError` in `backend/services/batchService.js` (an orphaned EOF `.catch`) is tracked by #1227 and fixed in PR #1274; once #1274 lands, `node --check` passes on this file and the full Jest suite for the public-batch test runs end-to-end. This PR's hunk applies cleanly on top of #1274 (no overlap).

## Files
- `backend/services/batchService.js`
- `backend/tests/batch.test.js`

---
_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

