### PR TITLE
fix(ci): allow Python-2.0/0BSD in root license check

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           if [ -f "package.json" ]; then
             npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense"
+            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD;BlueOak-1.0.0"
           fi
 
       - name: Check Frontend Licenses
@@ -34,7 +34,7 @@ jobs:
           if [ -d "frontend" ] && [ -f "frontend/package.json" ]; then
             cd frontend
             npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD"
+            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD;BlueOak-1.0.0"
           fi
 
       - name: Check Backend Licenses
@@ -42,7 +42,7 @@ jobs:
           if [ -d "backend" ] && [ -f "backend/package.json" ]; then
             cd backend
             npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD"
+            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD;BlueOak-1.0.0"
           fi
 
       - name: Check Smart Contracts Licenses
@@ -50,5 +50,5 @@ jobs:
           if [ -d "smart-contracts" ] && [ -f "smart-contracts/package.json" ]; then
             cd smart-contracts
             npm ci --legacy-peer-deps || npm install --legacy-peer-deps
-            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD"
+            npx license-checker-rseidelsohn --summary --onlyAllow "MIT;ISC;Apache-2.0;BSD-3-Clause;BSD-2-Clause;CC-BY-4.0;CC-BY-3.0;CC0-1.0;Unlicense;Python-2.0;0BSD;BlueOak-1.0.0"
           fi


### PR DESCRIPTION
Aligns the **`Check Root Licenses`** step's `--onlyAllow` list with its sibling steps and adds the permissive `BlueOak-1.0.0`.

> _This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._

## What this fixes (a config inconsistency)
In `.github/workflows/license-check.yml`, the `Check Root Licenses` step was missing `Python-2.0` and `0BSD` even though the Frontend/Backend/Smart-Contracts steps already allowed them. The root tree contains `argparse@2.0.1` (Python-2.0) and `minimatch@10.2.6` (BlueOak-1.0.0), so the root check failed on every PR. This PR adds `Python-2.0;0BSD;BlueOak-1.0.0` to the root step and `BlueOak-1.0.0` to the other steps. All three are permissive, SPDX-recognized licenses.

## ⚠️ Separate issue requiring a MAINTAINER decision (not addressed here)
Even after this fix, the **Frontend** license check still fails:
```
Package "@img/sharp-libvips-linux-x64@1.2.4" is licensed under "LGPL-3.0-or-later" which is not permitted by the --onlyAllow flag. Exiting.
```
`@img/sharp-libvips-*` is a transitive dependency of `sharp`. **LGPL-3.0-or-later is a copyleft license** with source-availability obligations, so allowing it is a project licensing-policy decision only the repo owner can make — I have not added it. Options for the owner:
1. Add `LGPL-3.0-or-later` to the `--onlyAllow` lists (accepts the LGPL obligations), or
2. Remove/replace the `sharp` dependency, or
3. Document the LGPL compliance approach.

## Note
Other CropChain CI failures (frontend build breakage from duplicated `.catch` chains / `sourceIndex` already declared) are tracked separately in #1227.