### PR TITLE
fix: cap request body size and prevent image decompression bombs

### DIFF
--- a/ml-service/app.py
+++ b/ml-service/app.py
@@ -9,9 +9,17 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from PIL import Image
+from PIL import Image, DecompressionBombError
 
 app = Flask(__name__)
+
+# ── Request body size limit ────────────────────────────────────────────────
+MAX_MB = int(os.environ.get("ML_MAX_UPLOAD_MB", "10"))
+app.config["MAX_CONTENT_LENGTH"] = MAX_MB * 1024 * 1024
+
+# ── Decompression-bomb guard (Pillow) ──────────────────────────────────────
+# Reject images exceeding ~100 megapixels before full decode.
+Image.MAX_IMAGE_PIXELS = 100_000_000
 
 # ── CORS: only allow the main backend ──────────────────────────────────────
 ALLOWED_ORIGIN = os.environ.get("CORS_ORIGIN", "http://localhost:3001")
@@ -227,6 +235,14 @@ def predict():
     })
 
 
+@app.errorhandler(413)
+def request_entity_too_large(error):
+    return jsonify({
+        "error": "Payload too large",
+        "details": f"Request body exceeds the {MAX_MB} MB limit"
+    }), 413
+
+
 @app.route("/predict-image", methods=["POST"])
 @require_api_key
 @limiter.limit(os.environ.get("ML_RATE_LIMIT_PREDICT_IMAGE", "10 per second"))
@@ -265,6 +281,11 @@ def predict_image():
         res = analyze_crop_image(pil_img)
         return jsonify(res), 200
 
+    except DecompressionBombError:
+        return jsonify({
+            "error": "Image too large",
+            "details": f"Image exceeds the {Image.MAX_IMAGE_PIXELS:,} pixel limit (decompression bomb)"
+        }), 413
     except Exception as e:
         return jsonify({"error": "Failed to process image payload", "details": str(e)}), 422
 


### PR DESCRIPTION
## Summary

This PR fixes Issue #1233: `ml-service/app.py` never sets `app.config["MAX_CONTENT_LENGTH"]`, so Flask buffers unbounded request bodies. `POST /predict-image` calls `Image.open()` on attacker-controlled bytes; a crafted multi-GB upload or a tiny decompression bomb exhausts RAM/CPU and can OOM-kill the gunicorn workers.

## Changes

- **`ml-service/app.py` (lines 16-22):** Set `app.config["MAX_CONTENT_LENGTH"]` to `ML_MAX_UPLOAD_MB` (default 10 MB, configurable via env var) so Flask rejects oversized request bodies before buffering them.
- **`ml-service/app.py` (line 22):** Set `Image.MAX_IMAGE_PIXELS = 100_000_000` (100 megapixels) so Pillow raises `DecompressionBombError` before fully decoding a malicious image.
- **`ml-service/app.py` (lines 238-243):** Added `@app.errorhandler(413)` returning structured JSON (`{"error": "Payload too large", "details": "..."}`) instead of Flask's default HTML error page.
- **`ml-service/app.py` (lines 284-288):** Catch `DecompressionBombError` in `predict_image` and return a 413 with a clear message including the pixel limit.
- **`ml-service/app.py` (line 12):** Import `DecompressionBombError` from PIL.

## Fixes #1233

## Copilot Review Feedback

Other suggestions were evaluated but intentionally left unchanged because they are pre-existing issues outside the scope of Issue #1233:

| Comment | Verdict | Reason |
|---------|---------|--------|
| Add per-endpoint `MAX_CONTENT_LENGTH` overrides | Out of scope | Flask does not natively support per-route content-length limits; would require custom middleware beyond a targeted fix |
| Stream image processing instead of buffering | Out of scope | Pre-existing architecture gap; Pillow's `Image.open()` on a stream still reads the full image for dimension validation |
| Add virus/malware scanning for uploads | Out of scope | Pre-existing feature gap; introduces new infrastructure dependency beyond a targeted DoS fix |
