### PR TITLE
fix: remove dead blockchain init block in server.js that referenced undefined ethers

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -17,14 +17,6 @@ const PORT = process.env.PORT || 3001;
 
 const server = http.createServer(app);
 
-const PROVIDER_URL = process.env.INFURA_URL;
-const CONTRACT_ADDRESS = process.env.CONTRACT_ADDRESS;
-const PRIVATE_KEY = process.env.PRIVATE_KEY;
-
-let provider;
-let contractInstance;
-let wallet;
-
 // ─── Production safety guard ─────────────────────────────────────────────────
 // Refuse to start if production is configured without secure key management.
 // This prevents accidental deploys with a plaintext PRIVATE_KEY.
@@ -39,24 +31,6 @@ if (process.env.NODE_ENV === 'production' && !process.env.AWS_SECRET_ARN) {
   process.exit(1);
 }
 // ─────────────────────────────────────────────────────────────────────────────
-
-if (PROVIDER_URL && CONTRACT_ADDRESS && PRIVATE_KEY) {
-  try {
-    provider = new ethers.JsonRpcProvider(PROVIDER_URL);
-    wallet = new ethers.Wallet(PRIVATE_KEY, provider);
-    contractInstance = new ethers.Contract(
-      CONTRACT_ADDRESS,
-      blockchainService.getContractABI(),
-      wallet,
-    );
-    logger.info("Blockchain contract instance initialized");
-  } catch (error) {
-    logger.error("Failed to initialize blockchain connection", {
-      error: error.message,
-    });
-    contractInstance = null;
-  }
-}
 
 socketService.initializeSocketIO(server);
 logger.info("Socket.IO integration complete");


### PR DESCRIPTION
## Summary

This PR fixes Issue #1238: `backend/server.js:43-58` constructs `new ethers.JsonRpcProvider`, `new ethers.Wallet`, and `new ethers.Contract(...)` but never requires `ethers` or `blockchainService`. When `INFURA_URL`, `CONTRACT_ADDRESS`, and `PRIVATE_KEY` are set, a `ReferenceError: ethers is not defined` is thrown and swallowed by the surrounding `catch`, so the app logs "Failed to initialize blockchain connection" and continues with `contractInstance = null` while a real connection is never attempted.

## Changes

- **`backend/server.js` (removed lines 20-58):** Deleted the dead blockchain initialization block that referenced undefined `ethers` and `blockchainService` globals, along with its associated unused variables (`PROVIDER_URL`, `CONTRACT_ADDRESS`, `PRIVATE_KEY`, `provider`, `wallet`, `contractInstance`). Blockchain initialization is already handled properly by `blockchainService.initialize()` called via `runStartupTasks()` in `startup/bootstrap.js:46`. The production safety guard for plaintext `PRIVATE_KEY` was retained.

## Fixes #1238

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1238:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Add explicit `require("ethers")` and `require("./services/blockchainService")` to server.js | Out of scope | The dead block duplicates logic already handled by `blockchainService.initialize()` in bootstrap; adding imports would create two competing initialization paths |
| Export `provider`/`wallet` from server.js for use elsewhere | Out of scope | No other module reads these variables; the canonical instances live in `blockchainService` |
| Add a startup health check that verifies the blockchain connection is live | Out of scope | Pre-existing feature gap; would require new monitoring infrastructure beyond a targeted bugfix |
