### PR TITLE
fix: surface server errors instead of silently falling back to offline mode

### DIFF
--- a/frontend/src/services/realCropBatchService.ts
+++ b/frontend/src/services/realCropBatchService.ts
@@ -6,6 +6,10 @@ import { offlineStorage } from "./offlineStorage";
 const isOnline = () =>
   typeof navigator !== "undefined" ? navigator.onLine : true;
 
+const isNetworkError = (error: any): boolean => {
+  return !error.response;
+};
+
 export interface BatchData {
   batchId: string;
   farmerName: string;
@@ -55,9 +59,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.post("/batches", formData);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online creation failed, falling back to offline mode:",
+          "[realCropBatchService] Network failure during creation, falling back to offline mode:",
           error,
         );
       }
@@ -91,9 +98,12 @@ export const realCropBatchService = {
           ...data,
           batches: [...filteredPending, ...onlineBatches],
         };
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Failed to fetch online batches, returning offline ones:",
+          "[realCropBatchService] Network failure fetching batches, returning offline ones:",
           error,
         );
       }
@@ -110,9 +120,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Network failure during getBatch, falling back to offline storage:",
           error,
         );
       }
@@ -127,9 +140,12 @@ export const realCropBatchService = {
       try {
         const response = await apiClient.get(`/batches/public/${sanitizedId}`);
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online getPublicBatch failed, falling back to offline storage:",
+          "[realCropBatchService] Network failure during getPublicBatch, falling back to offline storage:",
           error,
         );
       }
@@ -150,9 +166,12 @@ export const realCropBatchService = {
           updateData,
         );
         return response.data.data.batch;
-      } catch (error) {
+      } catch (error: any) {
+        if (!isNetworkError(error)) {
+          throw error;
+        }
         console.warn(
-          "[realCropBatchService] Online update failed, falling back to offline mode:",
+          "[realCropBatchService] Network failure during update, falling back to offline mode:",
           error,
         );
       }


### PR DESCRIPTION
## Summary

This PR fixes Issue #1235: `realCropBatchService` forwards every `createBatch`/`getBatch`/`updateBatch` failure to the offline store and returns it as success. When the server rejects a submission (400 validation, 404, 500), the user sees a fabricated `TEMP-*` batch as if registration succeeded, and a later queued re-sync pushes the rejected payload back at the server.

## Changes

- **`frontend/src/services/realCropBatchService.ts` (line 9-11):** Added `isNetworkError()` helper that checks for the absence of `error.response` — Axios network errors (DNS failure, timeout, CORS, connection refused) have no `response` property, while server rejections (400, 404, 500) always do.
- **`createBatch` (line 62-65):** Catch block now re-throws server response errors; offline fallback only triggers on genuine network failures.
- **`getAllBatches` (line 101-104):** Same pattern — server errors are re-thrown instead of silently returning only offline batches.
- **`getBatch` (line 123-126):** Same pattern — server errors propagate to the caller.
- **`getPublicBatch` (line 143-146):** Same pattern.
- **`updateBatch` (line 169-172):** Same pattern — server errors propagate instead of being silently queued for offline sync.

## Fixes #1235

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1235:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Add retry logic with exponential backoff before falling back to offline | Out of scope | Introduces new retry infrastructure; the immediate fix is to stop treating server rejections as offline successes |
| Add a global error boundary for API failures | Out of scope | Pre-existing architectural gap; would require changes across multiple service consumers |
| Queue failed payloads for manual admin review | Out of scope | Pre-existing feature gap; introduces new UI and notification requirements beyond a targeted bugfix |
