### PR TITLE
fix: validate dates and restrict sort keys in getAllBatches

### DIFF
--- a/backend/controllers/batchController.js
+++ b/backend/controllers/batchController.js
@@ -348,12 +348,22 @@ exports.getBatches = async (req, res) => {
     const start = startDate || dateFrom;
     const end = endDate || dateTo;
     if (start || end) {
-      query.createdAt = {};
-      if (start) {
-        query.createdAt.$gte = new Date(start);
+      const parsedStart = start ? new Date(start) : null;
+      const parsedEnd = end ? new Date(end) : null;
+
+      if ((start && isNaN(parsedStart.getTime())) || (end && isNaN(parsedEnd.getTime()))) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid date format. Please provide a valid date string.",
+        });
       }
-      if (end) {
-        query.createdAt.$lte = new Date(end);
+
+      query.createdAt = {};
+      if (parsedStart) {
+        query.createdAt.$gte = parsedStart;
+      }
+      if (parsedEnd) {
+        query.createdAt.$lte = parsedEnd;
       }
     }
 
@@ -365,13 +375,31 @@ exports.getBatches = async (req, res) => {
     );
     const skip = (pageNumber - 1) * limitNumber;
 
+    const ALLOWED_SORT_FIELDS = [
+      "createdAt",
+      "updatedAt",
+      "batchId",
+      "farmerName",
+      "cropType",
+      "quantity",
+      "harvestDate",
+      "currentStage",
+      "status",
+      "origin",
+    ];
+
+    const ALLOWED_SORT_ORDERS = ["asc", "desc"];
+
+    const safeSortBy = ALLOWED_SORT_FIELDS.includes(sortBy) ? sortBy : "createdAt";
+    const safeSortOrder = ALLOWED_SORT_ORDERS.includes(sortOrder.toLowerCase()) ? sortOrder.toLowerCase() : "desc";
+
     const sort = {};
-    
+
     // If text search is active and no specific sort is requested, sort by relevance
-    if (search && sortBy === "createdAt") {
+    if (search && safeSortBy === "createdAt") {
       sort.score = { $meta: "textScore" };
     } else {
-      sort[sortBy] = sortOrder.toLowerCase() === "asc" ? 1 : -1;
+      sort[safeSortBy] = safeSortOrder === "asc" ? 1 : -1;
     }
 
     // Use lean() for read-only queries to skip Mongoose document hydration


### PR DESCRIPTION
## Summary

This PR fixes Issue #1237: `getAllBatches` in `batchController.js` parses start/end dates with bare `new Date(start)` and passes the raw client value straight into `.sort({...})`. Invalid dates produce a Mongoose CastError → 500, and unvalidated sort keys let a client request arbitrary/malformed sort fields.

## Changes

- **Date validation (`backend/controllers/batchController.js:350-368`):** Dates are now parsed into temporary variables and validated with `isNaN(parsedDate.getTime())` before being used in the query. Invalid dates return a 400 response with a descriptive error message instead of triggering a Mongoose CastError 500.
- **Sort key allow-list (`backend/controllers/batchController.js:378-403`):** Added `ALLOWED_SORT_FIELDS` containing only safe, indexed fields (`createdAt`, `updatedAt`, `batchId`, `farmerName`, `cropType`, `quantity`, `harvestDate`, `currentStage`, `status`, `origin`). The `sortBy` parameter is validated against this list and falls back to `createdAt` if an unsupported field is provided. `ALLOWED_SORT_ORDERS` restricts values to `"asc"` / `"desc"` with `"desc"` as the safe default.

## Fixes #1237

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1237:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Move date/sort validation into a reusable middleware | Out of scope | Would require changes to route definitions and testing across multiple endpoints; a targeted inline fix is appropriate for this bugfix |
| Add schema-level validation for all query parameters | Out of scope | Pre-existing gap that would require a broader refactor of query handling across the controller |
| Add rate limiting to the endpoint | Out of scope | Pre-existing infrastructure concern unrelated to the date/sort validation bug |
