### PR TITLE
ci: add GitHub Actions layer caching to Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,6 +57,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
       - name: Sign the published Docker image
         env:


### PR DESCRIPTION
Enable BuildKit cache-from/cache-to with GHA backend. Each service gets its own cache scope. Relates to #865