### PR TITLE
fix: validate numeric inputs and reject NaN in predict-yield endpoint

### DIFF
--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -163,10 +163,36 @@ def predict_yield():
     if not body:
         return jsonify({"error": "Request body must be JSON"}), 400
 
+    errors = []
+
     crop = body.get("crop", "unknown")
-    area = float(body.get("area_hectares", 0))
-    temp = float(body.get("avg_temperature", 25))
-    rainfall = float(body.get("expected_rainfall", 100))
+
+    try:
+        area = float(body.get("area_hectares", 0))
+    except (TypeError, ValueError):
+        area = None
+        errors.append("'area_hectares' must be a number")
+
+    try:
+        temp = float(body.get("avg_temperature", 25))
+    except (TypeError, ValueError):
+        temp = None
+        errors.append("'avg_temperature' must be a number")
+
+    try:
+        rainfall = float(body.get("expected_rainfall", 100))
+    except (TypeError, ValueError):
+        rainfall = None
+        errors.append("'expected_rainfall' must be a number")
+
+    if errors:
+        return jsonify({"error": "Validation failed", "details": errors}), 422
+
+    if np.isnan(area) or np.isnan(temp) or np.isnan(rainfall):
+        return jsonify({
+            "error": "Validation failed",
+            "details": ["Numeric fields must not be NaN"]
+        }), 422
 
     if area <= 0:
         return jsonify({"error": "area_hectares must be > 0"}), 422


### PR DESCRIPTION
## Summary

This PR fixes Issue #1234: `ml-service/app.py:157-160` converts request fields with bare `float()` calls and no error handling. Non-numeric values such as `"abc"` raise `ValueError` resulting in a 500, and values parseable as NaN propagate through `temp_modifier`/`rain_modifier` into `round(expected_yield, 2)`, yielding invalid JSON responses.

## Changes

- **`ml-service/app.py` (`predict_yield` handler, lines 166-195):** Each `float()` parse is now wrapped in a `try/except (TypeError, ValueError)` block. Parse errors are collected into a list and returned as a structured 422 response (`{"error": "Validation failed", "details": [...]}`), consistent with the existing `/predict` handler. After successful parsing, `np.isnan()` checks reject NaN values before they reach the calculation logic.

## Fixes #1234

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1234:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Add a shared `parse_float` utility used by all endpoints | Out of scope | Would require changes to `/predict`, `/quality`, and other endpoints beyond the targeted fix |
| Add range validation for `area_hectares`, `avg_temperature`, `expected_rainfall` | Out of scope | Range bounds are a pre-existing gap; the immediate fix is preventing crashes on non-numeric/NaN input |
| Use Pydantic or marshmallow for request validation | Out of scope | Pre-existing architectural choice; introduces new dependency and refactor beyond a targeted bugfix |
